### PR TITLE
fix: correct publisher to zhoujinjing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "publisher": "joezhoujinjing",
+  "publisher": "zhoujinjing",
   "license": "MIT",
   "icon": "resources/icon.png",
   "categories": [


### PR DESCRIPTION
## Summary
- Fix `publisher` field in package.json from `joezhoujinjing` to `zhoujinjing` to match the actual VS Code Marketplace publisher ID

## Test plan
- [ ] Merge and verify the publish workflow succeeds with `VSCE_PAT`
- [ ] Extension appears at `zhoujinjing.hydra-code` on the Marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)