### PR TITLE
feat: add Create Worker/Copilot commands, rebrand to Hydra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cli/twt
 cli/tmux-worktree-tui
 
 .sisyphus/
+.hydra

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ This document serves as the primary rule file for AI Agents working on this proj
 - **Polymorphism**: Commands must handle `TmuxItem` base class and variants (`TmuxSessionItem`, `InactiveWorktreeItem`, etc.).
 - **Path Handling**: Use `getWorktreePath(item)` helper.
 - **Canonical Path Matching**: For path equality/deduplication/current-workspace checks, normalize to absolute paths with `~` expansion before comparison (do not collapse symlink aliases via `realpath`).
-- **Managed Worktree Location**: Create extension-managed worktrees under `~/.tmux-worktrees/<repo-name-hash>/` by default. Reuse shared helpers for path checks and orphan cleanup instead of hardcoding repo-local `.worktrees` path fragments.
+- **Managed Worktree Location**: Create extension-managed worktrees under `<repo-root>/.hydra/` (auto-added to `.gitignore`). Legacy worktrees under `~/.tmux-worktrees/<repo-name-hash>/` are still recognized for backward compatibility. Reuse shared helpers (`getManagedRepoWorktreesDir`, `isManagedWorktreePath`) for path checks and orphan cleanup.
 - **Session Namespace**: Build tmux session prefixes from repo-root identity (basename + short path hash), not display repo name alone, to avoid collisions across same-name repositories in different directories.
 - **Legacy Session Compatibility Isolation**: Keep legacy session-prefix compatibility logic centralized in `src/utils/sessionCompatibility.ts`; call helpers from commands/providers instead of duplicating fallback checks.
 - **Root Detection**: Determine the primary worktree by comparing worktree path to the primary worktree path derived from `git rev-parse --git-common-dir`, not by branch naming, folder basename, or the current workspace folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "vscode-tmux-worktree",
+  "name": "hydra",
   "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-tmux-worktree",
+      "name": "hydra",
       "version": "1.2.5",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vscode-tmux-worktree",
-  "displayName": "TMUX Worktree",
-  "description": "Manage tmux sessions with git worktrees",
+  "name": "hydra",
+  "displayName": "Hydra",
+  "description": "Control panel for managing an army of AI coding agents",
   "version": "1.2.5",
   "engines": {
     "vscode": "^1.85.0"
@@ -57,7 +57,7 @@
       "activitybar": [
         {
           "id": "tmux-explorer",
-          "title": "TMUX",
+          "title": "Hydra",
           "icon": "resources/tmux.svg"
         }
       ]
@@ -66,22 +66,22 @@
       "tmux-explorer": [
         {
           "id": "tmuxSessions",
-          "name": "TMUX Worktrees"
+          "name": "Hydra"
         }
       ]
     },
     "commands": [
       {
         "command": "tmux.attachCreate",
-        "title": "TMUX: Attach/Create Session"
+        "title": "Hydra: Attach/Create Session"
       },
       {
         "command": "tmux.newTask",
-        "title": "TMUX: New Task"
+        "title": "Hydra: Create Worker"
       },
       {
         "command": "tmux.removeTask",
-        "title": "TMUX: Remove Task"
+        "title": "Hydra: Remove Task"
       },
       {
         "command": "tmux.refresh",
@@ -119,16 +119,16 @@
       },
       {
         "command": "tmux.cleanupOrphans",
-        "title": "TMUX: Cleanup Orphans",
+        "title": "Hydra: Cleanup Orphans",
         "icon": "$(trash)"
       },
       {
         "command": "tmux.terminalPaste",
-        "title": "TMUX: Smart Paste (Image Support)"
+        "title": "Hydra: Smart Paste (Image Support)"
       },
       {
         "command": "tmux.pasteImage",
-        "title": "TMUX: Paste Image from Clipboard"
+        "title": "Hydra: Paste Image from Clipboard"
       },
       {
         "command": "tmux.createWorktreeFromBranch",
@@ -138,6 +138,16 @@
         "command": "tmux.switchBackend",
         "title": "Switch Backend",
         "icon": "$(arrow-swap)"
+      },
+      {
+        "command": "hydra.createCopilot",
+        "title": "Hydra: Create Copilot",
+        "icon": "$(hubot)"
+      },
+      {
+        "command": "hydra.createWorker",
+        "title": "Hydra: Create Worker",
+        "icon": "$(server-process)"
       }
     ],
     "keybindings": [
@@ -150,7 +160,7 @@
       }
     ],
     "configuration": {
-      "title": "TMUX Worktree",
+      "title": "Hydra",
       "properties": {
         "tmuxWorktree.multiplexer": {
           "type": "string",
@@ -165,6 +175,33 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Override the base branch used when creating new task worktrees (e.g. `master`, `origin/master`). Leave empty to auto-detect from `origin/main`, `main`, `origin/master`, `master`."
+        },
+        "hydra.baseBranch": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Override the base branch used when creating new worker worktrees (e.g. `master`, `origin/master`). Leave empty to auto-detect. Takes precedence over `tmuxWorktree.baseBranch`."
+        },
+        "hydra.defaultAgent": {
+          "type": "string",
+          "enum": [
+            "claude",
+            "codex",
+            "gemini",
+            "aider",
+            "custom"
+          ],
+          "default": "claude",
+          "markdownDescription": "Default AI agent to launch in new copilot/worker sessions."
+        },
+        "hydra.agentCommands": {
+          "type": "object",
+          "default": {
+            "claude": "claude",
+            "codex": "codex",
+            "gemini": "gemini",
+            "aider": "aider"
+          },
+          "markdownDescription": "Map of agent type to shell command used to launch the agent."
         }
       }
     },
@@ -181,18 +218,22 @@
           "group": "navigation"
         },
         {
-          "command": "tmux.newTask",
-          "when": "view == tmuxSessions",
-          "group": "navigation",
-          "icon": "$(plus)"
-        },
-        {
           "command": "tmux.filter",
           "when": "view == tmuxSessions",
           "group": "navigation"
         },
         {
           "command": "tmux.cleanupOrphans",
+          "when": "view == tmuxSessions",
+          "group": "navigation"
+        },
+        {
+          "command": "hydra.createCopilot",
+          "when": "view == tmuxSessions",
+          "group": "navigation"
+        },
+        {
+          "command": "hydra.createWorker",
           "when": "view == tmuxSessions",
           "group": "navigation"
         }

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getRepoRoot } from '../utils/git';
 import { getActiveBackend } from '../utils/multiplexer';
-import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem } from '../providers/tmuxSessionProvider';
+import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem, CopilotItem } from '../providers/tmuxSessionProvider';
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -6,11 +6,13 @@ import {
   WorktreeItem,
   TmuxDetailItem,
   InactiveDetailItem,
-  GitStatusItem
+  GitStatusItem,
+  CopilotItem,
 } from '../providers/tmuxSessionProvider';
 import { getActiveBackend } from '../utils/multiplexer';
 
 function getWorktreePath(item: TmuxItem): string | undefined {
+  if (item instanceof CopilotItem) return item.worktreePath;
   if (item instanceof TmuxSessionItem) return item.session.worktreePath;
   if (item instanceof InactiveWorktreeItem) return item.worktree.path;
   if (item instanceof TmuxDetailItem) return item.session?.worktreePath;

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import { getActiveBackend } from '../utils/multiplexer';
+import { pickAgentType, getAgentCommand } from '../utils/agentConfig';
+
+const COPILOT_SESSION_NAME = 'hydra-copilot';
+
+export async function createCopilot(): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await backend.isInstalled()) {
+    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+    return;
+  }
+
+  // Check if copilot session already exists
+  const sessions = await backend.listSessions();
+  for (const session of sessions) {
+    const role = await backend.getSessionRole(session.name);
+    if (role === 'copilot') {
+      const action = await vscode.window.showInformationMessage(
+        `Copilot session "${session.name}" already exists.`,
+        'Attach',
+        'Cancel'
+      );
+      if (action === 'Attach') {
+        const workdir = await backend.getSessionWorkdir(session.name);
+        backend.attachSession(session.name, workdir);
+      }
+      return;
+    }
+  }
+
+  // Pick agent type
+  const agentType = await pickAgentType();
+  if (!agentType) return;
+
+  // Use workspace folder as cwd (no git required)
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    vscode.window.showErrorMessage('No workspace folder open.');
+    return;
+  }
+  const cwd = workspaceFolders[0].uri.fsPath;
+
+  try {
+    // Create tmux session
+    await backend.createSession(COPILOT_SESSION_NAME, cwd);
+    await backend.setSessionWorkdir(COPILOT_SESSION_NAME, cwd);
+    await backend.setSessionRole(COPILOT_SESSION_NAME, 'copilot');
+    await backend.setSessionAgent(COPILOT_SESSION_NAME, agentType);
+
+    // Launch agent
+    const agentCommand = getAgentCommand(agentType);
+    await backend.sendKeys(COPILOT_SESSION_NAME, agentCommand);
+
+    // Attach
+    backend.attachSession(COPILOT_SESSION_NAME, cwd);
+
+    vscode.window.showInformationMessage(`Copilot created with ${agentType}`);
+    vscode.commands.executeCommand('tmux.refresh');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to create copilot: ${message}`);
+  }
+}

--- a/src/commands/createWorker.ts
+++ b/src/commands/createWorker.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import {
+  addWorktree,
+  branchNameToSlug,
+  getBaseBranch,
+  getRepoRoot,
+  getRepoSessionNamespace,
+  isGitRepo,
+  findGitReposInDir,
+  isSlugTaken,
+  localBranchExists,
+  validateBranchName
+} from '../utils/git';
+import { getActiveBackend } from '../utils/multiplexer';
+import { pickAgentType, getAgentCommand } from '../utils/agentConfig';
+
+async function resolveRepoRoot(): Promise<string | undefined> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    vscode.window.showErrorMessage('No workspace folder open.');
+    return undefined;
+  }
+
+  // Try normal getRepoRoot first
+  let repoRoot: string;
+  try {
+    repoRoot = getRepoRoot();
+  } catch {
+    repoRoot = workspaceFolders[0].uri.fsPath;
+  }
+
+  // If repoRoot is a git repo, use it directly
+  if (await isGitRepo(repoRoot)) {
+    return repoRoot;
+  }
+
+  // Not a git repo — scan subdirectories for git repos
+  const repos = await findGitReposInDir(repoRoot);
+  if (repos.length === 0) {
+    vscode.window.showErrorMessage('No git repositories found in workspace.');
+    return undefined;
+  }
+
+  const picked = await vscode.window.showQuickPick(
+    repos.map(r => ({ label: r.name, description: r.path, value: r.path })),
+    { placeHolder: 'Select a repository for the worker' }
+  );
+
+  return picked?.value;
+}
+
+export async function createWorker(): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await backend.isInstalled()) {
+    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+    return;
+  }
+
+  const repoRoot = await resolveRepoRoot();
+  if (!repoRoot) return;
+
+  const repoSessionNamespace = getRepoSessionNamespace(repoRoot);
+
+  // 1. Branch name input
+  const branchInput = await vscode.window.showInputBox({
+    prompt: 'Enter branch name (e.g., "feat/auth", "task/my-task")',
+    placeHolder: 'feat/my-task',
+    validateInput: (value) => validateBranchName(value)
+  });
+
+  if (!branchInput) return;
+
+  const branchName = branchInput.trim();
+  const branchValidationError = validateBranchName(branchName);
+  if (branchValidationError) {
+    vscode.window.showErrorMessage(branchValidationError);
+    return;
+  }
+
+  // 2. Pick agent type
+  const agentType = await pickAgentType();
+  if (!agentType) return;
+
+  try {
+    if (await localBranchExists(repoRoot, branchName)) {
+      throw new Error(`Branch "${branchName}" already exists.`);
+    }
+
+    // 3. Base branch
+    const baseBranch = await getBaseBranch(repoRoot);
+
+    // 4. Slug collision resolution
+    const slug = branchNameToSlug(branchName);
+    let finalSlug = slug;
+    let suffix = 1;
+    while (await isSlugTaken(finalSlug, repoSessionNamespace, repoRoot)) {
+      suffix++;
+      finalSlug = `${slug}-${suffix}`;
+    }
+
+    // 5. Create worktree
+    const worktreePath = await addWorktree(repoRoot, branchName, finalSlug, baseBranch);
+
+    // 6. Create session
+    const sessionName = backend.buildSessionName(repoSessionNamespace, finalSlug);
+    await backend.createSession(sessionName, worktreePath);
+    await backend.setSessionWorkdir(sessionName, worktreePath);
+    await backend.setSessionRole(sessionName, 'worker');
+    await backend.setSessionAgent(sessionName, agentType);
+
+    // 7. Launch agent
+    const agentCommand = getAgentCommand(agentType);
+    await backend.sendKeys(sessionName, agentCommand);
+
+    // 8. Attach
+    backend.attachSession(sessionName, worktreePath);
+
+    vscode.window.showInformationMessage(`Worker created: ${branchName} (${agentType})`);
+    vscode.commands.executeCommand('tmux.refresh');
+
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+  }
+}

--- a/src/commands/removeTask.ts
+++ b/src/commands/removeTask.ts
@@ -2,6 +2,10 @@ import * as vscode from "vscode";
 import * as fs from "fs";
 import { exec } from "../utils/exec";
 import { getActiveBackend } from "../utils/multiplexer";
+
+function isSessionNotFoundError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("can't find session");
+}
 import { getRepoRoot, getWorktreeBranch } from "../utils/git";
 import {
   TmuxItem,
@@ -11,6 +15,7 @@ import {
   TmuxDetailItem,
   InactiveDetailItem,
   GitStatusItem,
+  CopilotItem,
 } from "../providers/tmuxSessionProvider";
 import * as path from "path";
 import { toCanonicalPath } from "../utils/path";
@@ -63,6 +68,28 @@ export async function removeTask(item: TmuxItem): Promise<void> {
     return;
   }
 
+  // Handle CopilotItem: kill session only (no worktree)
+  if (item instanceof CopilotItem) {
+    const confirm = await vscode.window.showWarningMessage(
+      `Kill copilot session "${item.sessionName}"?`,
+      { modal: true },
+      "Kill Session",
+    );
+    if (confirm !== "Kill Session") return;
+
+    try {
+      await getActiveBackend().killSession(item.sessionName);
+    } catch (err) {
+      if (!isSessionNotFoundError(err)) {
+        vscode.window.showErrorMessage(`Failed to kill session: ${err}`);
+        return;
+      }
+    }
+    vscode.window.showInformationMessage(`Killed copilot session: ${item.sessionName}`);
+    vscode.commands.executeCommand("tmux.refresh");
+    return;
+  }
+
   const sessionName = item.sessionName;
   const isMain = isMainWorktreeItem(item);
 
@@ -86,11 +113,20 @@ export async function removeTask(item: TmuxItem): Promise<void> {
     worktreePath = item.worktreePath;
   }
 
+  // Resolve repo root from the item if available (workspace root may be a non-git parent).
+  let repoRoot: string | undefined;
+  if (item instanceof WorktreeItem && item.repoRoot) {
+    repoRoot = item.repoRoot;
+  } else {
+    try { repoRoot = getRepoRoot(); } catch { /* non-git workspace */ }
+  }
+
   try {
-    const repoRoot = getRepoRoot();
-    branchName = worktreePath ? await getWorktreeBranch(repoRoot, worktreePath) : undefined;
-    const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
-    slug = slug || extractRepoSessionSlug(sessionName, sessionPrefixConfig, { allowLegacy: true });
+    if (repoRoot) {
+      branchName = worktreePath ? await getWorktreeBranch(repoRoot, worktreePath) : undefined;
+      const sessionPrefixConfig = createRepoSessionPrefixConfig(repoRoot);
+      slug = slug || extractRepoSessionSlug(sessionName, sessionPrefixConfig, { allowLegacy: true });
+    }
   } catch {
     void 0;
   }
@@ -98,6 +134,17 @@ export async function removeTask(item: TmuxItem): Promise<void> {
 
   // ── Main worktree: tmux 세션만 종료, 워크트리/브랜치 삭제 불가 ──
   if (isMain) {
+    const backend = getActiveBackend();
+    const sessions = await backend.listSessions();
+    const sessionExists = sessions.some(s => s.name === sessionName);
+
+    if (!sessionExists) {
+      vscode.window.showInformationMessage(
+        `No active session for primary worktree "${sessionName}". Nothing to remove.`
+      );
+      return;
+    }
+
     const confirm = await vscode.window.showWarningMessage(
       `Kill tmux session "${sessionName}"?\n(Primary worktree cannot be removed)`,
       { modal: true },
@@ -106,10 +153,12 @@ export async function removeTask(item: TmuxItem): Promise<void> {
     if (confirm !== "Kill Session") return;
 
     try {
-      await getActiveBackend().killSession(sessionName);
+      await backend.killSession(sessionName);
       vscode.window.showInformationMessage(`Killed session: ${sessionName}`);
     } catch (err) {
-      vscode.window.showErrorMessage(`Failed to kill session: ${err}`);
+      if (!isSessionNotFoundError(err)) {
+        vscode.window.showErrorMessage(`Failed to kill session: ${err}`);
+      }
     }
     vscode.commands.executeCommand("tmux.refresh");
     return;
@@ -126,9 +175,10 @@ export async function removeTask(item: TmuxItem): Promise<void> {
 
     try {
       await getActiveBackend().killSession(sessionName);
-      vscode.window.showInformationMessage(`Killed orphan session: ${sessionName}`);
     } catch (err) {
-      vscode.window.showErrorMessage(`Failed to kill session: ${err}`);
+      if (!isSessionNotFoundError(err)) {
+        vscode.window.showErrorMessage(`Failed to kill session: ${err}`);
+      }
     }
     vscode.commands.executeCommand("tmux.refresh");
     return;
@@ -136,9 +186,8 @@ export async function removeTask(item: TmuxItem): Promise<void> {
 
   // ── 일반 워크트리: 세션 + 워크트리 + 브랜치 모두 삭제 가능 ──
 
-  if (worktreePath) {
+  if (worktreePath && repoRoot) {
     try {
-      const repoRoot = getRepoRoot();
       const managed = await isWorktreePathManagedByRepo(repoRoot, worktreePath);
       if (!managed) {
         vscode.window.showErrorMessage(
@@ -164,9 +213,8 @@ export async function removeTask(item: TmuxItem): Promise<void> {
     void 0;
   }
 
-  if (worktreePath && fs.existsSync(worktreePath)) {
+  if (worktreePath && repoRoot && fs.existsSync(worktreePath)) {
     try {
-      const repoRoot = getRepoRoot();
       await exec(`git worktree remove "${worktreePath}"`, { cwd: repoRoot });
     } catch {
       const forceConfirm = await vscode.window.showWarningMessage(
@@ -176,7 +224,6 @@ export async function removeTask(item: TmuxItem): Promise<void> {
       );
       if (forceConfirm === "Force Remove") {
         try {
-          const repoRoot = getRepoRoot();
           await exec(`git worktree remove "${worktreePath}" --force`, {
             cwd: repoRoot,
           });
@@ -191,7 +238,7 @@ export async function removeTask(item: TmuxItem): Promise<void> {
   }
 
   try {
-    const repoRoot = getRepoRoot();
+    if (!repoRoot) throw new Error("No repo root");
     if (!branchName) throw new Error("No branch");
 
     const localBranchesOutput = await exec("git for-each-ref --format='%(refname:short)' refs/heads", {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { TmuxSessionProvider } from './providers/tmuxSessionProvider';
 import { getActiveBackend, refreshBackendFromConfig, getConfiguredMultiplexerType, MultiplexerType } from './utils/multiplexer';
 import { attachCreate } from './commands/attachCreate';
-import { newTask } from './commands/newTask';
+// newTask is now an alias for createWorker
 import { removeTask } from './commands/removeTask';
 import { cleanupOrphans } from './commands/orphanCleanup';
 import { autoAttachOnStartup } from './commands/autoAttach';
@@ -16,6 +16,8 @@ import {
 } from './commands/contextMenu';
 import { terminalSmartPaste, pasteImageForce, cleanupTempImages } from './commands/pasteImage';
 import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
+import { createCopilot } from './commands/createCopilot';
+import { createWorker } from './commands/createWorker';
 
 function updateViewDescription(treeView: vscode.TreeView<unknown>): void {
   const backend = getActiveBackend();
@@ -33,7 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     treeView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
-    vscode.commands.registerCommand('tmux.newTask', newTask),
+    vscode.commands.registerCommand('tmux.newTask', createWorker),
     vscode.commands.registerCommand('tmux.removeTask', (item) => removeTask(item)),
     vscode.commands.registerCommand('tmux.cleanupOrphans', cleanupOrphans),
     vscode.commands.registerCommand('tmux.refresh', () => sessionProvider.refresh()),
@@ -73,7 +75,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.newWindow', newWindow),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
-    vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item))
+    vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
+    vscode.commands.registerCommand('hydra.createCopilot', createCopilot),
+    vscode.commands.registerCommand('hydra.createWorker', createWorker),
   );
 
   autoAttachOnStartup();

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { exec } from '../utils/exec';
-import { getRepoRoot, getRepoName, listWorktrees, Worktree, getBaseBranch } from '../utils/git';
-import { getActiveBackend, MultiplexerSession } from '../utils/multiplexer';
+import { getRepoRoot, getRepoName, listWorktrees, Worktree, getBaseBranch, findGitReposInDir } from '../utils/git';
+import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multiplexer';
 import { toCanonicalPath } from '../utils/path';
 import { createRepoSessionPrefixConfig, matchRepoSessionName } from '../utils/sessionCompatibility';
 
@@ -30,6 +30,8 @@ interface SessionWithStatus extends MultiplexerSession {
   status: SessionStatus;
   worktreePath?: string;
   slug: string;
+  hydraRole?: HydraRole;
+  hydraAgent?: string;
 }
 
 function isCurrentWorkspacePath(targetPath: string | undefined, activeWorkspacePath: string): boolean {
@@ -49,7 +51,6 @@ function getDefaultWorktreeSlug(worktree: Worktree, repoName: string): string {
     return baseName;
   }
 
-  // Keep session names unique when external worktrees reuse the repo directory name.
   if (parentName && parentName !== baseName) {
     return `${baseName}-${parentName}`;
   }
@@ -131,7 +132,6 @@ function buildWorktreeSlugMap(worktrees: Worktree[], repoName: string): Map<stri
     return `${candidate.slug}-${shortPathHash(candidate.worktree.path)}`;
   });
 
-  // Extra safety for extremely unlikely hash collisions.
   for (let i = 0; i < unresolved.length; i++) {
     const candidate = unresolved[i];
     const normalizedPath = toCanonicalPath(candidate.worktree.path);
@@ -193,12 +193,10 @@ function parseGitPorcelainStatus(lines: string[]): Pick<
       continue;
     }
 
-    // Porcelain v1: XY <path>
     const x = line[0] ?? ' ';
     const y = line[1] ?? ' ';
     const code = `${x}${y}`;
 
-    // Count each path once with a simple precedence.
     if (code.includes('D')) {
       gitDeleted++;
       continue;
@@ -325,7 +323,7 @@ async function getSessionStatus(sessionName: string, worktreePath?: string): Pro
 
   const now = Math.floor(Date.now() / 1000);
   let classification: Classification;
-  
+
   if (attached) {
     classification = 'attached';
   } else if (now - lastActive < 600) {
@@ -359,6 +357,68 @@ export class TmuxItem extends vscode.TreeItem {
   }
 }
 
+// ─── Group Items (Level 1) ────────────────────────────────
+
+export class CopilotGroupItem extends TmuxItem {
+  constructor() {
+    super('Copilot', vscode.TreeItemCollapsibleState.Expanded);
+    this.contextValue = 'copilotGroup';
+    this.iconPath = new vscode.ThemeIcon('hubot');
+  }
+}
+
+export class WorkerGroupItem extends TmuxItem {
+  public readonly repoRoot: string;
+  constructor(repoName: string, repoRoot: string, baseBranch?: string) {
+    super('Workers', vscode.TreeItemCollapsibleState.Expanded, repoName);
+    this.repoRoot = repoRoot;
+    this.contextValue = 'workerGroup';
+    this.iconPath = new vscode.ThemeIcon('server-process');
+    if (baseBranch) {
+      const shortName = baseBranch.replace(/^origin\//, '');
+      this.description = `${repoName} [base: ${shortName}]`;
+    } else {
+      this.description = repoName;
+    }
+  }
+}
+
+// ─── Copilot Item (Level 2) ──────────────────────────────
+
+export class CopilotItem extends TmuxItem {
+  public readonly worktreePath?: string;
+  public readonly agentType: string;
+  public readonly classification: Classification;
+
+  constructor(opts: {
+    sessionName: string;
+    agentType: string;
+    worktreePath?: string;
+    classification: Classification;
+  }) {
+    const label = `${opts.agentType}`;
+    const description = opts.worktreePath ? path.basename(opts.worktreePath) : undefined;
+    super(label, vscode.TreeItemCollapsibleState.Expanded, undefined, opts.sessionName);
+
+    this.worktreePath = opts.worktreePath;
+    this.agentType = opts.agentType;
+    this.classification = opts.classification;
+    this.description = description;
+    this.contextValue = 'tmuxItem';
+
+    // Blue circle: filled=attached, outline=idle
+    if (opts.classification === 'attached') {
+      this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'));
+    } else if (opts.classification === 'stopped') {
+      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('foreground'));
+    } else {
+      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.blue'));
+    }
+  }
+}
+
+// ─── Worker Item / Worktree Items (Level 2) ───────────────
+
 export class RepoGroupItem extends TmuxItem {
   constructor(
     public readonly repoName: string,
@@ -369,7 +429,6 @@ export class RepoGroupItem extends TmuxItem {
     this.contextValue = 'repoGroup';
     this.iconPath = new vscode.ThemeIcon('repo');
     if (baseBranch) {
-      // Strip remote prefix (e.g. "origin/main" → "main") for cleaner display
       const shortName = baseBranch.replace(/^origin\//, '');
       this.description = `[base: ${shortName}]`;
     }
@@ -377,7 +436,7 @@ export class RepoGroupItem extends TmuxItem {
 }
 
 /**
- * Level 2 – Icon rules from requirements:
+ * Level 2 – Icon rules:
  *   ● filled green  = git ✓ + tmux active
  *   ○ outline green = git ✓ + tmux stopped
  *   ⚠️ warning      = git not initialized
@@ -385,6 +444,7 @@ export class RepoGroupItem extends TmuxItem {
 export class WorktreeItem extends TmuxItem {
   public readonly isCurrentWorkspace: boolean;
   public readonly worktreePath?: string;
+  public readonly repoRoot?: string;
   public readonly hasGit: boolean;
   public readonly hasTmux: boolean;
   public readonly isMainWorktree: boolean;
@@ -394,6 +454,7 @@ export class WorktreeItem extends TmuxItem {
     repoName: string;
     sessionName: string;
     worktreePath?: string;
+    repoRoot?: string;
     isCurrentWorkspace: boolean;
     hasGit: boolean;
     hasTmux: boolean;
@@ -405,6 +466,7 @@ export class WorktreeItem extends TmuxItem {
 
     this.isCurrentWorkspace = opts.isCurrentWorkspace;
     this.worktreePath = opts.worktreePath;
+    this.repoRoot = opts.repoRoot;
     this.hasGit = opts.hasGit;
     this.hasTmux = opts.hasTmux;
     this.isMainWorktree = Boolean(opts.isMainWorktree);
@@ -421,6 +483,32 @@ export class WorktreeItem extends TmuxItem {
     }
   }
 }
+
+export class WorkerItem extends WorktreeItem {
+  public readonly agentType?: string;
+
+  constructor(opts: {
+    branchLabel: string;
+    repoName: string;
+    sessionName: string;
+    worktreePath?: string;
+    isCurrentWorkspace: boolean;
+    hasGit: boolean;
+    hasTmux: boolean;
+    isMainWorktree?: boolean;
+    agentType?: string;
+  }) {
+    super(opts);
+    this.agentType = opts.agentType;
+    if (opts.agentType) {
+      this.description = this.description
+        ? `${this.description} [${opts.agentType}]`
+        : `[${opts.agentType}]`;
+    }
+  }
+}
+
+// ─── Detail Items (Level 3+) ──────────────────────────────
 
 export class TmuxDetailItem extends TmuxItem {
   constructor(
@@ -522,9 +610,8 @@ export class GitStatusItem extends TmuxItem {
   }
 }
 
-// ─── Legacy compatibility ─────────────────────────────────
+// ─── Composite Items (backward compat) ───────────────────
 
-/** @deprecated use WorktreeItem */
 export class TmuxSessionItem extends WorktreeItem {
   public readonly session: SessionWithStatus;
   public readonly detailItem: TmuxDetailItem;
@@ -537,7 +624,9 @@ export class TmuxSessionItem extends WorktreeItem {
     isCurrentWorkspace: boolean,
     hasGit: boolean,
     extensionUri?: vscode.Uri,
-    branchLabelOverride?: string
+    branchLabelOverride?: string,
+    agentType?: string,
+    repoRoot?: string
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -547,6 +636,7 @@ export class TmuxSessionItem extends WorktreeItem {
       repoName,
       sessionName: session.name,
       worktreePath: session.worktreePath,
+      repoRoot,
       isCurrentWorkspace,
       hasGit,
       hasTmux: session.status.classification !== 'stopped',
@@ -556,6 +646,12 @@ export class TmuxSessionItem extends WorktreeItem {
     this.session = session;
     this.detailItem = new TmuxDetailItem(session, repoName, worktree, extensionUri);
 
+    if (agentType) {
+      this.description = this.description
+        ? `${this.description} [${agentType}]`
+        : `[${agentType}]`;
+    }
+
     const hasGitChanges = session.status.commitsAhead > 0 || session.status.gitModified > 0 ||
       session.status.gitDeleted > 0 || session.status.gitAdded > 0 || session.status.gitUntracked > 0;
     if (hasGitChanges) {
@@ -564,7 +660,6 @@ export class TmuxSessionItem extends WorktreeItem {
   }
 }
 
-/** @deprecated use WorktreeItem */
 export class InactiveWorktreeItem extends WorktreeItem {
   public readonly detailItem: InactiveDetailItem;
   public readonly gitStatusItem?: GitStatusItem;
@@ -579,7 +674,8 @@ export class InactiveWorktreeItem extends WorktreeItem {
     hasGit: boolean,
     extensionUri?: vscode.Uri,
     branchLabelOverride?: string,
-    gitStatusOverride?: SessionStatus
+    gitStatusOverride?: SessionStatus,
+    repoRoot?: string
   ) {
     const branchLabel = branchLabelOverride || worktree.branch || (worktree.isMain ? 'main' : path.basename(worktree.path));
 
@@ -588,6 +684,7 @@ export class InactiveWorktreeItem extends WorktreeItem {
       repoName,
       sessionName: targetSessionName,
       worktreePath: worktree.path,
+      repoRoot,
       isCurrentWorkspace,
       hasGit,
       hasTmux: false,
@@ -652,7 +749,20 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
         errorItem.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('charts.red'));
         return [errorItem];
       }
-      return this.getRepoGroups();
+      return this.getRootItems();
+    }
+
+    if (element instanceof CopilotGroupItem) {
+      return this.getCopilotItems();
+    }
+
+    if (element instanceof WorkerGroupItem) {
+      return this.getWorkerItems(element);
+    }
+
+    // Copilot children: detail item
+    if (element instanceof CopilotItem) {
+      return this.getCopilotDetailItems(element);
     }
 
     if (element instanceof RepoGroupItem) {
@@ -674,14 +784,124 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
     return [];
   }
 
-  private async getRepoGroups(): Promise<RepoGroupItem[]> {
+  // ── Root: [CopilotGroup, WorkerGroup] ──
+
+  private async getRootItems(): Promise<TmuxItem[]> {
     try {
-      const repoRoot = getRepoRoot();
-      const repoName = getRepoName(repoRoot);
+      this._error = undefined;
+      const items: TmuxItem[] = [new CopilotGroupItem()];
+
+      let repoRoot: string;
+      let repoName: string;
+      try {
+        repoRoot = getRepoRoot();
+        repoName = getRepoName(repoRoot);
+      } catch {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) return items;
+        repoRoot = workspaceFolders[0].uri.fsPath;
+        repoName = path.basename(repoRoot);
+      }
+
       let baseBranch: string | undefined;
-      try { baseBranch = await getBaseBranch(repoRoot); } catch { /* non-git or no default branch */ }
-      return [new RepoGroupItem(repoName, repoRoot, baseBranch)];
-    } catch { return []; }
+      try { baseBranch = await getBaseBranch(repoRoot); } catch { /* non-git */ }
+
+      items.push(new WorkerGroupItem(repoName, repoRoot, baseBranch));
+      return items;
+    } catch (err) {
+      this._error = err instanceof Error ? err.message : String(err);
+      return [];
+    }
+  }
+
+  // ── Copilot Group Children ──
+
+  private async getCopilotItems(): Promise<TmuxItem[]> {
+    try {
+      const backend = getActiveBackend();
+      const sessions = await backend.listSessions();
+      const items: TmuxItem[] = [];
+
+      for (const session of sessions) {
+        const role = await backend.getSessionRole(session.name);
+        if (role !== 'copilot') continue;
+
+        const agentType = await backend.getSessionAgent(session.name) || 'unknown';
+        const workdir = await backend.getSessionWorkdir(session.name);
+        const status = await getSessionStatus(session.name, workdir);
+
+        items.push(new CopilotItem({
+          sessionName: session.name,
+          agentType,
+          worktreePath: workdir,
+          classification: status.classification,
+        }));
+      }
+
+      if (items.length === 0) {
+        const hint = new TmuxItem('No copilot running', vscode.TreeItemCollapsibleState.None);
+        hint.iconPath = new vscode.ThemeIcon('info');
+        hint.command = {
+          command: 'hydra.createCopilot',
+          title: 'Create Copilot',
+        };
+        return [hint];
+      }
+
+      return items;
+    } catch {
+      return [];
+    }
+  }
+
+  private async getCopilotDetailItems(copilot: CopilotItem): Promise<TmuxItem[]> {
+    if (!copilot.sessionName) return [];
+    const backend = getActiveBackend();
+    const workdir = await backend.getSessionWorkdir(copilot.sessionName);
+    const status = await getSessionStatus(copilot.sessionName, workdir);
+    const session: SessionWithStatus = {
+      name: copilot.sessionName,
+      windows: 1,
+      attached: status.attached,
+      workdir,
+      status,
+      worktreePath: workdir,
+      slug: 'copilot',
+      hydraRole: 'copilot',
+      hydraAgent: copilot.agentType,
+    };
+    return [new TmuxDetailItem(session, '', undefined, this._extensionUri)];
+  }
+
+  // ── Worker Group Children ──
+
+  private async getWorkerItems(group: WorkerGroupItem): Promise<TmuxItem[]> {
+    const workspaceRoot = group.repoRoot;
+    const isGit = await isGitInitialized(workspaceRoot);
+
+    // If workspace itself is a git repo, show its worktrees directly (no sub-grouping)
+    if (isGit) {
+      const repoName = group.repoName || path.basename(workspaceRoot);
+      return this.getWorktreeItems(repoName, workspaceRoot);
+    }
+
+    // Non-git workspace: scan for git repos in immediate children → RepoGroupItem per repo
+    const subRepos = await findGitReposInDir(workspaceRoot);
+    const items: TmuxItem[] = [];
+
+    for (const repo of subRepos) {
+      let baseBranch: string | undefined;
+      try { baseBranch = await getBaseBranch(repo.path); } catch { /* no default branch */ }
+      items.push(new RepoGroupItem(repo.name, repo.path, baseBranch));
+    }
+
+    if (items.length === 0) {
+      const hint = new TmuxItem('No git repos found', vscode.TreeItemCollapsibleState.None);
+      hint.iconPath = new vscode.ThemeIcon('info');
+      return [hint];
+    }
+
+    return items;
   }
 
   private async getWorktreeItems(repoName: string, repoRoot: string): Promise<TmuxItem[]> {
@@ -726,34 +946,50 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
 
       for (const session of allSessions) {
+        // Skip copilot sessions — they appear under the Copilot group
+        const role = await backend.getSessionRole(session.name);
+        if (role === 'copilot') continue;
+
         session.workdir = await backend.getSessionWorkdir(session.name);
         const workdir = toCanonicalPath(session.workdir);
+
+        // Match by prefix (existing repo sessions)
         const matchedSession = matchRepoSessionName(
           session.name,
           workdir,
           sessionPrefixConfig,
           { allowLegacy: true }
         );
-        if (!matchedSession) {
+
+        // Also match workers whose workdir is a managed worktree for this repo
+        const isWorkerForRepo = role === 'worker' && workdir && !matchedSession &&
+          await this.isWorkdirManagedByRepo(workdir, repoRoot);
+
+        if (!matchedSession && !isWorkerForRepo) {
           continue;
         }
 
         const status = await getSessionStatus(session.name, workdir);
+        const agentType = await backend.getSessionAgent(session.name);
         let entry = workdir ? pathMap.get(workdir) : undefined;
 
         if (!entry) {
-          status.classification = 'orphan';
-          entry = { sessions: [], hasGit: false };
+          if (!isWorkerForRepo) {
+            status.classification = 'orphan';
+          }
+          entry = { sessions: [], hasGit: workdir ? await isGitInitialized(workdir) : false };
           pathMap.set(workdir || `orphan:${session.name}`, entry);
         }
 
-        const slug = matchedSession.slug || 'main';
+        const slug = matchedSession?.slug || path.basename(workdir || session.name);
 
         entry.sessions.push({
           ...session,
           status,
           worktreePath: workdir,
-          slug
+          slug,
+          hydraRole: role || undefined,
+          hydraAgent: agentType || undefined,
         });
       }
 
@@ -789,7 +1025,8 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
             hasGit,
             this._extensionUri,
             branchLabel,
-            stoppedStatus
+            stoppedStatus,
+            repoRoot
           ));
           continue;
         }
@@ -814,7 +1051,9 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
             isCurrentWorkspace,
             hasGit,
             this._extensionUri,
-            branchLabel
+            branchLabel,
+            sessions[0].hydraAgent,
+            repoRoot
           ));
         }
       }
@@ -859,6 +1098,25 @@ export class TmuxSessionProvider implements vscode.TreeDataProvider<TmuxItem> {
       this._error = err instanceof Error ? err.message : String(err);
       return [];
     }
+  }
+
+  private async isWorkdirManagedByRepo(workdir: string, repoRoot: string): Promise<boolean> {
+    try {
+      const output = await exec(`git -C "${repoRoot}" worktree list --porcelain`);
+      const worktreePaths = output
+        .split('\n')
+        .filter(line => line.startsWith('worktree '))
+        .map(line => line.substring('worktree '.length).trim());
+      const candidate = toCanonicalPath(workdir);
+      if (!candidate) return false;
+      for (const wtPath of worktreePaths) {
+        const resolved = toCanonicalPath(wtPath) || path.resolve(wtPath);
+        if (resolved === candidate) return true;
+      }
+    } catch {
+      // not a git repo
+    }
+    return false;
   }
 
   private sortAndFilter(items: TmuxItem[]): TmuxItem[] {

--- a/src/utils/agentConfig.ts
+++ b/src/utils/agentConfig.ts
@@ -1,0 +1,50 @@
+import * as vscode from 'vscode';
+
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'aider' | 'custom';
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  gemini: 'Gemini',
+  aider: 'Aider',
+  custom: 'Custom',
+};
+
+export function getDefaultAgent(): AgentType {
+  return vscode.workspace
+    .getConfiguration('hydra')
+    .get<AgentType>('defaultAgent', 'claude');
+}
+
+export function getAgentCommand(agentType: string): string {
+  const commands = vscode.workspace
+    .getConfiguration('hydra')
+    .get<Record<string, string>>('agentCommands', {
+      claude: 'claude',
+      codex: 'codex',
+      gemini: 'gemini',
+      aider: 'aider',
+    });
+  return commands[agentType] || agentType;
+}
+
+export async function pickAgentType(): Promise<AgentType | undefined> {
+  const defaultAgent = getDefaultAgent();
+  const items = (Object.keys(AGENT_LABELS) as AgentType[]).map(key => ({
+    label: AGENT_LABELS[key],
+    description: key === defaultAgent ? '(default)' : '',
+    value: key,
+  }));
+
+  // Move default to top
+  items.sort((a, b) => {
+    if (a.value === defaultAgent) return -1;
+    if (b.value === defaultAgent) return 1;
+    return 0;
+  });
+
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Select agent type',
+  });
+  return picked?.value;
+}

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -14,6 +14,32 @@ export interface Worktree {
   isMain: boolean;
 }
 
+export async function isGitRepo(dirPath: string): Promise<boolean> {
+  try {
+    await exec(`git -C ${shellQuote(dirPath)} rev-parse --git-dir`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function findGitReposInDir(parentDir: string): Promise<{ name: string; path: string }[]> {
+  const repos: { name: string; path: string }[] = [];
+  try {
+    const entries = fs.readdirSync(parentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const childPath = path.join(parentDir, entry.name);
+      if (await isGitRepo(childPath)) {
+        repos.push({ name: entry.name, path: childPath });
+      }
+    }
+  } catch {
+    // parent dir not readable
+  }
+  return repos.sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export function validateBranchName(branchName: string): string | undefined {
   const trimmedBranch = branchName.trim();
 
@@ -102,7 +128,8 @@ export function getRepoSessionNamespace(repoRoot: string): string {
 
 // Determine base branch by checking common default branch names in order
 export async function getBaseBranch(repoRoot: string): Promise<string> {
-  const override = vscode.workspace.getConfiguration('tmuxWorktree').get<string>('baseBranch');
+  const override = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch')
+    || vscode.workspace.getConfiguration('tmuxWorktree').get<string>('baseBranch');
   if (override) {
     try {
       await exec(`git rev-parse --verify ${override}`, { cwd: repoRoot });
@@ -137,14 +164,30 @@ export function getManagedWorktreesRoot(): string {
 }
 
 export function getManagedRepoWorktreesDir(repoRoot: string): string {
+  return path.join(repoRoot, '.hydra', 'worktrees');
+}
+
+export function getLegacyManagedRepoWorktreesDir(repoRoot: string): string {
   return path.join(getManagedWorktreesRoot(), getRepoSessionNamespace(repoRoot));
 }
 
 export function isManagedWorktreePath(repoRoot: string, worktreePath: string): boolean {
-  const managedDir = toCanonicalPath(getManagedRepoWorktreesDir(repoRoot));
   const candidatePath = toCanonicalPath(worktreePath);
-  if (!managedDir || !candidatePath) return false;
-  return candidatePath === managedDir || candidatePath.startsWith(`${managedDir}${path.sep}`);
+  if (!candidatePath) return false;
+
+  // Check new location: <repo>/.hydra/worktrees/
+  const hydraDir = toCanonicalPath(getManagedRepoWorktreesDir(repoRoot));
+  if (hydraDir && (candidatePath === hydraDir || candidatePath.startsWith(`${hydraDir}${path.sep}`))) {
+    return true;
+  }
+
+  // Check legacy location: ~/.tmux-worktrees/<namespace>/
+  const legacyDir = toCanonicalPath(getLegacyManagedRepoWorktreesDir(repoRoot));
+  if (legacyDir && (candidatePath === legacyDir || candidatePath.startsWith(`${legacyDir}${path.sep}`))) {
+    return true;
+  }
+
+  return false;
 }
 
 // Ensure the managed worktree directory exists.
@@ -153,6 +196,21 @@ export async function ensureWorktreesDir(repoRoot: string): Promise<string> {
   if (!fs.existsSync(worktreesDir)) {
     await fs.promises.mkdir(worktreesDir, { recursive: true });
   }
+
+  // Add .hydra to .gitignore if not already there
+  const gitignorePath = path.join(repoRoot, '.gitignore');
+  try {
+    const content = fs.existsSync(gitignorePath)
+      ? fs.readFileSync(gitignorePath, 'utf-8')
+      : '';
+    if (!content.split('\n').some(line => line.trim() === '.hydra' || line.trim() === '.hydra/')) {
+      const newline = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+      fs.writeFileSync(gitignorePath, `${content}${newline}.hydra\n`, 'utf-8');
+    }
+  } catch {
+    // ignore gitignore errors
+  }
+
   return worktreesDir;
 }
 

--- a/src/utils/multiplexer.ts
+++ b/src/utils/multiplexer.ts
@@ -5,6 +5,8 @@ import { createBackendFromConfig } from './backendFactory';
 
 export type MultiplexerType = 'tmux' | 'zellij';
 
+export type HydraRole = 'copilot' | 'worker';
+
 export interface MultiplexerSession {
   name: string;
   windows: number; // tmux: windows, zellij: tabs
@@ -50,6 +52,17 @@ export interface MultiplexerBackend {
 
   getSessionWorkdir(sessionName: string): Promise<string | undefined>;
   setSessionWorkdir(sessionName: string, workdir: string): Promise<void>;
+
+  // ── Hydra Metadata ──
+
+  getSessionRole(sessionName: string): Promise<HydraRole | undefined>;
+  setSessionRole(sessionName: string, role: HydraRole): Promise<void>;
+  getSessionAgent(sessionName: string): Promise<string | undefined>;
+  setSessionAgent(sessionName: string, agent: string): Promise<void>;
+
+  // ── Keys ──
+
+  sendKeys(sessionName: string, keys: string): Promise<void>;
 
   // ── Session Status ──
 

--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { exec } from './exec';
 import { toCanonicalPath } from './path';
 import { shellQuote } from './shell';
-import { MultiplexerBackend, MultiplexerSession, SessionStatusInfo } from './multiplexer';
+import { MultiplexerBackend, MultiplexerSession, SessionStatusInfo, HydraRole } from './multiplexer';
 
 const TMUX_ENV_KEYS_TO_STRIP = [
   'ELECTRON_RUN_AS_NODE',
@@ -133,6 +133,46 @@ export class TmuxBackend implements MultiplexerBackend {
 
   async setSessionWorkdir(sessionName: string, workdir: string): Promise<void> {
     await exec(`tmux set-option -t "${sessionName}" @workdir "${workdir}"`);
+  }
+
+  async getSessionRole(sessionName: string): Promise<HydraRole | undefined> {
+    try {
+      const output = await exec(`tmux show-options -t "${sessionName}" @hydra-role`);
+      const parts = output.split(' ');
+      if (parts.length >= 2) {
+        const value = parts.slice(1).join(' ').trim() as HydraRole;
+        if (value === 'copilot' || value === 'worker') return value;
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async setSessionRole(sessionName: string, role: HydraRole): Promise<void> {
+    await exec(`tmux set-option -t "${sessionName}" @hydra-role "${role}"`);
+  }
+
+  async getSessionAgent(sessionName: string): Promise<string | undefined> {
+    try {
+      const output = await exec(`tmux show-options -t "${sessionName}" @hydra-agent`);
+      const parts = output.split(' ');
+      if (parts.length >= 2) {
+        const value = parts.slice(1).join(' ').trim();
+        return value || undefined;
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async setSessionAgent(sessionName: string, agent: string): Promise<void> {
+    await exec(`tmux set-option -t "${sessionName}" @hydra-agent "${agent}"`);
+  }
+
+  async sendKeys(sessionName: string, keys: string): Promise<void> {
+    await exec(`tmux send-keys -t ${shellQuote(sessionName)} ${shellQuote(keys)} Enter`);
   }
 
   async getSessionInfo(sessionName: string): Promise<SessionStatusInfo> {

--- a/src/utils/zellijBackend.ts
+++ b/src/utils/zellijBackend.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { exec, ExecOptions } from './exec';
-import { MultiplexerBackend, MultiplexerSession, SessionStatusInfo } from './multiplexer';
+import { MultiplexerBackend, MultiplexerSession, SessionStatusInfo, HydraRole } from './multiplexer';
 import { shellQuote } from './shell';
 
 // Zellij derives its IPC socket path from $TMPDIR + session name.
@@ -55,8 +55,10 @@ function zellijExec(command: string, options?: ExecOptions): Promise<string> {
 // Zellij has no built-in session metadata like tmux's @workdir.
 // We persist session→workdir mappings in a JSON file.
 
-const WORKDIR_STORE_DIR = path.join(os.homedir(), '.config', 'vscode-tmux-worktree');
+const METADATA_STORE_DIR = path.join(os.homedir(), '.config', 'vscode-tmux-worktree');
+const WORKDIR_STORE_DIR = METADATA_STORE_DIR;
 const WORKDIR_STORE_FILE = path.join(WORKDIR_STORE_DIR, 'zellij-workdirs.json');
+const HYDRA_STORE_FILE = path.join(METADATA_STORE_DIR, 'zellij-hydra.json');
 
 function readWorkdirStore(): Record<string, string> {
   try {
@@ -72,6 +74,27 @@ function readWorkdirStore(): Record<string, string> {
 function writeWorkdirStore(store: Record<string, string>): void {
   fs.mkdirSync(WORKDIR_STORE_DIR, { recursive: true });
   fs.writeFileSync(WORKDIR_STORE_FILE, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+interface HydraSessionMeta {
+  role?: HydraRole;
+  agent?: string;
+}
+
+function readHydraStore(): Record<string, HydraSessionMeta> {
+  try {
+    if (fs.existsSync(HYDRA_STORE_FILE)) {
+      return JSON.parse(fs.readFileSync(HYDRA_STORE_FILE, 'utf-8'));
+    }
+  } catch {
+    // corrupted file – start fresh
+  }
+  return {};
+}
+
+function writeHydraStore(store: Record<string, HydraSessionMeta>): void {
+  fs.mkdirSync(METADATA_STORE_DIR, { recursive: true });
+  fs.writeFileSync(HYDRA_STORE_FILE, JSON.stringify(store, null, 2), 'utf-8');
 }
 
 // ─── Output Parsing ───────────────────────────────────────
@@ -153,9 +176,12 @@ export class ZellijBackend implements MultiplexerBackend {
 
   async killSession(sessionName: string): Promise<void> {
     await zellijExec(`zellij kill-session "${sessionName}"`);
-    const store = readWorkdirStore();
-    delete store[sessionName];
-    writeWorkdirStore(store);
+    const wdStore = readWorkdirStore();
+    delete wdStore[sessionName];
+    writeWorkdirStore(wdStore);
+    const hydraStore = readHydraStore();
+    delete hydraStore[sessionName];
+    writeHydraStore(hydraStore);
   }
 
   async hasSession(sessionName: string): Promise<boolean> {
@@ -176,6 +202,39 @@ export class ZellijBackend implements MultiplexerBackend {
     const store = readWorkdirStore();
     store[sessionName] = workdir;
     writeWorkdirStore(store);
+  }
+
+  async getSessionRole(sessionName: string): Promise<HydraRole | undefined> {
+    const store = readHydraStore();
+    return store[sessionName]?.role;
+  }
+
+  async setSessionRole(sessionName: string, role: HydraRole): Promise<void> {
+    const store = readHydraStore();
+    if (!store[sessionName]) store[sessionName] = {};
+    store[sessionName].role = role;
+    writeHydraStore(store);
+  }
+
+  async getSessionAgent(sessionName: string): Promise<string | undefined> {
+    const store = readHydraStore();
+    return store[sessionName]?.agent;
+  }
+
+  async setSessionAgent(sessionName: string, agent: string): Promise<void> {
+    const store = readHydraStore();
+    if (!store[sessionName]) store[sessionName] = {};
+    store[sessionName].agent = agent;
+    writeHydraStore(store);
+  }
+
+  async sendKeys(sessionName: string, keys: string): Promise<void> {
+    // Zellij action write only works from inside a session. Find the attached terminal.
+    const shortName = getShortName(sessionName);
+    const terminal = vscode.window.terminals.find(t => t.name === shortName);
+    if (terminal) {
+      terminal.sendText(keys, true);
+    }
   }
 
   async getSessionInfo(sessionName: string): Promise<SessionStatusInfo> {


### PR DESCRIPTION
## Summary

- **Create Worker** command: full flow with branch validation, base branch detection, slug collision resolution, worktree creation under `.hydra/worktrees/`, tmux session setup with metadata, and agent launch
- **Create Copilot** command: single-session copilot agent (reattaches if already exists)
- **Agent config**: extracted agent type picker and command mapping to shared `agentConfig.ts`
- **Multiplexer backends**: added `getSessionRole`, `setSessionRole`, `getSessionAgent`, `setSessionAgent` for session metadata
- **Rebrand**: "TMUX Worktree" → "Hydra" across sidebar, commands, and UI
- **Managed worktrees**: moved to `<repo>/.hydra/worktrees/` (auto-added to `.gitignore`), legacy `~/.tmux-worktrees/` still recognized

## Test plan

- [ ] `Hydra: Create Worker` — prompts for branch, validates, creates worktree + session + launches agent
- [ ] `Hydra: Create Copilot` — creates copilot session, reattaches on second invoke
- [ ] `Hydra: Remove Task` — kills session and removes worktree
- [ ] Sidebar shows "Hydra" branding
- [ ] Worker visible in sidebar with correct role/agent metadata
- [ ] Zellij backend compiles (session metadata methods added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)