### PR TITLE
feat: CLI install & update mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,11 @@
         "command": "hydra.createWorker",
         "title": "Hydra: Create Worker",
         "icon": "$(server-process)"
+      },
+      {
+        "command": "hydra.setupCli",
+        "title": "Hydra: Setup CLI",
+        "icon": "$(terminal)"
       }
     ],
     "keybindings": [
@@ -226,6 +231,11 @@
         },
         {
           "command": "tmux.cleanupOrphans",
+          "when": "view == hydraCopilots || view == hydraWorkers",
+          "group": "navigation"
+        },
+        {
+          "command": "hydra.setupCli",
           "when": "view == hydraCopilots || view == hydraWorkers",
           "group": "navigation"
         },

--- a/skills/hydra/SKILL.md
+++ b/skills/hydra/SKILL.md
@@ -11,21 +11,12 @@ Create and manage Hydra workers (git worktree + tmux session + AI agent) from na
 
 Requires: **Node.js 18+**, **git**, **tmux** (macOS/Linux only — tmux is not available on Windows).
 
-If `hydra` is not on PATH, install it:
+The CLI is automatically installed when the Hydra VS Code extension activates:
 
-```bash
-# Clone and build
-mkdir -p ~/.hydra
-git clone https://github.com/joezhoujinjing/hydra.git ~/.hydra/repo
-cd ~/.hydra/repo && npm install && npm run compile
-
-# Link the CLI globally (pick one)
-npm link
-# or: ln -s ~/.hydra/repo/out/cli/index.js /usr/local/bin/hydra
-
-# Verify
-hydra --version
-```
+1. Install the **Hydra Code** VS Code extension
+2. The CLI is automatically installed at `~/.hydra/bin/hydra`
+3. Add to your shell profile: `export PATH="$HOME/.hydra/bin:$PATH"`
+4. Verify: `hydra --version`
 
 ## Invocation
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,82 +1,108 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
+import { outputResult, outputError, type OutputOpts } from '../output';
 
 export function registerListCommand(program: Command): void {
   program
     .command('list')
     .description('List all Hydra copilots and workers')
-    .option('--json', 'Output as JSON')
-    .action(async (opts: { json?: boolean }) => {
+    .action(async () => {
+      const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
         const state = await sm.sync();
 
-        if (opts.json) {
-          console.log(JSON.stringify(state, null, 2));
-          return;
-        }
-
-        // Legend
-        console.log('\n  \x1b[32m●\x1b[0m Running  ○ Stopped');
-
-        // Pretty-print copilots (sorted alphabetically by name for stability)
+        // Sort copilots and workers alphabetically by name for stability
         const copilots = Object.values(state.copilots)
           .sort((a, b) => (a.sessionName || a.tmuxSession).localeCompare(b.sessionName || b.tmuxSession));
-        if (copilots.length > 0) {
-          console.log('\nCopilots:');
-          console.log('─'.repeat(60));
-          for (const c of copilots) {
-            const statusIcon = c.status === 'running' ? '\x1b[32m●\x1b[0m' : '○';
-            const attached = c.attached ? ' (attached)' : '';
-            const name = c.sessionName || c.tmuxSession;
-            console.log(`  ${statusIcon} ${name}  [${c.agent}]${attached}`);
-            if (c.workdir) console.log(`    workdir: ${c.workdir}`);
-          }
-        } else {
-          console.log('\nNo copilots running.');
-        }
-
-        // Pretty-print workers (sorted alphabetically by name within each repo group)
         const workers = Object.values(state.workers);
-        if (workers.length > 0) {
-          console.log('\nWorkers:');
-          console.log('─'.repeat(60));
 
-          // Group by repo
-          const byRepo = new Map<string, typeof workers>();
-          for (const w of workers) {
-            const key = w.repo || 'unknown';
-            const group = byRepo.get(key) || [];
-            group.push(w);
-            byRepo.set(key, group);
+        const data = {
+          copilots: copilots.map(c => ({
+            session: c.sessionName || c.tmuxSession,
+            agent: c.agent,
+            status: c.status,
+            attached: c.attached,
+            workdir: c.workdir || null,
+          })),
+          workers: workers.map(w => ({
+            session: w.sessionName || w.tmuxSession,
+            repo: w.repo || null,
+            branch: w.branch || null,
+            agent: w.agent,
+            status: w.status,
+            attached: w.attached,
+            workdir: w.workdir || null,
+          })),
+          count: copilots.length + workers.length,
+        };
+
+        outputResult(data, globalOpts, () => {
+          const isTTY = process.stdout.isTTY;
+
+          // Legend
+          if (isTTY) {
+            console.log('\n  \x1b[32m\u25CF\x1b[0m Running  \u25CB Stopped');
           }
 
-          // Sort repo groups alphabetically, sort workers within each group by name
-          const sortedRepos = [...byRepo.keys()].sort((a, b) => a.localeCompare(b));
-          for (const repo of sortedRepos) {
-            const repoWorkers = byRepo.get(repo)!
-              .sort((a, b) => (a.sessionName || a.tmuxSession).localeCompare(b.sessionName || b.tmuxSession));
-            console.log(`  ${repo}:`);
-            for (const w of repoWorkers) {
-              const statusIcon = w.status === 'running' ? '\x1b[32m●\x1b[0m' : '○';
-              const attached = w.attached ? ' (attached)' : '';
-              const branch = w.branch ? ` (${w.branch})` : '';
-              const name = w.sessionName || w.tmuxSession;
-              console.log(`    ${statusIcon} ${name}${branch}  [${w.agent}]${attached}`);
-              if (w.workdir) console.log(`      workdir: ${w.workdir}`);
+          // Pretty-print copilots
+          if (copilots.length > 0) {
+            console.log('\nCopilots:');
+            if (isTTY) console.log('\u2500'.repeat(60));
+            for (const c of copilots) {
+              const statusIcon = isTTY
+                ? (c.status === 'running' ? '\x1b[32m\u25CF\x1b[0m' : '\u25CB')
+                : `[${c.status}]`;
+              const attached = c.attached ? ' (attached)' : '';
+              const name = c.sessionName || c.tmuxSession;
+              console.log(`  ${statusIcon} ${name}  [${c.agent}]${attached}`);
+              if (c.workdir) console.log(`    workdir: ${c.workdir}`);
             }
+          } else {
+            console.log('\nNo copilots running.');
           }
-        } else {
-          console.log('\nNo workers.');
-        }
 
-        console.log('');
+          // Pretty-print workers (sorted alphabetically by name within each repo group)
+          if (workers.length > 0) {
+            console.log('\nWorkers:');
+            if (isTTY) console.log('\u2500'.repeat(60));
+
+            // Group by repo
+            const byRepo = new Map<string, typeof workers>();
+            for (const w of workers) {
+              const key = w.repo || 'unknown';
+              const group = byRepo.get(key) || [];
+              group.push(w);
+              byRepo.set(key, group);
+            }
+
+            // Sort repo groups alphabetically, sort workers within each group by name
+            const sortedRepos = [...byRepo.keys()].sort((a, b) => a.localeCompare(b));
+            for (const repo of sortedRepos) {
+              const repoWorkers = byRepo.get(repo)!
+                .sort((a, b) => (a.sessionName || a.tmuxSession).localeCompare(b.sessionName || b.tmuxSession));
+              console.log(`  ${repo}:`);
+              for (const w of repoWorkers) {
+                const statusIcon = isTTY
+                  ? (w.status === 'running' ? '\x1b[32m\u25CF\x1b[0m' : '\u25CB')
+                  : `[${w.status}]`;
+                const attached = w.attached ? ' (attached)' : '';
+                const branch = w.branch ? ` (${w.branch})` : '';
+                const name = w.sessionName || w.tmuxSession;
+                console.log(`    ${statusIcon} ${name}${branch}  [${w.agent}]${attached}`);
+                if (w.workdir) console.log(`      workdir: ${w.workdir}`);
+              }
+            }
+          } else {
+            console.log('\nNo workers.');
+          }
+
+          console.log('');
+        });
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
+        outputError(error, globalOpts);
       }
     });
 }

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -2,8 +2,9 @@ import * as path from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
-import { getRepoRootFromPath } from '../../core/git';
+import { getRepoRootFromPath, localBranchExists } from '../../core/git';
 import { toCanonicalPath } from '../../core/path';
+import { outputResult, outputError, type OutputOpts } from '../output';
 
 function expandPath(p: string): string {
   return toCanonicalPath(p) || path.resolve(p);
@@ -31,9 +32,13 @@ export function registerWorkerCommands(program: Command): void {
       task?: string;
       taskFile?: string;
     }) => {
+      const globalOpts = program.opts() as OutputOpts;
       try {
         const repoPath = expandPath(opts.repo);
         const repoRoot = await getRepoRootFromPath(repoPath);
+
+        // Check if branch exists before create to detect resume
+        const branchExisted = await localBranchExists(repoRoot, opts.branch);
 
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
@@ -47,18 +52,31 @@ export function registerWorkerCommands(program: Command): void {
           taskFile: opts.taskFile,
         });
 
-        console.log(`Worker created: ${workerInfo.sessionName}`);
-        console.log(`  Branch:   ${workerInfo.branch}`);
-        console.log(`  Agent:    ${workerInfo.agent}`);
-        console.log(`  Workdir:  ${workerInfo.workdir}`);
-        console.log(`  Session:  ${workerInfo.tmuxSession}`);
+        const status = branchExisted ? 'exists' : 'created';
+
+        outputResult(
+          {
+            status,
+            session: workerInfo.sessionName,
+            branch: workerInfo.branch,
+            agent: workerInfo.agent,
+            workdir: workerInfo.workdir,
+          },
+          globalOpts,
+          () => {
+            const label = branchExisted ? 'Worker resumed' : 'Worker created';
+            console.log(`${label}: ${workerInfo.sessionName}`);
+            console.log(`  Branch:   ${workerInfo.branch}`);
+            console.log(`  Agent:    ${workerInfo.agent}`);
+            console.log(`  Workdir:  ${workerInfo.workdir}`);
+            console.log(`  Session:  ${workerInfo.tmuxSession}`);
+          },
+        );
 
         // Wait for delayed Enter (Claude trust prompt) before exiting
         await postCreatePromise;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
+        outputError(error, globalOpts);
       }
     });
 
@@ -66,15 +84,19 @@ export function registerWorkerCommands(program: Command): void {
     .command('delete <session>')
     .description('Delete a worker (kill session + remove worktree + delete branch)')
     .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
         await sm.deleteWorker(sessionName);
-        console.log(`Deleted worker: ${sessionName}`);
+
+        outputResult(
+          { status: 'deleted', session: sessionName },
+          globalOpts,
+          () => console.log(`Deleted worker: ${sessionName}`),
+        );
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
+        outputError(error, globalOpts);
       }
     });
 
@@ -82,15 +104,19 @@ export function registerWorkerCommands(program: Command): void {
     .command('stop <session>')
     .description('Stop a worker (kill tmux session, keep worktree)')
     .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
         await sm.stopWorker(sessionName);
-        console.log(`Stopped worker: ${sessionName}`);
+
+        outputResult(
+          { status: 'stopped', session: sessionName },
+          globalOpts,
+          () => console.log(`Stopped worker: ${sessionName}`),
+        );
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
+        outputError(error, globalOpts);
       }
     });
 
@@ -99,19 +125,30 @@ export function registerWorkerCommands(program: Command): void {
     .description('Start a stopped worker')
     .option('--agent <type>', 'Agent type override')
     .action(async (sessionName: string, opts: { agent?: string }) => {
+      const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
         const { workerInfo, postCreatePromise } = await sm.startWorker(sessionName, opts.agent);
-        console.log(`Started worker: ${workerInfo.sessionName}`);
-        console.log(`  Agent:  ${workerInfo.agent}`);
-        console.log(`  Workdir: ${workerInfo.workdir}`);
+
+        outputResult(
+          {
+            status: 'started',
+            session: workerInfo.sessionName,
+            agent: workerInfo.agent,
+            workdir: workerInfo.workdir,
+          },
+          globalOpts,
+          () => {
+            console.log(`Started worker: ${workerInfo.sessionName}`);
+            console.log(`  Agent:  ${workerInfo.agent}`);
+            console.log(`  Workdir: ${workerInfo.workdir}`);
+          },
+        );
 
         await postCreatePromise;
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Error: ${message}`);
-        process.exit(1);
+        outputError(error, globalOpts);
       }
     });
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,14 @@ const program = new Command();
 program
   .name('hydra')
   .description('CLI for managing Hydra copilots and workers')
-  .version(pkg.version);
+  .version(pkg.version)
+  .option('--json', 'Output results as JSON')
+  .option('--quiet', 'Suppress non-essential output');
+
+// Auto-enable --json when stdout is not a TTY (piped output)
+if (!process.stdout.isTTY) {
+  program.setOptionValue('json', true);
+}
 
 registerListCommand(program);
 registerWorkerCommands(program);

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,95 @@
+// Exit codes following agent-friendly CLI conventions
+export const EXIT_OK = 0;
+export const EXIT_INTERNAL = 1;
+export const EXIT_VALIDATION = 2;
+export const EXIT_NOT_FOUND = 4;
+export const EXIT_CONFLICT = 5;
+
+export interface OutputOpts {
+  json?: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Output a successful result.
+ * - --quiet: nothing (takes precedence)
+ * - --json: JSON.stringify to stdout
+ * - else: call prettyPrint callback
+ */
+export function outputResult(
+  data: Record<string, unknown>,
+  opts: OutputOpts,
+  prettyPrint: () => void,
+): void {
+  if (opts.quiet) {
+    return;
+  }
+  if (opts.json) {
+    console.log(JSON.stringify(data));
+    return;
+  }
+  prettyPrint();
+}
+
+/**
+ * Output an error and exit with the appropriate code.
+ * - --json: structured JSON error to stderr
+ * - else: plain text error to stderr
+ */
+export function outputError(error: unknown, opts: OutputOpts): never {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = classifyError(message);
+  const retryable = code === EXIT_INTERNAL;
+
+  if (opts.json) {
+    const errorObj: Record<string, unknown> = { error: { code, message, retryable } };
+    const hint = getHint(message, code);
+    if (hint) {
+      (errorObj.error as Record<string, unknown>).hint = hint;
+    }
+    console.error(JSON.stringify(errorObj));
+  } else {
+    console.error(`Error: ${message}`);
+  }
+
+  process.exit(code);
+}
+
+/**
+ * Classify an error message into an exit code by pattern-matching known messages.
+ */
+export function classifyError(message: string): number {
+  const lower = message.toLowerCase();
+
+  // Validation errors
+  if (
+    lower.includes('invalid branch name') ||
+    lower.includes('required option') ||
+    lower.includes('missing required') ||
+    lower.includes('validation')
+  ) {
+    return EXIT_VALIDATION;
+  }
+
+  // Not found
+  if (lower.includes('not found') || lower.includes('does not exist')) {
+    return EXIT_NOT_FOUND;
+  }
+
+  // Conflict / already exists
+  if (lower.includes('already exists') || lower.includes('has no managed worktree')) {
+    return EXIT_CONFLICT;
+  }
+
+  return EXIT_INTERNAL;
+}
+
+function getHint(message: string, code: number): string | undefined {
+  if (code === EXIT_NOT_FOUND) {
+    return 'Use "hydra list --json" to see available sessions.';
+  }
+  if (message.includes('has no managed worktree')) {
+    return 'Delete the branch first or use a different name.';
+  }
+  return undefined;
+}

--- a/src/core/cliInstaller.ts
+++ b/src/core/cliInstaller.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const HYDRA_DIR = path.join(os.homedir(), '.hydra');
+const BIN_DIR = path.join(HYDRA_DIR, 'bin');
+const WRAPPER_PATH = path.join(BIN_DIR, 'hydra');
+const EXT_PATH_FILE = path.join(HYDRA_DIR, 'ext-path');
+const VERSION_FILE = path.join(HYDRA_DIR, 'cli-version');
+
+const WRAPPER_SCRIPT = `#!/bin/sh
+EXT_PATH=$(cat "$HOME/.hydra/ext-path" 2>/dev/null)
+if [ -z "$EXT_PATH" ] || [ ! -f "$EXT_PATH/out/cli/index.js" ]; then
+  echo "Error: Hydra VS Code extension not found. Open VS Code with Hydra installed." >&2
+  exit 1
+fi
+exec node "$EXT_PATH/out/cli/index.js" "$@"
+`;
+
+export function installCli(extensionPath: string, version: string): { installed: boolean; updated: boolean } {
+  // Create ~/.hydra/bin/ directory
+  fs.mkdirSync(BIN_DIR, { recursive: true });
+
+  // Always write ext-path to handle extension updates
+  fs.writeFileSync(EXT_PATH_FILE, extensionPath, 'utf-8');
+
+  // Write wrapper script
+  fs.writeFileSync(WRAPPER_PATH, WRAPPER_SCRIPT, { encoding: 'utf-8', mode: 0o755 });
+
+  // Determine install vs update by comparing cli-version
+  let previousVersion: string | undefined;
+  try {
+    previousVersion = fs.readFileSync(VERSION_FILE, 'utf-8').trim();
+  } catch {
+    // File doesn't exist — fresh install
+  }
+
+  fs.writeFileSync(VERSION_FILE, version, 'utf-8');
+
+  if (!previousVersion) {
+    return { installed: true, updated: false };
+  }
+  if (previousVersion !== version) {
+    return { installed: false, updated: true };
+  }
+  // Same version, no change
+  return { installed: false, updated: false };
+}
+
+export function isCliOnPath(): boolean {
+  const envPath = process.env.PATH || '';
+  return envPath.split(path.delimiter).some(p => {
+    try {
+      return fs.realpathSync(p) === fs.realpathSync(BIN_DIR);
+    } catch {
+      return p === BIN_DIR || p === '$HOME/.hydra/bin' || p.endsWith('/.hydra/bin');
+    }
+  });
+}
+
+export function getShellConfigSnippet(): string {
+  return 'export PATH="$HOME/.hydra/bin:$PATH"';
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
 import { createCopilot } from './commands/createCopilot';
 import { createWorker } from './commands/createWorker';
 import { ensureHydraGlobalConfig } from './utils/hydraGlobalConfig';
+import { installCli, isCliOnPath, getShellConfigSnippet } from './core/cliInstaller';
 
 function updateViewDescriptions(...views: vscode.TreeView<unknown>[]): void {
   const backend = getActiveBackend();
@@ -82,9 +83,11 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
     vscode.commands.registerCommand('hydra.createCopilot', createCopilot),
     vscode.commands.registerCommand('hydra.createWorker', createWorker),
+    vscode.commands.registerCommand('hydra.setupCli', () => setupCli(context)),
   );
 
   ensureHydraGlobalConfig();
+  silentInstallCli(context);
   autoAttachOnStartup();
 
   const refreshAll = () => { copilotProvider.refresh(); workerProvider.refresh(); };
@@ -114,6 +117,50 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push({
       dispose: () => clearInterval(intervalId)
   });
+}
+
+function silentInstallCli(context: vscode.ExtensionContext): void {
+  try {
+    const version = (context.extension.packageJSON as { version: string }).version;
+    const result = installCli(context.extensionPath, version);
+    if (result.installed && !isCliOnPath()) {
+      const snippet = getShellConfigSnippet();
+      vscode.window.showInformationMessage(
+        `Hydra CLI installed. Add to PATH: \`${snippet}\``,
+        'Copy to Clipboard',
+        'Dismiss'
+      ).then(choice => {
+        if (choice === 'Copy to Clipboard') {
+          vscode.env.clipboard.writeText(snippet);
+        }
+      });
+    }
+  } catch (err) {
+    // CLI install is best-effort — don't block activation
+    console.error('Hydra CLI install failed:', err);
+  }
+}
+
+function setupCli(context: vscode.ExtensionContext): void {
+  try {
+    const version = (context.extension.packageJSON as { version: string }).version;
+    installCli(context.extensionPath, version);
+    const snippet = getShellConfigSnippet();
+    if (isCliOnPath()) {
+      vscode.window.showInformationMessage('Hydra CLI is installed and on PATH.');
+    } else {
+      vscode.window.showInformationMessage(
+        `Hydra CLI installed at ~/.hydra/bin/hydra. Add to PATH: \`${snippet}\``,
+        'Copy to Clipboard'
+      ).then(choice => {
+        if (choice === 'Copy to Clipboard') {
+          vscode.env.clipboard.writeText(snippet);
+        }
+      });
+    }
+  } catch (err) {
+    vscode.window.showErrorMessage(`Failed to setup Hydra CLI: ${err}`);
+  }
 }
 
 export function deactivate() {

--- a/src/resources/COPILOT_AGENTS.md
+++ b/src/resources/COPILOT_AGENTS.md
@@ -31,8 +31,11 @@ Save the printed session name for monitoring.
 ## Monitoring Workers
 
 ```bash
-# List running workers
-tmux list-sessions | grep <namespace>
+# List all workers (pretty-print)
+hydra list
+
+# List all workers (structured JSON for parsing)
+hydra list --json
 
 # Read last 20 lines of a worker's terminal
 tmux capture-pane -t <session_name> -p | tail -20


### PR DESCRIPTION
## Summary

- **Auto-install CLI wrapper** on extension activation — writes `~/.hydra/bin/hydra` shell script that delegates to the extension's bundled `out/cli/index.js`
- **Survives extension updates** — rewrites `~/.hydra/ext-path` on every activation so the wrapper always points to the current extension
- **PATH notification** — shows "Copy to Clipboard" prompt on fresh install when `~/.hydra/bin` isn't on PATH
- **`hydra.setupCli` command** — manual re-install + PATH status check from sidebar button
- **Agent-friendly CLI output** — JSON mode (`--json`), TTY detection, structured exit codes
- **Updated docs** — COPILOT_AGENTS.md uses `hydra list`, SKILL.md simplified install instructions

## Test plan

- [ ] Activate extension in VS Code → verify `~/.hydra/bin/hydra` exists and is executable
- [ ] Run `~/.hydra/bin/hydra --version` → should print version
- [ ] Run `~/.hydra/bin/hydra list` → should delegate to extension's bundled CLI
- [ ] Check `~/.hydra/ext-path` contains the correct extension path
- [ ] Click "Setup Hydra CLI" button in sidebar → shows PATH status
- [ ] Delete `~/.hydra/cli-version`, reload VS Code → should show PATH notification
- [ ] Update extension version, reload → should silently update (no notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)