### PR TITLE
feat: separate editor groups for copilots and workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getRepoRoot } from '../utils/git';
 import { getActiveBackend } from '../utils/multiplexer';
-import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem, CopilotItem } from '../providers/tmuxSessionProvider';
+import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem } from '../providers/tmuxSessionProvider';
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
@@ -37,7 +37,8 @@ async function handleTreeViewItem(item: TmuxItem): Promise<void> {
 
     if (exists) {
         const workdir = await backend.getSessionWorkdir(sessionName);
-        backend.attachSession(sessionName, workdir);
+        const role = await backend.getSessionRole(sessionName);
+        backend.attachSession(sessionName, workdir, undefined, role);
         return;
     }
 
@@ -78,7 +79,8 @@ async function handleCommandExecution(): Promise<void> {
     if (matchingSessions.length > 0) {
         for (const session of matchingSessions) {
             const workdir = await backend.getSessionWorkdir(session);
-            backend.attachSession(session, workdir);
+            const role = await backend.getSessionRole(session);
+            backend.attachSession(session, workdir, undefined, role);
         }
         vscode.window.showInformationMessage(`Attached to ${matchingSessions.length} session(s)`);
     } else {

--- a/src/commands/autoAttach.ts
+++ b/src/commands/autoAttach.ts
@@ -46,6 +46,7 @@ export async function autoAttachOnStartup(): Promise<void> {
     if (index > 0) {
       await sleep(ATTACH_STAGGER_MS);
     }
-    backend.attachSession(sessionName);
+    const role = await backend.getSessionRole(sessionName);
+    backend.attachSession(sessionName, undefined, undefined, role);
   }
 }

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -9,7 +9,8 @@ import {
   GitStatusItem,
   CopilotItem,
 } from '../providers/tmuxSessionProvider';
-import { getActiveBackend } from '../utils/multiplexer';
+import { getActiveBackend, HydraRole } from '../utils/multiplexer';
+import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
 
 function getWorktreePath(item: TmuxItem): string | undefined {
   if (item instanceof CopilotItem) return item.worktreePath;
@@ -19,6 +20,12 @@ function getWorktreePath(item: TmuxItem): string | undefined {
   if (item instanceof InactiveDetailItem) return item.worktree?.path;
   if (item instanceof WorktreeItem) return item.worktreePath;
   if (item instanceof GitStatusItem) return item.worktreePath;
+  return undefined;
+}
+
+function getRoleFromItem(item: TmuxItem): HydraRole | undefined {
+  if (item instanceof CopilotItem) return 'copilot';
+  if (item instanceof TmuxSessionItem) return item.session.hydraRole;
   return undefined;
 }
 
@@ -52,7 +59,8 @@ export async function attach(item: TmuxItem): Promise<void> {
     await ensureSessionExists(item.sessionName, worktreePath);
 
     const workdir = worktreePath || await backend.getSessionWorkdir(item.sessionName);
-    backend.attachSession(item.sessionName, workdir, vscode.TerminalLocation.Panel);
+    const role = getRoleFromItem(item);
+    backend.attachSession(item.sessionName, workdir, vscode.TerminalLocation.Panel, role);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to attach: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -74,7 +82,8 @@ export async function attachInEditor(item: TmuxItem): Promise<void> {
     await ensureSessionExists(item.sessionName, worktreePath);
 
     const workdir = worktreePath || await backend.getSessionWorkdir(item.sessionName);
-    backend.attachSession(item.sessionName, workdir, vscode.TerminalLocation.Editor);
+    const role = getRoleFromItem(item);
+    backend.attachSession(item.sessionName, workdir, getHydraEditorLocation(role), role);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to attach: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -50,7 +50,7 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
   for (const session of sessions) {
     if (session.name === sessionName) {
       const workdir = await backend.getSessionWorkdir(session.name);
-      backend.attachSession(session.name, workdir);
+      backend.attachSession(session.name, workdir, undefined, 'copilot');
       return;
     }
   }
@@ -71,7 +71,7 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
     // Send onboarding prompt after agent boots
     sendCopilotOnboarding(backend, sessionName);
 
-    backend.attachSession(sessionName, cwd);
+    backend.attachSession(sessionName, cwd, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');
@@ -114,7 +114,7 @@ export async function createCopilot(): Promise<void> {
       );
       if (action === 'Attach') {
         const workdir = await backend.getSessionWorkdir(session.name);
-        backend.attachSession(session.name, workdir);
+        backend.attachSession(session.name, workdir, undefined, 'copilot');
       }
       return;
     }
@@ -141,7 +141,7 @@ export async function createCopilot(): Promise<void> {
     sendCopilotOnboarding(backend, sessionName);
 
     // Attach
-    backend.attachSession(sessionName, cwd);
+    backend.attachSession(sessionName, cwd, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');

--- a/src/commands/createWorker.ts
+++ b/src/commands/createWorker.ts
@@ -83,7 +83,7 @@ export async function createWorker(): Promise<void> {
     });
 
     // Attach (vscode-specific) — no need to await postCreatePromise, extension is long-running
-    backend.attachSession(workerInfo.sessionName, workerInfo.workdir);
+    backend.attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
 
     vscode.window.showInformationMessage(`Worker created: ${branchName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,8 +96,12 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.window.onDidOpenTerminal(() => refreshAll()),
-    vscode.window.onDidCloseTerminal(() => refreshAll()),
+    vscode.window.onDidOpenTerminal(() => {
+      refreshAll();
+    }),
+    vscode.window.onDidCloseTerminal(() => {
+      refreshAll();
+    }),
     vscode.window.onDidChangeWindowState((e) => {
         if (e.focused) refreshAll();
     })

--- a/src/utils/hydraEditorGroup.ts
+++ b/src/utils/hydraEditorGroup.ts
@@ -43,7 +43,10 @@ export function getHydraEditorLocation(role?: HydraRole): vscode.TerminalEditorL
  * Returns a plain shortName when no role is specified.
  */
 export function buildHydraTerminalName(shortName: string, role?: HydraRole): string {
-  if (role === 'copilot') return `${HYDRA_PREFIX_COPILOT} ${shortName}`;
+  if (role === 'copilot') {
+    const agentName = shortName.replace(/^hydra-copilot-/, '');
+    return `${HYDRA_PREFIX_COPILOT} ${agentName}`;
+  }
   if (role === 'worker') return `${HYDRA_PREFIX_WORKER} ${shortName}`;
   return shortName;
 }

--- a/src/utils/hydraEditorGroup.ts
+++ b/src/utils/hydraEditorGroup.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { HydraRole } from './multiplexer';
+
+export const HYDRA_PREFIX_COPILOT = 'Copilot:';
+export const HYDRA_PREFIX_WORKER = 'Worker:';
+
+/**
+ * Scan tabGroups for a tab whose label starts with the given prefix.
+ * Returns the viewColumn of the first match, or undefined.
+ */
+function findGroupByPrefix(prefix: string): vscode.ViewColumn | undefined {
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      if (typeof tab.label === 'string' && tab.label.startsWith(prefix)) {
+        return group.viewColumn;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get the location options for a Hydra terminal.
+ * When a role is specified, discovers the editor group containing only that role's tabs.
+ * Falls back to ViewColumn.Beside when no matching group is found (creates a new group).
+ */
+export function getHydraEditorLocation(role?: HydraRole): vscode.TerminalEditorLocationOptions {
+  let existing: vscode.ViewColumn | undefined;
+  if (role === 'copilot') {
+    existing = findGroupByPrefix(HYDRA_PREFIX_COPILOT);
+  } else if (role === 'worker') {
+    existing = findGroupByPrefix(HYDRA_PREFIX_WORKER);
+  } else {
+    // No role: search for either prefix (backward compat)
+    existing = findGroupByPrefix(HYDRA_PREFIX_COPILOT) ?? findGroupByPrefix(HYDRA_PREFIX_WORKER);
+  }
+  return { viewColumn: existing ?? vscode.ViewColumn.Beside, preserveFocus: false };
+}
+
+/**
+ * Build a terminal name with a Hydra prefix based on role.
+ * Returns a plain shortName when no role is specified.
+ */
+export function buildHydraTerminalName(shortName: string, role?: HydraRole): string {
+  if (role === 'copilot') return `${HYDRA_PREFIX_COPILOT} ${shortName}`;
+  if (role === 'worker') return `${HYDRA_PREFIX_WORKER} ${shortName}`;
+  return shortName;
+}
+
+/**
+ * Get the terminal icon (resources/tmux.svg) for a Hydra terminal.
+ */
+export function getHydraTerminalIcon(): vscode.Uri {
+  // __dirname at runtime is `out/utils/`, so go up two levels to reach the extension root
+  return vscode.Uri.file(path.join(__dirname, '..', '..', 'resources', 'tmux.svg'));
+}
+
+/**
+ * Get the terminal tab color based on role.
+ * Blue for copilot, green for worker.
+ */
+export function getHydraTerminalColor(role?: HydraRole): vscode.ThemeColor | undefined {
+  if (role === 'copilot') return new vscode.ThemeColor('terminal.ansiBlue');
+  if (role === 'worker') return new vscode.ThemeColor('terminal.ansiGreen');
+  return undefined;
+}

--- a/src/utils/multiplexer.ts
+++ b/src/utils/multiplexer.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { createBackendFromConfig } from './backendFactory';
-import { MultiplexerBackendCore } from '../core/types';
+import { MultiplexerBackendCore, HydraRole } from '../core/types';
 
 // ─── Re-export shared types from core ─────────────────────
 export { MultiplexerType, HydraRole, MultiplexerSession, SessionStatusInfo } from '../core/types';
@@ -11,7 +11,8 @@ export interface MultiplexerBackend extends MultiplexerBackendCore {
   attachSession(
     sessionName: string,
     cwd?: string,
-    location?: vscode.TerminalLocation
+    location?: vscode.TerminalLocation | vscode.TerminalEditorLocationOptions,
+    role?: HydraRole
   ): vscode.Terminal;
 }
 

--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -17,8 +17,6 @@ function findTerminalBySession(sessionName: string): vscode.Terminal | undefined
   const candidateNames = [
     buildHydraTerminalName(shortName, 'copilot'),
     buildHydraTerminalName(shortName, 'worker'),
-    shortName,
-    `tmux: ${sessionName}`,
   ];
   return vscode.window.terminals.find(t => candidateNames.includes(t.name));
 }

--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import { exec } from './exec';
 import { TmuxBackendCore, buildStoredTmuxEnvScrubCommand } from '../core/tmux';
-import { MultiplexerBackend } from './multiplexer';
+import { MultiplexerBackend, HydraRole } from './multiplexer';
+import { getHydraEditorLocation, buildHydraTerminalName, getHydraTerminalIcon, getHydraTerminalColor } from './hydraEditorGroup';
 
 function getShortName(sessionName: string): string {
   const parts = sessionName.split('_');
@@ -11,22 +12,37 @@ function getShortName(sessionName: string): string {
   return sessionName;
 }
 
+function findTerminalBySession(sessionName: string): vscode.Terminal | undefined {
+  const shortName = getShortName(sessionName);
+  const candidateNames = [
+    buildHydraTerminalName(shortName, 'copilot'),
+    buildHydraTerminalName(shortName, 'worker'),
+    shortName,
+    `tmux: ${sessionName}`,
+  ];
+  return vscode.window.terminals.find(t => candidateNames.includes(t.name));
+}
+
 export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
   attachSession(
     sessionName: string,
     cwd?: string,
-    location: vscode.TerminalLocation = vscode.TerminalLocation.Editor
+    location?: vscode.TerminalLocation | vscode.TerminalEditorLocationOptions,
+    role?: HydraRole
   ): vscode.Terminal {
+    const resolvedLocation = location ?? getHydraEditorLocation(role);
     const shortName = getShortName(sessionName);
-    const terminalName = shortName;
+    const terminalName = buildHydraTerminalName(shortName, role);
 
-    const oldName = `tmux: ${sessionName}`;
-    const existing = vscode.window.terminals.find(t => t.name === terminalName || t.name === oldName);
+    const existing = findTerminalBySession(sessionName);
 
     if (existing) {
       void exec(`tmux set-window-option -t "${sessionName}":. window-size latest`).catch(() => {});
       const options = existing.creationOptions as vscode.TerminalOptions;
-      if (options && options.location === location) {
+      // For editor locations, reuse if both are editor-area targets
+      const existingIsEditor = options?.location !== vscode.TerminalLocation.Panel;
+      const requestedIsEditor = resolvedLocation !== vscode.TerminalLocation.Panel;
+      if (options && existingIsEditor === requestedIsEditor) {
         existing.show();
         return existing;
       }
@@ -68,8 +84,9 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
         'VSCODE_SHELL_INTEGRATION': null,
         'VSCODE_INJECTION': null,
       },
-      location,
-      iconPath: new vscode.ThemeIcon('server')
+      location: resolvedLocation,
+      iconPath: getHydraTerminalIcon(),
+      color: getHydraTerminalColor(role)
     });
     terminal.show();
     return terminal;


### PR DESCRIPTION
## Summary
- Role-aware editor group discovery: copilot and worker terminals open in separate editor groups
- Custom terminal tab favicon using `resources/tmux.svg` with blue color for copilots and green for workers
- Shortened tab prefixes from "Hydra Copilot:" / "Hydra Worker:" to "Copilot:" / "Worker:" (favicon already identifies Hydra)
- Version bump to 0.1.16

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (no new warnings)
- [x] Manual test: copilot and worker tabs appear in separate editor groups with correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)