### PR TITLE
fix: always show repo group in workers panel

### DIFF
--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -765,13 +765,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         group.workers.push(w);
       }
 
-      // If only one repo, show workers directly
-      if (byRepo.size === 1) {
-        const group = [...byRepo.values()][0];
-        return this.buildWorkerItems(group.workers, group.repoName, group.repoRoot);
-      }
-
-      // Multiple repos → RepoGroupItem per repo
+      // Always show RepoGroupItem per repo
       const items: TmuxItem[] = [];
       for (const group of byRepo.values()) {
         let baseBranch: string | undefined;


### PR DESCRIPTION
## Summary
- Always show `RepoGroupItem` wrapper in the Workers panel, even when there's only one repo
- Previously, single-repo setups showed workers flat without the repo name, making it unclear which repo they belonged to

## Test plan
- [ ] With workers from a single repo, verify the repo name group header appears
- [ ] With workers from multiple repos, verify grouping still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)