### PR TITLE
fix: send Enter separately after message paste (#31)

### DIFF
--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -170,8 +170,10 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async sendMessage(sessionName: string, message: string): Promise<void> {
-    await exec(`tmux send-keys -t ${shellQuote(sessionName)} ${shellQuote(message)} Enter`);
+    // Send message text literally (without Enter) to avoid it being absorbed in bracketed paste
+    await exec(`tmux send-keys -l -t ${shellQuote(sessionName)} ${shellQuote(message)}`);
     await new Promise(resolve => setTimeout(resolve, 100));
+    // Send Enter separately to submit
     await exec(`tmux send-keys -t ${shellQuote(sessionName)} Enter`);
   }
 


### PR DESCRIPTION
## Summary
- Fix `hydra worker send` not submitting messages when using bracketed paste mode
- Send message text with `send-keys -l` (literal), then send `Enter` as a separate command
- Root cause: `Enter` in the same `send-keys` command gets absorbed into the paste rather than acting as submission

Fixes #31

## Test plan
- [ ] `hydra worker send <session> "short message"` — submits immediately
- [ ] `hydra worker send <session> "$(cat long-multiline-file.md)"` — submits after paste

🤖 Generated with [Claude Code](https://claude.com/claude-code)