### PR TITLE
feat: release notes system with CHANGELOG.md

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,7 @@ jobs:
           if [ "$BUMP_TYPE" = "skip" ]; then
             VERSION=$(node -p "require('./package.json').version")
             echo "Skipping version bump, using current: $VERSION"
+            echo "bumped=false" >> $GITHUB_OUTPUT
           else
             CURRENT=$(node -p "require('./package.json').version")
             IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
@@ -88,15 +89,42 @@ jobs:
             done
 
             npm version $VERSION --no-git-tag-version
-
-            git add package.json package-lock.json
-            git commit -m "chore: release v${VERSION}"
-            git tag "v${VERSION}"
-            git push origin main
-            git push origin "v${VERSION}"
+            echo "bumped=true" >> $GITHUB_OUTPUT
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Determine previous tag for release notes
+          PREV_TAG=$(git tag --sort=-creatordate | grep -v "^v${VERSION}$" | head -1)
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Generate Release Notes
+        if: steps.version.outputs.bumped == 'true' && steps.version.outputs.prev_tag != ''
+        id: release_notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PREV_TAG="${{ steps.version.outputs.prev_tag }}"
+
+          # Create the new tag locally (not pushed yet) so the script can reference it
+          if ! git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            git tag "v${VERSION}"
+          fi
+
+          # Generate release notes (also updates CHANGELOG.md)
+          NOTES=$(bash scripts/release-notes.sh "$PREV_TAG" "v${VERSION}" 2>/dev/null || true)
+
+          # Save release notes body for GitHub Release
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            echo "$NOTES"
+            echo 'RELEASE_NOTES_EOF'
+          } >> $GITHUB_OUTPUT
+
+          # Commit changelog + version bump together
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore: release v${VERSION}"
+          git push origin main
+          git push origin "v${VERSION}"
 
       - name: Compile
         run: npm run compile
@@ -118,4 +146,5 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           files: hydra-${{ steps.version.outputs.version }}.vsix
-          generate_release_notes: true
+          body: ${{ steps.release_notes.outputs.body }}
+          generate_release_notes: ${{ steps.release_notes.outputs.body == '' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ Critical lessons learned — do not change without understanding the full implic
 - Run `npm run compile` and `npm run lint` before committing
 - Descriptive, conventional commit messages
 
+## Release Workflow
+
+Releases are automated via `.github/workflows/publish.yml` — bumps version, generates changelog via `scripts/release-notes.sh`, publishes to Marketplace + Open VSX, and creates a GitHub Release. Changelog categories: `feat:` → Added, `fix:` → Fixed, `revert:` → Removed, everything else → Changed. Manual use: `bash scripts/release-notes.sh [<prev-tag> <new-tag>]`.
+
 ---
 
 ## Install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+## [0.1.21] - 2026-05-04
+
+### Changed
+- chore: restructure CLAUDE.md and AGENTS.md — single source of truth (#49)
+- chore: clean up launch.json — remove legacy Go CLI entries (#48)
+
+### Commits
+1. 4e8b4ff chore: restructure CLAUDE.md and AGENTS.md — single source of truth (#49)
+2. b997b0c chore: clean up launch.json — remove legacy Go CLI entries (#48)
+
+## [0.1.20] - 2026-05-03
+
+### Added
+- feat: add rename command for copilots and workers (#42)
+
+### Commits
+1. 6e0b5a0 feat: add rename command for copilots and workers (#42)
+
+## [0.1.19] - 2026-05-03
+
+### Added
+- feat: separate editor groups for copilots and workers (#36)
+
+### Commits
+1. 8102c78 feat: separate editor groups for copilots and workers (#36)
+
+## [0.1.18] - 2026-05-03
+
+### Changed
+- test: use --dangerously-skip-permissions instead of --allowedTools
+- test: try claude-opus-4-6[1m] model suffix
+- Add Claude Code GitHub Workflow (#37)
+
+### Fixed
+- fix: align Claude workflow config with working pattern
+
+### Commits
+1. ed928c7 test: use --dangerously-skip-permissions instead of --allowedTools
+2. 4b9e831 test: try claude-opus-4-6[1m] model suffix
+3. d3a729c fix: align Claude workflow config with working pattern
+4. 9475378 Add Claude Code GitHub Workflow (#37)
+
+## [0.1.17] - 2026-05-03
+
+### Changed
+- chore: remove Zellij backend entirely (#33) (#35)
+
+### Commits
+1. 24e73ca chore: remove Zellij backend entirely (#33) (#35)
+
+## [0.1.16] - 2026-05-03
+
+### Fixed
+- fix: send Enter separately after message paste to avoid bracketed paste absorption (#31) (#32)
+
+### Commits
+1. 7a39a53 fix: send Enter separately after message paste to avoid bracketed paste absorption (#31) (#32)
+
+## [0.1.15] - 2026-05-03
+
+### Added
+- feat: add copilot preflight CLI verification (#30)
+
+### Commits
+1. d6218ab feat: add copilot preflight CLI verification (#30)
+
+## [0.1.13] - 2026-05-03
+
+### Added
+- feat(cli): worker logs, send commands + CLI install (#29)
+
+### Commits
+1. 4dc323a feat(cli): worker logs, send commands + CLI install (#29)
+
+## [0.1.12] - 2026-05-03
+
+### Added
+- feat: CLI install & update mechanism (#28)
+
+### Commits
+1. e5961c2 feat: CLI install & update mechanism (#28)
+
+## [0.1.11] - 2026-05-03
+
+### Added
+- feat(cli): stable sorting and status legend for list command (#26)
+
+### Fixed
+- fix: add missing hydra activity bar icon SVG
+
+### Commits
+1. 4d91c45 fix: add missing hydra activity bar icon SVG
+2. 8140367 feat(cli): stable sorting and status legend for list command (#26)
+
+## [0.1.10] - 2026-05-03
+
+### Changed
+- chore: remove legacy Go CLI (#27)
+
+### Commits
+1. e450b04 chore: remove legacy Go CLI (#27)
+
+## [0.1.9] - 2026-05-03
+
+### Changed
+- docs: revamp README and add real-world workflow examples (#25)
+
+### Commits
+1. ca7bc97 docs: revamp README and add real-world workflow examples (#25)
+
+## [0.1.8] - 2026-05-02
+
+### Fixed
+- fix: publish workflow and Marketplace icon (#24)
+
+### Commits
+1. 1ebf6bd fix: publish workflow and Marketplace icon (#24)
+
+## [0.1.7] - 2026-05-02
+
+### Changed
+- chore: resize SVG icons to 150x150
+- chore: rename to hydra-code, bump to v0.1.3, update icons
+- chore: remove completed CLI rewrite planning doc
+- chore: replace hardcoded ~/code paths with ~/.hydra/repo
+
+### Fixed
+- fix: skip past existing tags in publish workflow (#23)
+- fix: correct publisher to zhoujinjing for VS Code Marketplace
+
+### Commits
+1. 82771ec fix: skip past existing tags in publish workflow (#23)
+2. 240fae4 fix: correct publisher to zhoujinjing for VS Code Marketplace
+3. 1096378 chore: resize SVG icons to 150x150
+4. 4545405 chore: rename to hydra-code, bump to v0.1.3, update icons
+5. 76c8cdf chore: remove completed CLI rewrite planning doc
+6. d9936c3 chore: replace hardcoded ~/code paths with ~/.hydra/repo

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Generate release notes from git history and prepend to CHANGELOG.md
+#
+# Usage:
+#   scripts/release-notes.sh [<prev-tag> <new-tag>]
+#
+# If no arguments given, computes:
+#   prev-tag = second most recent tag (by creator date)
+#   new-tag  = most recent tag (by creator date)
+#
+# Output: writes to stdout AND prepends to CHANGELOG.md (if it exists)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+# --- Resolve tags -----------------------------------------------------------
+
+if [ $# -ge 2 ]; then
+  PREV_TAG="$1"
+  NEW_TAG="$2"
+elif [ $# -eq 1 ]; then
+  NEW_TAG="$1"
+  PREV_TAG=$(git tag --sort=-creatordate | grep -v "^${NEW_TAG}$" | head -1)
+else
+  NEW_TAG=$(git tag --sort=-creatordate | head -1)
+  PREV_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+fi
+
+if [ -z "$PREV_TAG" ] || [ -z "$NEW_TAG" ]; then
+  echo "Error: could not determine tag range" >&2
+  exit 1
+fi
+
+# --- Collect commits ---------------------------------------------------------
+
+DATE=$(git log -1 --format=%ci "$NEW_TAG" | cut -d' ' -f1)
+VERSION="${NEW_TAG#v}"  # strip leading 'v'
+
+# Get commits between tags, excluding release commits
+COMMITS=$(git log --oneline "$PREV_TAG".."$NEW_TAG" --no-merges | grep -v 'chore: release' || true)
+
+if [ -z "$COMMITS" ]; then
+  # Include merge commits if no non-merge commits found
+  COMMITS=$(git log --oneline "$PREV_TAG".."$NEW_TAG" | grep -v 'chore: release' || true)
+fi
+
+if [ -z "$COMMITS" ]; then
+  echo "No commits found between $PREV_TAG and $NEW_TAG" >&2
+  exit 0
+fi
+
+# --- Classify commits --------------------------------------------------------
+
+ADDED=""
+CHANGED=""
+FIXED=""
+REMOVED=""
+COMMIT_LIST=""
+NUM=0
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  HASH=$(echo "$line" | awk '{print $1}')
+  MSG=$(echo "$line" | cut -d' ' -f2-)
+  NUM=$((NUM + 1))
+
+  # Build numbered commit list
+  COMMIT_LIST="${COMMIT_LIST}${NUM}. ${HASH} ${MSG}
+"
+
+  # Extract PR number if present — pattern: (#NN)
+  PR=""
+  if echo "$MSG" | grep -qE '\(#[0-9]+\)'; then
+    PR=$(echo "$MSG" | grep -oE '\(#[0-9]+\)' | tail -1)
+  fi
+
+  # Format entry: use full message (already includes PR ref)
+  ENTRY="- ${MSG}"
+
+  # Classify by conventional commit prefix
+  case "$MSG" in
+    feat:*|feat\(*) ADDED="${ADDED}${ENTRY}
+" ;;
+    fix:*|fix\(*)   FIXED="${FIXED}${ENTRY}
+" ;;
+    revert:*|revert\(*) REMOVED="${REMOVED}${ENTRY}
+" ;;
+    *)               CHANGED="${CHANGED}${ENTRY}
+" ;;
+  esac
+done <<< "$COMMITS"
+
+# --- Build release section ---------------------------------------------------
+
+build_section() {
+  echo "## [${VERSION}] - ${DATE}"
+  echo ""
+
+  if [ -n "$ADDED" ]; then
+    echo "### Added"
+    printf '%s' "$ADDED"
+    echo ""
+  fi
+
+  if [ -n "$CHANGED" ]; then
+    echo "### Changed"
+    printf '%s' "$CHANGED"
+    echo ""
+  fi
+
+  if [ -n "$FIXED" ]; then
+    echo "### Fixed"
+    printf '%s' "$FIXED"
+    echo ""
+  fi
+
+  if [ -n "$REMOVED" ]; then
+    echo "### Removed"
+    printf '%s' "$REMOVED"
+    echo ""
+  fi
+
+  echo "### Commits"
+  printf '%s' "$COMMIT_LIST"
+}
+
+SECTION=$(build_section)
+
+# --- Output ------------------------------------------------------------------
+
+# Print to stdout (for CI to capture as release body)
+echo "$SECTION"
+
+# --- Prepend to CHANGELOG.md ------------------------------------------------
+
+if [ -f "$CHANGELOG" ]; then
+  # Read existing content after the "# Changelog" header
+  EXISTING=$(sed '1{/^# Changelog$/d;}' "$CHANGELOG" | sed '/./,$!d')
+
+  {
+    echo "# Changelog"
+    echo ""
+    echo "$SECTION"
+    if [ -n "$EXISTING" ]; then
+      echo ""
+      echo "$EXISTING"
+    fi
+  } > "$CHANGELOG"
+else
+  {
+    echo "# Changelog"
+    echo ""
+    echo "$SECTION"
+  } > "$CHANGELOG"
+fi
+
+echo "" >&2
+echo "Updated $CHANGELOG" >&2


### PR DESCRIPTION
## Summary
- Add `scripts/release-notes.sh` that generates structured changelog entries from git history, classifying commits by conventional commit prefix (feat→Added, fix→Fixed, revert→Removed, else→Changed)
- Create `CHANGELOG.md` backfilled with 14 releases (v0.1.7–v0.1.21)
- Integrate release notes into `.github/workflows/publish.yml` — generates changelog alongside version bump, uses it as GitHub Release body
- Document release workflow in `AGENTS.md`
- Delete 28 legacy tags (v0.0.18 + all v1.x.x) from local and remote

## Test plan
- [ ] Run `bash scripts/release-notes.sh v0.1.20 v0.1.21` and verify output format
- [ ] Run `npm run compile && npm run lint` — no new errors
- [ ] Review CHANGELOG.md for correct categorization and ordering
- [ ] Trigger a test publish via `workflow_dispatch` to verify CI integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)