### PR TITLE
feat: show PR status alongside git changes in tree view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@ After changes, always run `npm run compile` to verify the build succeeds before 
 To test the extension in a VS Code Extension Development Host:
 
 ```bash
-cd <worktree-or-repo-path>
+cd <absolute-path-to-worktree-or-repo>
 npm run compile
 mkdir -p /tmp/hydra-test
-code --extensionDevelopmentPath="$(pwd)" /tmp/hydra-test
+code --extensionDevelopmentPath="<absolute-path-to-worktree-or-repo>" /tmp/hydra-test
 ```
 
 ## Project Structure

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -22,6 +22,8 @@ export interface SessionStatus {
   classification: Classification;
   commitsAhead: number;
   cpuUsage: number;
+  prNumber?: number;
+  prState?: 'open' | 'closed' | 'merged';
 }
 
 interface SessionWithStatus extends MultiplexerSession {
@@ -233,6 +235,33 @@ async function isGitInitialized(dirPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+interface PrInfo {
+  number: number;
+  state: 'open' | 'closed' | 'merged';
+}
+
+async function fetchRepoPrStatuses(repoRoot: string): Promise<Map<string, PrInfo>> {
+  const map = new Map<string, PrInfo>();
+  try {
+    const json = await exec(
+      `gh pr list -R "${repoRoot}" --state all --json headRefName,number,state --limit 100`
+    );
+    const prs: { headRefName: string; number: number; state: string }[] = JSON.parse(json);
+    // Keep the first (most recent) PR per branch
+    for (const pr of prs) {
+      if (!map.has(pr.headRefName)) {
+        const state = pr.state === 'MERGED' ? 'merged'
+          : pr.state === 'CLOSED' ? 'closed'
+          : 'open';
+        map.set(pr.headRefName, { number: pr.number, state });
+      }
+    }
+  } catch {
+    void 0;
+  }
+  return map;
 }
 
 // ─── Tree Item Classes ────────────────────────────────────
@@ -466,12 +495,22 @@ export class GitStatusItem extends TmuxItem {
     if (status.gitModified > 0) parts.push(`M:${status.gitModified}`);
     if (newCount > 0) parts.push(`U:${newCount}`);
     if (status.gitDeleted > 0) parts.push(`D:${status.gitDeleted}`);
+    if (status.prNumber) parts.push(`PR #${status.prNumber} ${status.prState}`);
 
     const label = parts.join(' · ');
     super(label, vscode.TreeItemCollapsibleState.None, repoName, sessionName);
 
     this.contextValue = 'tmuxItem';
-    this.iconPath = new vscode.ThemeIcon('git-commit', new vscode.ThemeColor('charts.green'));
+
+    let iconColor: vscode.ThemeColor;
+    if (status.prState === 'merged') {
+      iconColor = new vscode.ThemeColor('charts.purple');
+    } else if (status.prState === 'closed') {
+      iconColor = new vscode.ThemeColor('charts.red');
+    } else {
+      iconColor = new vscode.ThemeColor('charts.green');
+    }
+    this.iconPath = new vscode.ThemeIcon('git-commit', iconColor);
     this.worktreePath = worktreePath;
   }
 }
@@ -521,7 +560,7 @@ export class TmuxSessionItem extends WorktreeItem {
 
     const hasGitChanges = session.status.commitsAhead > 0 || session.status.gitModified > 0 ||
       session.status.gitDeleted > 0 || session.status.gitAdded > 0 || session.status.gitUntracked > 0;
-    if (hasGitChanges) {
+    if (hasGitChanges || session.status.prNumber) {
       this.gitStatusItem = new GitStatusItem(session.status, repoName, session.name, session.worktreePath);
     }
   }
@@ -565,7 +604,7 @@ export class InactiveWorktreeItem extends WorktreeItem {
     if (gitStatusOverride) {
       const hasGitChanges = gitStatusOverride.commitsAhead > 0 || gitStatusOverride.gitModified > 0 ||
         (gitStatusOverride.gitAdded + gitStatusOverride.gitUntracked) > 0 || gitStatusOverride.gitDeleted > 0;
-      if (hasGitChanges) {
+      if (hasGitChanges || gitStatusOverride.prNumber) {
         this.gitStatusItem = new GitStatusItem(gitStatusOverride, repoName, targetSessionName, worktree.path);
       }
     }
@@ -779,6 +818,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
 
   private async buildWorkerItems(workers: WorkerInfo[], repoName: string, repoRoot: string): Promise<TmuxItem[]> {
     const activePath = getActiveWorkspacePath();
+    const prMap = await fetchRepoPrStatuses(repoRoot);
     const items: TmuxItem[] = [];
 
     for (const w of workers) {
@@ -790,8 +830,14 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         ? await getWorktreeBranchLabel(w.workdir, w.branch || w.slug)
         : (w.branch || w.slug);
 
+      const pr = prMap.get(branchLabel);
+
       if (w.status === 'running') {
         const status = await getSessionStatus(w.sessionName, w.workdir);
+        if (pr) {
+          status.prNumber = pr.number;
+          status.prState = pr.state;
+        }
         const session: SessionWithStatus = {
           name: w.sessionName,
           windows: 1,
@@ -810,10 +856,20 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       } else {
         const worktree: Worktree = { path: w.workdir, branch: w.branch, isMain: false };
         const gitStatus = hasGit && w.workdir ? await getWorktreeGitStatus(w.workdir) : undefined;
-        const stoppedStatus: SessionStatus | undefined = gitStatus ? {
+        let stoppedStatus: SessionStatus | undefined = gitStatus ? {
           attached: false, panes: 0, lastActive: 0, classification: 'stopped', cpuUsage: 0,
           ...gitStatus
         } : undefined;
+        if (pr) {
+          if (!stoppedStatus) {
+            stoppedStatus = {
+              attached: false, panes: 0, lastActive: 0, classification: 'stopped', cpuUsage: 0,
+              gitDirty: 0, gitModified: 0, gitAdded: 0, gitDeleted: 0, gitUntracked: 0, commitsAhead: 0,
+            };
+          }
+          stoppedStatus.prNumber = pr.number;
+          stoppedStatus.prState = pr.state;
+        }
         items.push(new InactiveWorktreeItem(
           worktree, repoName, w.sessionName, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, stoppedStatus, repoRoot

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -246,7 +246,8 @@ async function fetchRepoPrStatuses(repoRoot: string): Promise<Map<string, PrInfo
   const map = new Map<string, PrInfo>();
   try {
     const json = await exec(
-      `gh pr list -R "${repoRoot}" --state all --json headRefName,number,state --limit 100`
+      'gh pr list --state all --json headRefName,number,state --limit 100',
+      { cwd: repoRoot }
     );
     const prs: { headRefName: string; number: number; state: string }[] = JSON.parse(json);
     // Keep the first (most recent) PR per branch


### PR DESCRIPTION
## Summary
- Display PR number and state (`open`/`closed`/`merged`) in the Level 4 `GitStatusItem` label, e.g. `↑2 · M:3 · PR #46 open`
- Use a single batched `gh pr list --state all` call per repo instead of one call per worktree
- Show `GitStatusItem` even when there are no local changes but a PR exists (e.g. `PR #42 merged`)
- Color the git-commit icon by PR state: green (open), purple (merged), red (closed)

Closes #50

## Test plan
- [ ] Create a worker with a branch that has an open PR — verify `PR #N open` appears in tree
- [ ] Merge/close a PR — verify label updates to `PR #N merged`/`PR #N closed` with correct icon color
- [ ] Branch with no PR — verify no PR info shown, behavior unchanged
- [ ] Branch with local changes + PR — verify both git changes and PR status on same line
- [ ] Repo with many worktrees — verify only one `gh pr list` call (check network/timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)