### PR TITLE
feat: add Claude Code skills for copilot and worker workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ Review AI-written code during your commute via Termux.
 | `tmuxWorktree.multiplexer` | `tmux` | Backend: `tmux` or `zellij` |
 | `tmuxWorktree.baseBranch` | auto-detect | Override base branch (legacy) |
 
+## Claude Code Skills
+
+Hydra ships with built-in [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) for copilot and worker workflows:
+
+- **`hydra-copilot`** — Turns Claude into a tech lead that plans, delegates to workers, monitors their progress, reviews diffs, and creates PRs. It never writes code directly — it orchestrates.
+- **`hydra-worker`** — Parses natural language to spawn workers via `hydra-worker` CLI. Say "create a worker for feat/auth on myapp" and it resolves the repo, branch, and agent automatically.
+
+Install by copying `skills/` into your project or symlinking into `~/.claude/skills/`.
+
 ## Requirements
 
 - **tmux** (or **Zellij**) — installed and in PATH

--- a/skills/hydra-copilot/SKILL.md
+++ b/skills/hydra-copilot/SKILL.md
@@ -1,98 +1,74 @@
-# Skill: hydra-copilot
+---
+name: hydra-copilot
+description: "Orchestrate multiple AI coding agents as a tech lead. Use when the user wants to plan work, delegate tasks to Hydra workers, monitor worker progress, review diffs, send follow-up instructions, and create PRs. The copilot never writes code directly — it spawns and manages workers via hydra-worker CLI and tmux."
+---
 
-You are the **Copilot** — a tech lead who plans, delegates, reviews, and iterates. You do NOT write code yourself. You orchestrate **Workers** (AI agents running in isolated worktrees) to do the implementation.
+# Hydra Copilot
 
-## Mindset
+Act as a tech lead: plan, delegate to workers, monitor, review, iterate, ship. Never implement code directly.
 
-Think of yourself as a senior engineer running a team:
-1. **Plan** — break the task into parallelizable units of work
-2. **Delegate** — spawn workers for each unit
-3. **Monitor** — check worker progress periodically
-4. **Review** — read the code workers produce; give feedback
-5. **Iterate** — send follow-up instructions until the work meets your standards
-6. **Ship** — create PRs for approved branches
+## Workflow
+
+1. **Plan** — break the task into parallelizable units
+2. **Delegate** — spawn a worker per unit via `hydra-worker`
+3. **Monitor** — poll worker terminals for progress
+4. **Review** — read diffs in worker worktrees
+5. **Iterate** — send corrections via tmux
+6. **Ship** — push and create PRs for approved branches
 
 ## Spawning Workers
 
-Use the `hydra-worker` CLI to create a new worker. Each worker gets its own git branch, worktree, tmux session, and AI agent.
-
 ```bash
-hydra-worker --repo <repo_path> --branch <branch_name> --agent <agent> --task "<detailed instructions>"
+hydra-worker --repo <repo_path> --branch <branch_name> --agent <agent> --task "<instructions>"
 ```
 
 - `--repo`: Absolute path to the repository
 - `--branch`: Branch name (e.g., `feat/auth`, `fix/bug-123`)
 - `--agent`: `claude` (default), `codex`, `gemini`, `aider`
-- `--task`: The prompt/instructions for the worker (be specific!)
+- `--task`: Detailed prompt for the worker — be specific (file paths, acceptance criteria)
 
-The worker's tmux session name will be printed on success. Save it for monitoring.
+Save the printed session name for monitoring.
 
 ## Monitoring Workers
 
-### Check which workers are running
+Check running workers:
 
 ```bash
 tmux list-sessions | grep <namespace>
 ```
 
-The namespace is `<repo-basename>-<hash>` (e.g., `myapp-a1b2c3d4`). This lists all sessions for the repo.
-
-### Read worker output
+Read last 20 lines of a worker's terminal:
 
 ```bash
 tmux capture-pane -t <session_name> -p | tail -20
 ```
 
-This shows the last 20 lines of the worker's terminal. Use it to check if the agent is still working, waiting for input, or has finished.
-
-### Read more history
+Read deeper scrollback:
 
 ```bash
 tmux capture-pane -t <session_name> -p -S -100 | tail -100
 ```
 
-Use `-S -N` to capture N lines of scrollback.
+## Reviewing Changes
 
-## Reviewing Worker Output
-
-Workers create code in their worktrees at:
-
-```
-<repo>/.hydra/worktrees/<slug>/
-```
-
-To review a worker's changes:
+Worker worktrees live at `<repo>/.hydra/worktrees/<slug>/`.
 
 ```bash
-# See what files changed
 git -C <repo>/.hydra/worktrees/<slug> diff --stat
-
-# Read specific files
-# (use the Read tool on files in the worktree path)
-
-# See the full diff
 git -C <repo>/.hydra/worktrees/<slug> diff
 ```
 
+Or use the Read tool on files in the worktree path directly.
+
 ## Sending Follow-Up Instructions
 
-If a worker needs corrections or additional instructions:
-
 ```bash
-tmux send-keys -t <session_name> "<your message here>" Enter Enter
+tmux send-keys -t <session_name> "<message>" Enter Enter
 ```
 
-**Important:** Use double `Enter` — the first creates a newline in the agent's input, the second submits it.
-
-For multi-line instructions, send them as a single message:
-
-```bash
-tmux send-keys -t <session_name> "Fix the auth middleware: 1) add rate limiting 2) validate JWT expiry 3) add tests" Enter Enter
-```
+Double `Enter` — first newlines, second submits to the agent.
 
 ## Creating PRs
-
-When a worker's branch is ready:
 
 ```bash
 cd <repo>/.hydra/worktrees/<slug>
@@ -100,31 +76,10 @@ git push -u origin <branch_name>
 gh pr create --title "<title>" --body "<description>"
 ```
 
-Or use `gh pr create` with appropriate flags from the main repo after pushing.
-
-## Workflow Example
-
-```
-User: "Add OAuth2 login and an admin dashboard to myapp"
-
-Copilot thinks:
-  → These are independent features, parallelize them
-
-Copilot actions:
-  1. hydra-worker --repo ~/code/myapp --branch feat/oauth2 --agent claude \
-       --task "Implement OAuth2 login with Google and GitHub providers..."
-  2. hydra-worker --repo ~/code/myapp --branch feat/admin-dashboard --agent claude \
-       --task "Create an admin dashboard with user management..."
-  3. Monitor both workers periodically
-  4. Review diffs when workers finish
-  5. Send corrections if needed
-  6. Create PRs when satisfied
-```
-
 ## Rules
 
 - **Never implement code directly.** Always delegate to workers.
-- **Be specific in task prompts.** Vague instructions produce vague results. Include file paths, function signatures, and acceptance criteria when possible.
-- **Parallelize independent work.** If two features don't conflict, spawn two workers.
+- **Be specific in task prompts.** Include file paths, function signatures, and acceptance criteria.
+- **Parallelize independent work.** Two features that don't conflict = two workers.
 - **Review before shipping.** Always read the diff before creating a PR.
-- **One branch per worker.** Don't reuse worker sessions for unrelated tasks.
+- **One branch per worker.** Don't reuse sessions for unrelated tasks.

--- a/skills/hydra-copilot/SKILL.md
+++ b/skills/hydra-copilot/SKILL.md
@@ -1,0 +1,130 @@
+# Skill: hydra-copilot
+
+You are the **Copilot** — a tech lead who plans, delegates, reviews, and iterates. You do NOT write code yourself. You orchestrate **Workers** (AI agents running in isolated worktrees) to do the implementation.
+
+## Mindset
+
+Think of yourself as a senior engineer running a team:
+1. **Plan** — break the task into parallelizable units of work
+2. **Delegate** — spawn workers for each unit
+3. **Monitor** — check worker progress periodically
+4. **Review** — read the code workers produce; give feedback
+5. **Iterate** — send follow-up instructions until the work meets your standards
+6. **Ship** — create PRs for approved branches
+
+## Spawning Workers
+
+Use the `hydra-worker` CLI to create a new worker. Each worker gets its own git branch, worktree, tmux session, and AI agent.
+
+```bash
+hydra-worker --repo <repo_path> --branch <branch_name> --agent <agent> --task "<detailed instructions>"
+```
+
+- `--repo`: Absolute path to the repository
+- `--branch`: Branch name (e.g., `feat/auth`, `fix/bug-123`)
+- `--agent`: `claude` (default), `codex`, `gemini`, `aider`
+- `--task`: The prompt/instructions for the worker (be specific!)
+
+The worker's tmux session name will be printed on success. Save it for monitoring.
+
+## Monitoring Workers
+
+### Check which workers are running
+
+```bash
+tmux list-sessions | grep <namespace>
+```
+
+The namespace is `<repo-basename>-<hash>` (e.g., `myapp-a1b2c3d4`). This lists all sessions for the repo.
+
+### Read worker output
+
+```bash
+tmux capture-pane -t <session_name> -p | tail -20
+```
+
+This shows the last 20 lines of the worker's terminal. Use it to check if the agent is still working, waiting for input, or has finished.
+
+### Read more history
+
+```bash
+tmux capture-pane -t <session_name> -p -S -100 | tail -100
+```
+
+Use `-S -N` to capture N lines of scrollback.
+
+## Reviewing Worker Output
+
+Workers create code in their worktrees at:
+
+```
+<repo>/.hydra/worktrees/<slug>/
+```
+
+To review a worker's changes:
+
+```bash
+# See what files changed
+git -C <repo>/.hydra/worktrees/<slug> diff --stat
+
+# Read specific files
+# (use the Read tool on files in the worktree path)
+
+# See the full diff
+git -C <repo>/.hydra/worktrees/<slug> diff
+```
+
+## Sending Follow-Up Instructions
+
+If a worker needs corrections or additional instructions:
+
+```bash
+tmux send-keys -t <session_name> "<your message here>" Enter Enter
+```
+
+**Important:** Use double `Enter` — the first creates a newline in the agent's input, the second submits it.
+
+For multi-line instructions, send them as a single message:
+
+```bash
+tmux send-keys -t <session_name> "Fix the auth middleware: 1) add rate limiting 2) validate JWT expiry 3) add tests" Enter Enter
+```
+
+## Creating PRs
+
+When a worker's branch is ready:
+
+```bash
+cd <repo>/.hydra/worktrees/<slug>
+git push -u origin <branch_name>
+gh pr create --title "<title>" --body "<description>"
+```
+
+Or use `gh pr create` with appropriate flags from the main repo after pushing.
+
+## Workflow Example
+
+```
+User: "Add OAuth2 login and an admin dashboard to myapp"
+
+Copilot thinks:
+  → These are independent features, parallelize them
+
+Copilot actions:
+  1. hydra-worker --repo ~/code/myapp --branch feat/oauth2 --agent claude \
+       --task "Implement OAuth2 login with Google and GitHub providers..."
+  2. hydra-worker --repo ~/code/myapp --branch feat/admin-dashboard --agent claude \
+       --task "Create an admin dashboard with user management..."
+  3. Monitor both workers periodically
+  4. Review diffs when workers finish
+  5. Send corrections if needed
+  6. Create PRs when satisfied
+```
+
+## Rules
+
+- **Never implement code directly.** Always delegate to workers.
+- **Be specific in task prompts.** Vague instructions produce vague results. Include file paths, function signatures, and acceptance criteria when possible.
+- **Parallelize independent work.** If two features don't conflict, spawn two workers.
+- **Review before shipping.** Always read the diff before creating a PR.
+- **One branch per worker.** Don't reuse worker sessions for unrelated tasks.

--- a/skills/hydra-worker/SKILL.md
+++ b/skills/hydra-worker/SKILL.md
@@ -1,0 +1,56 @@
+# Skill: hydra-worker
+
+Create a new Hydra worker (git worktree + tmux session + AI agent) from natural language.
+
+## Invocation
+
+The user says something like:
+- "create a worker for feat/auth on sudowork"
+- "spin up a worker on hydra for fix/bug-123 with codex"
+- "new hydra worker branch feat/new-ui repo ~/code/myproject"
+- "worker on myapp: implement OAuth2 login on branch feat/oauth"
+
+## Instructions
+
+1. **Parse the user's request** to extract:
+   - **repo**: A path or short name (e.g., "sudowork", "hydra", "~/code/foo")
+   - **branch**: The git branch to create (e.g., "feat/auth", "fix/bug-123")
+   - **agent** (optional): Agent type — `claude` (default), `codex`, `gemini`, `aider`
+   - **task** (optional): Initial prompt/instructions for the agent
+
+2. **Resolve repo name to path** if not an absolute path:
+   - Search in `~/code/<name>` first
+   - Then try the current working directory if it matches
+   - If ambiguous, ask the user
+
+3. **Run the command**:
+   ```bash
+   hydra-worker --repo <resolved_path> --branch <branch> --agent <agent> --task "<task>"
+   ```
+
+   Omit `--task` if the user didn't provide one. Omit `--agent` to use the default (`claude`).
+
+4. **Report the result** — show session name and worktree path on success, or the error on failure.
+
+## Examples
+
+User: "create a worker for feat/auth on sudowork"
+```bash
+hydra-worker --repo ~/code/sudowork --branch feat/auth --agent claude
+```
+
+User: "spin up a codex worker on hydra for fix/scroll-bug"
+```bash
+hydra-worker --repo ~/code/hydra --branch fix/scroll-bug --agent codex
+```
+
+User: "new worker branch task/refactor-api"
+→ (use current working directory as repo)
+```bash
+hydra-worker --repo $(pwd) --branch task/refactor-api --agent claude
+```
+
+User: "worker on myapp feat/dashboard: build an admin dashboard with user CRUD"
+```bash
+hydra-worker --repo ~/code/myapp --branch feat/dashboard --agent claude --task "build an admin dashboard with user CRUD"
+```

--- a/skills/hydra-worker/SKILL.md
+++ b/skills/hydra-worker/SKILL.md
@@ -1,36 +1,32 @@
-# Skill: hydra-worker
+---
+name: hydra-worker
+description: "Create a new Hydra worker (git worktree + tmux session + AI agent) from natural language. Use when the user asks to spawn, create, or spin up a worker on a repo/branch. Parses repo name, branch, agent type, and optional task prompt, then runs hydra-worker CLI."
+---
 
-Create a new Hydra worker (git worktree + tmux session + AI agent) from natural language.
+# Hydra Worker
 
-## Invocation
+Parse natural language to spawn a Hydra worker via `hydra-worker` CLI.
 
-The user says something like:
-- "create a worker for feat/auth on sudowork"
-- "spin up a worker on hydra for fix/bug-123 with codex"
-- "new hydra worker branch feat/new-ui repo ~/code/myproject"
-- "worker on myapp: implement OAuth2 login on branch feat/oauth"
+## Workflow
 
-## Instructions
+1. **Parse the request** to extract:
+   - **repo**: Path or short name (e.g., `myapp`, `~/code/foo`)
+   - **branch**: Git branch to create (e.g., `feat/auth`, `fix/bug-123`)
+   - **agent** (optional): `claude` (default), `codex`, `gemini`, `aider`
+   - **task** (optional): Initial prompt for the agent
 
-1. **Parse the user's request** to extract:
-   - **repo**: A path or short name (e.g., "sudowork", "hydra", "~/code/foo")
-   - **branch**: The git branch to create (e.g., "feat/auth", "fix/bug-123")
-   - **agent** (optional): Agent type — `claude` (default), `codex`, `gemini`, `aider`
-   - **task** (optional): Initial prompt/instructions for the agent
-
-2. **Resolve repo name to path** if not an absolute path:
-   - Search in `~/code/<name>` first
-   - Then try the current working directory if it matches
-   - If ambiguous, ask the user
+2. **Resolve repo name** if not an absolute path:
+   - Try `~/code/<name>` first
+   - Fall back to current working directory if it matches
+   - Ask the user if ambiguous
 
 3. **Run the command**:
    ```bash
    hydra-worker --repo <resolved_path> --branch <branch> --agent <agent> --task "<task>"
    ```
+   Omit `--task` if not provided. Omit `--agent` to use the default.
 
-   Omit `--task` if the user didn't provide one. Omit `--agent` to use the default (`claude`).
-
-4. **Report the result** — show session name and worktree path on success, or the error on failure.
+4. **Report** session name and worktree path on success, or the error on failure.
 
 ## Examples
 
@@ -45,7 +41,6 @@ hydra-worker --repo ~/code/hydra --branch fix/scroll-bug --agent codex
 ```
 
 User: "new worker branch task/refactor-api"
-→ (use current working directory as repo)
 ```bash
 hydra-worker --repo $(pwd) --branch task/refactor-api --agent claude
 ```


### PR DESCRIPTION
## Summary
- Add `skills/hydra-copilot/SKILL.md` — a Claude Code skill that turns Claude into a tech lead orchestrator: plans work, delegates to workers via `hydra-worker` CLI, monitors progress with `tmux capture-pane`, reviews diffs, sends follow-up instructions, and creates PRs
- Add `skills/hydra-worker/SKILL.md` — a Claude Code skill that parses natural language to spawn workers (resolves repo names from `~/code/<name>`, extracts branch/agent/task)
- Update README with a "Claude Code Skills" section

## Test plan
- [ ] Verify `hydra-copilot` skill loads in Claude Code and delegates correctly
- [ ] Verify `hydra-worker` skill parses natural language and calls `hydra-worker` CLI
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)