### PR TITLE
feat: add rename command for copilots and workers

### DIFF
--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -1,11 +1,32 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
+import { SessionManager } from '../../core/sessionManager';
 import { outputResult, outputError, type OutputOpts } from '../output';
 
 export function registerCopilotCommands(program: Command): void {
   const copilot = program
     .command('copilot')
     .description('Manage Hydra copilots');
+
+  copilot
+    .command('rename <session> <new-name>')
+    .description('Rename a copilot session')
+    .action(async (sessionName: string, newName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const copilot = await sm.renameCopilot(sessionName, newName);
+
+        outputResult(
+          { status: 'renamed', oldSession: sessionName, newSession: copilot.sessionName },
+          globalOpts,
+          () => console.log(`Renamed copilot: ${sessionName} -> ${copilot.sessionName}`),
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
 
   copilot
     .command('logs <session>')

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -153,6 +153,36 @@ export function registerWorkerCommands(program: Command): void {
     });
 
   worker
+    .command('rename <session> <new-branch>')
+    .description('Rename a worker (branch, worktree, and session)')
+    .action(async (sessionName: string, newBranch: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const worker = await sm.renameWorker(sessionName, newBranch);
+
+        outputResult(
+          {
+            status: 'renamed',
+            oldSession: sessionName,
+            session: worker.sessionName,
+            branch: worker.branch,
+            workdir: worker.workdir,
+          },
+          globalOpts,
+          () => {
+            console.log(`Renamed worker: ${sessionName} -> ${worker.sessionName}`);
+            console.log(`  Branch:   ${worker.branch}`);
+            console.log(`  Workdir:  ${worker.workdir}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  worker
     .command('logs <session>')
     .description('Read worker terminal output')
     .option('--lines <n>', 'Number of lines to capture', '50')

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -400,6 +400,143 @@ export class SessionManager {
     return copilotInfo;
   }
 
+  async renameWorker(oldSessionName: string, newBranchName: string): Promise<WorkerInfo> {
+    const state = this.readSessionState();
+    const worker = state.workers[oldSessionName];
+    if (!worker) {
+      throw new Error(`Worker "${oldSessionName}" not found`);
+    }
+
+    if (!worker.repoRoot) {
+      throw new Error(`Worker "${oldSessionName}" has no associated repository`);
+    }
+
+    // Validate new branch name
+    const validationError = coreGit.validateBranchName(newBranchName);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    // Derive new slug, session name, worktree path
+    const repoSessionNamespace = coreGit.getRepoSessionNamespace(worker.repoRoot, this.backend);
+    const newSlug = coreGit.branchNameToSlug(newBranchName, this.backend);
+    const newSessionName = this.backend.buildSessionName(repoSessionNamespace, newSlug);
+    const worktreesDir = coreGit.getManagedRepoWorktreesDir(worker.repoRoot);
+    const newWorktreePath = path.join(worktreesDir, newSlug);
+
+    // Check conflicts
+    if (newSessionName !== oldSessionName && (state.workers[newSessionName] || state.copilots[newSessionName])) {
+      throw new Error(`Session "${newSessionName}" already exists`);
+    }
+    if (await coreGit.localBranchExists(worker.repoRoot, newBranchName)) {
+      throw new Error(`Branch "${newBranchName}" already exists`);
+    }
+
+    // 1. Rename git branch
+    if (worker.branch) {
+      await exec(
+        `git branch -m ${shellQuote(worker.branch)} ${shellQuote(newBranchName)}`,
+        { cwd: worker.repoRoot },
+      );
+
+      // Update vscode-merge-base config
+      try {
+        const baseBranch = await exec(
+          `git config ${shellQuote(`branch.${worker.branch}.vscode-merge-base`)}`,
+          { cwd: worker.repoRoot },
+        );
+        if (baseBranch.trim()) {
+          await exec(
+            `git config ${shellQuote(`branch.${newBranchName}.vscode-merge-base`)} ${shellQuote(baseBranch.trim())}`,
+            { cwd: worker.repoRoot },
+          );
+        }
+      } catch {
+        // No vscode-merge-base config — skip
+      }
+      try {
+        await exec(
+          `git config --unset ${shellQuote(`branch.${worker.branch}.vscode-merge-base`)}`,
+          { cwd: worker.repoRoot },
+        );
+      } catch {
+        // Already absent — skip
+      }
+    }
+
+    // 2. Move worktree directory (if it's a managed worktree and slug changed)
+    if (worker.workdir && newSlug !== worker.slug && fs.existsSync(worker.workdir)) {
+      await exec(
+        `git worktree move ${shellQuote(worker.workdir)} ${shellQuote(newWorktreePath)}`,
+        { cwd: worker.repoRoot },
+      );
+    }
+
+    // 3. Rename tmux session (if running and name changed)
+    if (newSessionName !== oldSessionName) {
+      const hasLive = await this.backend.hasSession(oldSessionName);
+      if (hasLive) {
+        await this.backend.renameSession(oldSessionName, newSessionName);
+
+        // Update @workdir metadata if worktree moved
+        if (newSlug !== worker.slug) {
+          await this.backend.setSessionWorkdir(newSessionName, newWorktreePath);
+        }
+      }
+    }
+
+    // 4. Update sessions.json
+    const worktreeMoved = newSlug !== worker.slug && fs.existsSync(newWorktreePath);
+    delete state.workers[oldSessionName];
+    worker.sessionName = newSessionName;
+    worker.tmuxSession = newSessionName;
+    worker.branch = newBranchName;
+    worker.slug = newSlug;
+    if (worktreeMoved) {
+      worker.workdir = newWorktreePath;
+    }
+    state.workers[newSessionName] = worker;
+    state.updatedAt = new Date().toISOString();
+    this.writeSessionState(state);
+
+    return worker;
+  }
+
+  async renameCopilot(oldSessionName: string, newSessionName: string): Promise<CopilotInfo> {
+    const state = this.readSessionState();
+    const copilot = state.copilots[oldSessionName];
+    if (!copilot) {
+      throw new Error(`Copilot "${oldSessionName}" not found`);
+    }
+
+    // Validate new name
+    const sanitized = this.backend.sanitizeSessionName(newSessionName);
+    if (!sanitized) {
+      throw new Error('New session name is invalid');
+    }
+
+    // Check conflict
+    if (state.copilots[newSessionName] || state.workers[newSessionName]) {
+      throw new Error(`Session "${newSessionName}" already exists`);
+    }
+
+    // Rename live tmux session (copilots are always running)
+    const hasLive = await this.backend.hasSession(oldSessionName);
+    if (hasLive) {
+      await this.backend.renameSession(oldSessionName, newSessionName);
+    }
+
+    // Update sessions.json
+    delete state.copilots[oldSessionName];
+    copilot.sessionName = newSessionName;
+    copilot.tmuxSession = newSessionName;
+    state.copilots[newSessionName] = copilot;
+    state.updatedAt = new Date().toISOString();
+    this.writeSessionState(state);
+
+    return copilot;
+  }
+
   async deleteCopilot(sessionName: string): Promise<void> {
     try {
       await this.backend.killSession(sessionName);

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -97,6 +97,10 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
     await exec(`tmux kill-session -t ${shellQuote(sessionName)}`);
   }
 
+  async renameSession(oldName: string, newName: string): Promise<void> {
+    await exec(`tmux rename-session -t ${shellQuote(oldName)} ${shellQuote(newName)}`);
+  }
+
   async hasSession(sessionName: string): Promise<boolean> {
     try {
       await exec(`tmux has-session -t ${shellQuote(sessionName)}`);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,6 +28,7 @@ export interface MultiplexerBackendCore {
   listSessions(): Promise<MultiplexerSession[]>;
   createSession(sessionName: string, cwd: string): Promise<void>;
   killSession(sessionName: string): Promise<void>;
+  renameSession(oldName: string, newName: string): Promise<void>;
   hasSession(sessionName: string): Promise<boolean>;
   getSessionWorkdir(sessionName: string): Promise<string | undefined>;
   setSessionWorkdir(sessionName: string, workdir: string): Promise<void>;


### PR DESCRIPTION
## Summary

- Add `hydra worker rename <session> <new-branch>` — renames git branch, moves worktree directory, renames tmux session, and updates sessions.json
- Add `hydra copilot rename <session> <new-name>` — renames tmux session and updates sessions.json
- Add `renameSession` to `MultiplexerBackendCore` interface

## Test plan

- [x] Worker rename (running): branch, worktree dir, tmux session, and sessions.json all updated
- [x] Worker rename (stopped): branch and worktree renamed without tmux session
- [x] Copilot rename (running): tmux session and sessions.json updated
- [x] Conflict detection: exits with code 5 when target branch/session exists
- [x] Not found: exits with code 4 with helpful hint
- [x] Invalid branch name: exits with validation error
- [x] vscode-merge-base config migrated to new branch name

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)