### PR TITLE
feat: local-only worker instructions, global copilot injection

### DIFF
--- a/run/hydra-worker
+++ b/run/hydra-worker
@@ -152,28 +152,28 @@ else
   echo '.hydra' > "$GITIGNORE"
 fi
 
-# --- Inject worker instructions into worktree ---
+# --- Inject worker instructions into local-only file ---
 WORKER_INSTRUCTIONS="$HOME/.hydra/WORKER_AGENTS.md"
 if [[ -f "$WORKER_INSTRUCTIONS" ]]; then
-  # Determine target file based on agent type
+  # Use local-only files that don't conflict with the repo's own instruction files
   case "$AGENT" in
-    claude|aider) TARGET_FILE="$WORKTREE_PATH/CLAUDE.md" ;;
-    codex)        TARGET_FILE="$WORKTREE_PATH/AGENTS.md" ;;
-    gemini)       TARGET_FILE="$WORKTREE_PATH/GEMINI.md" ;;
-    *)            TARGET_FILE="$WORKTREE_PATH/CLAUDE.md" ;;
+    claude|aider) TARGET_FILE="$WORKTREE_PATH/CLAUDE.local.md" ;;
+    codex)        TARGET_FILE="$WORKTREE_PATH/AGENTS.override.md" ;;
+    *)            TARGET_FILE="" ;; # gemini and others: no reliable local-only mechanism
   esac
 
-  # Check for duplicates: skip if <hydra> tag already exists in target
-  if [[ -f "$TARGET_FILE" ]] && grep -q '<hydra>' "$TARGET_FILE"; then
-    echo "  Worker instructions already present in $(basename "$TARGET_FILE"), skipping injection."
-  else
-    {
-      echo ""
-      echo "<hydra>"
-      cat "$WORKER_INSTRUCTIONS"
-      echo "</hydra>"
-    } >> "$TARGET_FILE"
-    echo "  Injected worker instructions into $(basename "$TARGET_FILE")"
+  if [[ -n "$TARGET_FILE" ]]; then
+    # Check for duplicates: skip if <hydra> tag already exists in target
+    if [[ -f "$TARGET_FILE" ]] && grep -q '<hydra>' "$TARGET_FILE"; then
+      echo "  Worker instructions already present in $(basename "$TARGET_FILE"), skipping."
+    else
+      {
+        echo "<hydra>"
+        cat "$WORKER_INSTRUCTIONS"
+        echo "</hydra>"
+      } >> "$TARGET_FILE"
+      echo "  Injected worker instructions into $(basename "$TARGET_FILE")"
+    fi
   fi
 fi
 
@@ -190,31 +190,31 @@ tmux set-option -t "$SESSION_NAME" '@hydra-role' 'worker'
 tmux set-option -t "$SESSION_NAME" '@hydra-agent' "$AGENT"
 
 # --- Launch agent ---
+if [[ -n "$TASK" ]]; then
+  # Write task to a file to avoid shell quoting issues with tmux send-keys
+  TASK_FILE="$WORKTREE_PATH/.hydra-task.md"
+  printf '%s' "$TASK" > "$TASK_FILE"
+fi
+
 get_agent_command() {
   local agent="$1"
-  local task="$2"
+  local task_file="$2"
   case "$agent" in
     claude)
-      if [[ -n "$task" ]]; then
-        printf 'claude %q' "$task"
+      if [[ -n "$task_file" ]]; then
+        echo "claude \"\$(cat $task_file)\""
       else
         echo "claude"
       fi
       ;;
-    codex)
-      if [[ -n "$task" ]]; then
-        printf 'codex %q' "$task"
-      else
-        echo "codex"
-      fi
-      ;;
+    codex)  echo "codex" ;;
     gemini) echo "gemini" ;;
     aider)  echo "aider" ;;
     *)      echo "$agent" ;;
   esac
 }
 
-AGENT_CMD="$(get_agent_command "$AGENT" "$TASK")"
+AGENT_CMD="$(get_agent_command "$AGENT" "${TASK_FILE:-}")"
 tmux send-keys -t "$SESSION_NAME" "$AGENT_CMD" Enter
 
 # --- Output ---

--- a/src/utils/hydraGlobalConfig.ts
+++ b/src/utils/hydraGlobalConfig.ts
@@ -106,12 +106,38 @@ You are a **focused worker agent** operating in a Hydra-managed worktree. Your j
 - **If blocked, say so.** Output a clear message describing the blocker so the copilot can see it via \`tmux capture-pane\`.
 `;
 
-/** Ensure ~/.hydra/ exists and write default instruction files if missing. */
+const HYDRA_TAG = '<hydra>';
+const HYDRA_BLOCK_START = '<hydra>\n';
+const HYDRA_BLOCK_END = '</hydra>\n';
+
+/** Append content wrapped in <hydra> tags to a file, skipping if already present. */
+function injectHydraBlock(filePath: string, content: string): boolean {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf-8');
+    if (existing.includes(HYDRA_TAG)) { return false; }
+  }
+
+  const block = `\n${HYDRA_BLOCK_START}${content}${HYDRA_BLOCK_END}`;
+  fs.appendFileSync(filePath, block, 'utf-8');
+  return true;
+}
+
+/**
+ * Ensure ~/.hydra/ exists with default instruction files,
+ * and inject copilot instructions into global agent config files.
+ */
 export function ensureHydraGlobalConfig(): void {
+  // Ensure ~/.hydra/ directory
   if (!fs.existsSync(HYDRA_DIR)) {
     fs.mkdirSync(HYDRA_DIR, { recursive: true });
   }
 
+  // Write default instruction files to ~/.hydra/
   const copilotPath = path.join(HYDRA_DIR, 'COPILOT_AGENTS.md');
   if (!fs.existsSync(copilotPath)) {
     fs.writeFileSync(copilotPath, COPILOT_AGENTS_MD, 'utf-8');
@@ -121,12 +147,18 @@ export function ensureHydraGlobalConfig(): void {
   if (!fs.existsSync(workerPath)) {
     fs.writeFileSync(workerPath, WORKER_AGENTS_MD, 'utf-8');
   }
+
+  // Inject copilot instructions into global agent config files
+  const home = os.homedir();
+  injectHydraBlock(path.join(home, '.claude', 'CLAUDE.md'), COPILOT_AGENTS_MD);
+  injectHydraBlock(path.join(home, '.codex', 'AGENTS.md'), COPILOT_AGENTS_MD);
+  injectHydraBlock(path.join(home, '.gemini', 'GEMINI.md'), COPILOT_AGENTS_MD);
 }
 
 /**
- * Inject worker instructions into the worktree's agent instruction file.
- * Wraps content in <hydra> tags; skips if already present.
- * Returns the target file path if injected, or undefined if skipped.
+ * Inject worker instructions into LOCAL-ONLY files in the worktree.
+ * Uses CLAUDE.local.md for Claude/Aider, AGENTS.override.md for Codex.
+ * Gemini is not supported (no reliable local-only mechanism).
  */
 export function injectWorkerInstructions(worktreePath: string, agentType: string): string | undefined {
   const workerPath = path.join(HYDRA_DIR, 'WORKER_AGENTS.md');
@@ -134,20 +166,22 @@ export function injectWorkerInstructions(worktreePath: string, agentType: string
 
   let targetFilename: string;
   switch (agentType) {
-    case 'codex': targetFilename = 'AGENTS.md'; break;
-    case 'gemini': targetFilename = 'GEMINI.md'; break;
-    default: targetFilename = 'CLAUDE.md'; break;
+    case 'claude':
+    case 'aider':
+      targetFilename = 'CLAUDE.local.md';
+      break;
+    case 'codex':
+      targetFilename = 'AGENTS.override.md';
+      break;
+    default:
+      return undefined; // gemini and others: no reliable local-only mechanism
   }
+
   const targetFile = path.join(worktreePath, targetFilename);
-
-  // Duplicate check
-  if (fs.existsSync(targetFile)) {
-    const existing = fs.readFileSync(targetFile, 'utf-8');
-    if (existing.includes('<hydra>')) { return undefined; }
-  }
-
   const content = fs.readFileSync(workerPath, 'utf-8');
-  const block = `\n<hydra>\n${content}</hydra>\n`;
-  fs.appendFileSync(targetFile, block, 'utf-8');
-  return targetFile;
+
+  if (injectHydraBlock(targetFile, content)) {
+    return targetFile;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

- **Worker instructions** now use local-only files that don't conflict with the repo's own instruction files:
  - Claude/Aider → `CLAUDE.local.md` (gitignored by convention)
  - Codex → `AGENTS.override.md` (gitignored by convention)
  - Gemini → skipped (no reliable local-only mechanism)
- **Copilot instructions** injected into global agent configs on extension activation:
  - `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`
  - Wrapped in `<hydra>` tags with duplicate detection
- **Task prompt fix**: `hydra-worker --task` now writes to a temp file instead of `printf %q`, fixing shell quoting issues with special characters

## Test plan

- [x] `hydra-worker` creates `CLAUDE.local.md` (not `CLAUDE.md`) in worktree for claude agent
- [x] Repo's own `CLAUDE.md` is untouched
- [x] `<hydra>` duplicate detection works
- [x] Build passes (`npm run compile`)
- [ ] Extension activation creates `~/.hydra/` and injects into global configs
- [ ] Codex worker creates `AGENTS.override.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)