### PR TITLE
feat: add session manager for unified sessions.json state

### DIFF
--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { getActiveBackend } from '../utils/multiplexer';
 import { pickAgentType, getAgentCommand } from '../utils/agentConfig';
+import { addCopilot } from '../utils/sessionManager';
 
 export async function createCopilot(): Promise<void> {
   const backend = getActiveBackend();
@@ -59,6 +60,14 @@ export async function createCopilot(): Promise<void> {
     // Launch agent
     const agentCommand = getAgentCommand(agentType);
     await backend.sendKeys(sessionName, agentCommand);
+
+    // Register in sessions.json
+    addCopilot(sessionName, {
+      status: 'running',
+      agent: agentType,
+      workdir: cwd,
+      tmuxSession: sessionName,
+    });
 
     // Attach
     backend.attachSession(sessionName, cwd);

--- a/src/commands/createWorker.ts
+++ b/src/commands/createWorker.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   addWorktree,
@@ -14,6 +15,7 @@ import {
 import { getActiveBackend } from '../utils/multiplexer';
 import { pickAgentType, getAgentCommand } from '../utils/agentConfig';
 import { injectWorkerInstructions } from '../utils/hydraGlobalConfig';
+import { addWorker } from '../utils/sessionManager';
 
 async function resolveRepoRoot(): Promise<string | undefined> {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -116,7 +118,19 @@ export async function createWorker(): Promise<void> {
     const agentCommand = getAgentCommand(agentType);
     await backend.sendKeys(sessionName, agentCommand);
 
-    // 8. Attach
+    // 8. Register in sessions.json
+    const repoName = path.basename(repoRoot);
+    addWorker(sessionName, {
+      repo: repoName,
+      branch: branchName,
+      slug: finalSlug,
+      status: 'running',
+      agent: agentType,
+      workdir: worktreePath,
+      tmuxSession: sessionName,
+    });
+
+    // 9. Attach
     backend.attachSession(sessionName, worktreePath);
 
     vscode.window.showInformationMessage(`Worker created: ${branchName} (${agentType})`);

--- a/src/utils/sessionManager.ts
+++ b/src/utils/sessionManager.ts
@@ -1,0 +1,107 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface CopilotEntry {
+  status: 'running' | 'stopped';
+  agent: string;
+  workdir: string;
+  tmuxSession: string;
+  lastSeenAt: string;
+}
+
+export interface WorkerEntry {
+  repo: string;
+  branch: string;
+  slug: string;
+  status: 'running' | 'stopped';
+  agent: string;
+  workdir: string;
+  tmuxSession: string;
+  lastSeenAt: string;
+}
+
+export interface SessionsData {
+  copilots: Record<string, CopilotEntry>;
+  workers: Record<string, WorkerEntry>;
+  updatedAt: string;
+}
+
+const SESSIONS_DIR = path.join(os.homedir(), '.hydra');
+const SESSIONS_FILE = path.join(SESSIONS_DIR, 'sessions.json');
+
+function emptyData(): SessionsData {
+  return { copilots: {}, workers: {}, updatedAt: new Date().toISOString() };
+}
+
+export function readSessions(): SessionsData {
+  try {
+    if (!fs.existsSync(SESSIONS_FILE)) {
+      return emptyData();
+    }
+    const raw = fs.readFileSync(SESSIONS_FILE, 'utf-8');
+    const data = JSON.parse(raw) as SessionsData;
+    return {
+      copilots: data.copilots || {},
+      workers: data.workers || {},
+      updatedAt: data.updatedAt || new Date().toISOString(),
+    };
+  } catch {
+    return emptyData();
+  }
+}
+
+export function writeSessions(data: SessionsData): void {
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  data.updatedAt = new Date().toISOString();
+  const tmpFile = SESSIONS_FILE + '.tmp';
+  fs.writeFileSync(tmpFile, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmpFile, SESSIONS_FILE);
+}
+
+export function addCopilot(sessionName: string, data: Omit<CopilotEntry, 'lastSeenAt'>): void {
+  const sessions = readSessions();
+  sessions.copilots[sessionName] = {
+    ...data,
+    lastSeenAt: new Date().toISOString(),
+  };
+  writeSessions(sessions);
+}
+
+export function removeCopilot(sessionName: string): void {
+  const sessions = readSessions();
+  delete sessions.copilots[sessionName];
+  writeSessions(sessions);
+}
+
+export function addWorker(sessionName: string, data: Omit<WorkerEntry, 'lastSeenAt'>): void {
+  const sessions = readSessions();
+  sessions.workers[sessionName] = {
+    ...data,
+    lastSeenAt: new Date().toISOString(),
+  };
+  writeSessions(sessions);
+}
+
+export function removeWorker(sessionName: string): void {
+  const sessions = readSessions();
+  delete sessions.workers[sessionName];
+  writeSessions(sessions);
+}
+
+export function updateStatus(sessionName: string, status: 'running' | 'stopped'): void {
+  const sessions = readSessions();
+  if (sessions.copilots[sessionName]) {
+    sessions.copilots[sessionName].status = status;
+    sessions.copilots[sessionName].lastSeenAt = new Date().toISOString();
+  } else if (sessions.workers[sessionName]) {
+    sessions.workers[sessionName].status = status;
+    sessions.workers[sessionName].lastSeenAt = new Date().toISOString();
+  }
+  writeSessions(sessions);
+}
+
+export function listAll(): { copilots: Record<string, CopilotEntry>; workers: Record<string, WorkerEntry> } {
+  const sessions = readSessions();
+  return { copilots: sessions.copilots, workers: sessions.workers };
+}


### PR DESCRIPTION
## Summary
- Add `src/utils/sessionManager.ts` — TypeScript module for managing `~/.hydra/sessions.json` with CRUD operations (addCopilot, removeCopilot, addWorker, removeWorker, updateStatus, listAll) and atomic writes
- Integrate into `createWorker.ts` and `createCopilot.ts` so the extension updates sessions.json on session creation
- Update bash `hydra-worker` CLI to write sessions.json via jq after worker creation

This establishes `~/.hydra/sessions.json` as the single source of truth for all Hydra sessions (copilots + workers), shared between the VS Code extension and CLI tools.

## Test plan
- [ ] Create a worker via VS Code sidebar — verify entry appears in `~/.hydra/sessions.json`
- [ ] Create a copilot via VS Code sidebar — verify entry appears in `~/.hydra/sessions.json`
- [ ] Create a worker via `hydra-worker` CLI — verify entry appears in `~/.hydra/sessions.json`
- [ ] Run `hydra-list` — verify output matches sessions.json
- [ ] Verify `npm run compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)