### PR TITLE
chore: add .hydra to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cli/twt
 cli/tmux-worktree-tui
 
 .sisyphus/
+.hydra


### PR DESCRIPTION
## Summary

- Add `.hydra` to `.gitignore` so the worker worktrees directory doesn't show as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)