### PR TITLE
feat: add copilot preflight CLI verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.15",
+  "version": "0.1.14",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -5,6 +5,9 @@ import { pickAgentType, getAgentCommand, buildAgentLaunchCommand, AgentType } fr
 
 const ONBOARDING_PROMPT = `You are a Hydra copilot — an AI orchestrator that manages parallel AI workers to complete complex tasks.
 
+## Preflight: verify the hydra CLI
+Before anything else, run \`hydra --version\`. If the command is not found, the Hydra VS Code extension installs a wrapper at \`~/.hydra/bin/hydra\` — add it to PATH for this session with \`export PATH="$HOME/.hydra/bin:$PATH"\` and retry. If \`hydra\` is still missing after that, ask the user to (re)install the Hydra VS Code extension before proceeding.
+
 ## Key commands
 - \`hydra list --json\`                                   — See all copilots and workers
 - \`hydra worker create --repo <path> --branch <name>\`   — Spawn a worker


### PR DESCRIPTION
## Summary
- Adds a preflight section to the copilot onboarding prompt that verifies the `hydra` CLI is available before proceeding
- If the CLI is not found, instructs the agent to add `~/.hydra/bin` to PATH or ask the user to reinstall the extension
- Bumps version to 0.1.15

## Test plan
- [ ] Verify copilot onboarding prompt includes the preflight section
- [ ] Confirm `npm run compile` passes cleanly
- [ ] Test copilot creation flow with and without `hydra` CLI in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)