### PR TITLE
docs: rebrand README with Hydra metaphor and parallel workflow vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,264 +4,118 @@
 
 <h1 align="center">Hydra</h1>
 
-<p align="center"><strong>Command an army of AI coding agents — each on its own branch, in its own terminal, all visible from VS Code.</strong></p>
+<p align="center">
+  <strong>Grow heads. Ship faster.</strong><br>
+  Orchestrate an army of parallel AI agents directly from VS Code.
+</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
+    <img src="https://img.shields.io/visual-studio-marketplace/v/zhoujinjing.hydra-code?label=Marketplace" alt="Marketplace" />
+  </a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
+    <img src="https://img.shields.io/visual-studio-marketplace/i/zhoujinjing.hydra-code" alt="Installs" />
+  </a>
+  <a href="LICENSE.md">
+    <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />
+  </a>
+</p>
 
 🌏 **Read this in other languages:** **English** | [中文](docs/README.zh.md)
 
+---
+
+## The Vision
+
+In Greek mythology, the Hydra was a beast that grew two heads for every one cut off. In software engineering, we face a similar "beast": a mountain of tasks that grows faster than we can code.
+
+**Hydra** turns this metaphor on its head. Instead of struggling against the growth, you embrace it. You become the central nervous system, spawning and orchestrating as many AI agent "heads" as you need. One head builds the auth, another optimizes the database, a third writes the tests — all working simultaneously, all visible from your sidebar.
+
+**Stop working sequentially. Start working in parallel.**
+
+---
+
+## A Story of Parallel Power
+
+Imagine you're porting 40 features from an old codebase. Doing it alone is a weeks-long slog. With Hydra, it looks like this:
+
+1. **Spawn a Copilot** on your `main` branch. You tell it: "Analyze these 40 features and break them into 8 logical groups."
+2. **Delegate to Workers.** With a single command, your Copilot spawns 8 Workers. Each gets its own git branch, its own isolated worktree, and its own AI agent (Claude, Gemini, or Codex).
+3. **Orchestrate.** You watch your sidebar. 8 terminals are alive. 8 agents are coding. You see their CPU usage, their git diffs, and their progress in real-time.
+4. **Review & Ship.** As Workers finish, you review their diffs, merge their branches, and move on.
+
+**What took weeks now takes hours.**
+
+```text
+[ YOU: THE ARCHITECT ]
+         │
+         ▼
+ [ COPILOT (main) ] ──────────────────┐
+ (Plans, Monitors, Reviews)           │
+         │                            │
+         ├─> [ WORKER 1 (feat/auth) ] ─┼─> "Building OAuth2 flow..."
+         ├─> [ WORKER 2 (feat/ui)   ] ─┼─> "Styling the dashboard..."
+         ├─> [ WORKER 3 (fix/perf)  ] ─┼─> "Optimizing DB queries..."
+         └─> [ WORKER 4 (docs/api)  ] ─┼─> "Generating OpenAPI docs..."
+                                      │
+                                [ THE ARMY ]
+```
+
+---
+
 ## Why Hydra?
 
-Modern AI coding agents are powerful — but one agent at a time is a bottleneck.
-Hydra turns VS Code into a **command center** where you orchestrate many agents in parallel, each isolated on its own git branch, each visible in a single sidebar.
+- **The Serial Bottleneck:** Switching between tasks is expensive. Waiting for one AI agent to finish before starting the next is a waste of your most precious resource: time.
+- **Context is King:** Hydra isolates agents in their own git worktrees. No more "agent halluncinations" because they saw unrelated code. No more git conflicts because two agents touched the same file in the same directory.
+- **Persistent Souls:** Every agent lives in a `tmux` session. Close VS Code, restart your computer, or SSH in from your phone — your agents are still there, working for you.
 
-**You are the orchestrator. Your agents are the army.**
+---
 
-```
-Your Project
-├── main            → Copilot (Claude) — orchestrating the work, reviewing PRs
-├── feat/auth       → Worker (Claude) — building OAuth from scratch
-├── feat/dashboard  → Worker (Codex) — creating the admin dashboard
-├── fix/perf        → Worker (Gemini) — profiling and fixing bottlenecks
-└── feat/api-tests  → Worker (Claude) — writing integration tests
-```
+## Quick Start (60 Seconds)
 
-Every session persists in tmux. Close VS Code, SSH from your phone, come back tomorrow — your agents are still running.
+1. **Install:** Search for **"Hydra Code"** in the VS Code Marketplace.
+2. **Prerequisites:** Ensure `tmux` and `git` are installed on your system.
+3. **Launch Copilot:** Open the Hydra sidebar (robot icon) and click **"Create Copilot"**.
+4. **Spawn your first Worker:** 
+   - Click **"Create Worker"**.
+   - Name your branch (e.g., `feat/my-new-idea`).
+   - Choose an agent (e.g., `claude`).
+   - **Watch the magic happen.**
 
-## Hero Use Case: The Parity Port
+---
 
-Imagine you need to port 40 features from one codebase to another. Doing it sequentially takes weeks. With Hydra:
+## Capabilities
 
-1. **Copilot** (on `main`) analyzes the master issue, breaks it into 8 independent tasks
-2. **Copilot** spawns 8 Workers — one per feature group — each on its own branch
-3. All 8 Workers implement their features **simultaneously**
-4. **Copilot** monitors progress, reviews diffs, sends follow-up instructions
-5. You merge PRs as they complete — what took weeks now takes hours
+### 🏛️ The Command Center (Sidebar)
+Your sidebar is no longer just a file explorer. It's a high-fidelity dashboard for your AI army.
+- **Live Vitals:** See CPU usage, terminal activity, and pane counts for every agent.
+- **Git Intelligence:** Track how many commits every worker is ahead of main, and see exactly how many files they've touched.
+- **One-Click Attach:** Jump into any agent's terminal or embed it directly as an editor tab.
 
-```
-codebase/
-├── main               → Copilot: breaking down the master issue, reviewing PRs
-├── port/auth          → Worker: porting authentication (3 features)
-├── port/billing       → Worker: porting billing flow (5 features)
-├── port/notifications → Worker: porting notification system (4 features)
-├── port/search        → Worker: porting search & filters (6 features)
-├── port/settings      → Worker: porting user settings (3 features)
-├── port/analytics     → Worker: porting analytics dashboard (5 features)
-├── port/export        → Worker: porting data export (4 features)
-└── port/onboarding    → Worker: porting onboarding flow (3 features)
-```
+### 💂 The Army (Workers & Worktrees)
+Hydra automates the heavy lifting of git management.
+- **Isolated Worktrees:** Every worker gets a dedicated directory under `.hydra/worktrees/`. They won't mess with your primary workspace.
+- **Autonomous Mode:** Workers can be launched with auto-approved permissions, letting them work while you sleep.
 
-> See the full walkthrough in [examples/parity-port.md](examples/parity-port.md).
+### 🧠 The Brain (Copilots)
+A Copilot is your tech lead. It doesn't need a worktree; it lives in your current folder and uses the `hydra` CLI to manage your workers.
 
-## Core Concepts
+### 🖇️ Smart Tools
+- **CLI-First:** The `hydra` command lets you (and your agents) control everything from the terminal.
+- **Smart Paste:** Copy an image? `Cmd+V` in the terminal saves it and inserts the path. Perfect for showing UI bugs to your agents.
 
-### The Orchestrator: Copilot
+---
 
-A persistent AI agent session in your current workspace. The Copilot acts as your **tech lead** — it plans work, spawns Workers, monitors their progress, reviews their output, and coordinates merges.
+## Reference & Documentation
 
-- One per workspace — runs on your current branch
-- No worktree needed — it works in your existing directory
-- Survives VS Code restarts via tmux
-- Can spawn and manage Workers via the [Hydra CLI](#cli-tool-hydra)
-
-### The Army: Workers
-
-Disposable AI agents that each get their own git branch, worktree, and terminal session. Give a Worker a task and it works independently — no conflicts with your code or other Workers.
-
-- One per task — isolated git worktree per branch
-- Auto-creates branch + worktree + session + launches agent in one step
-- Workers live under `<repo>/.hydra/worktrees/` to keep your repo root clean
-- Run with auto-approved permissions for autonomous operation
-
-### The Mental Model
-
-```
-┌─────────────────────────────────────────────────┐
-│                   VS Code                        │
-│  ┌─────────────┐  ┌──────────────────────────┐  │
-│  │  Hydra       │  │  Editor / Terminal Tabs   │  │
-│  │  Sidebar     │  │                          │  │
-│  │             │  │  ┌────────────────────┐  │  │
-│  │  Copilots   │  │  │ Worker: feat/auth  │  │  │
-│  │   ● Claude  │  │  │ (Claude running)   │  │  │
-│  │             │  │  └────────────────────┘  │  │
-│  │  Workers    │  │  ┌────────────────────┐  │  │
-│  │   ● auth   │  │  │ Worker: feat/api   │  │  │
-│  │   ● api    │  │  │ (Codex running)    │  │  │
-│  │   ● perf   │  │  └────────────────────┘  │  │
-│  │   ○ docs   │  │                          │  │
-│  └─────────────┘  └──────────────────────────┘  │
-└─────────────────────────────────────────────────┘
-         │                      │
-         ▼                      ▼
-   Live status:           tmux sessions
-   pane count,            persist independently
-   CPU, git diff          of VS Code
-```
-
-## Supported Agents
-
-| Agent | Command | Description |
-|-------|---------|-------------|
-| Claude | `claude` | Anthropic's Claude Code CLI |
-| Codex | `codex --full-auto` | OpenAI's Codex CLI |
-| Gemini | `gemini` | Google's Gemini CLI |
-| Custom | configurable | Any CLI agent you want |
-
-Configure default agent and commands in settings:
-
-```json
-{
-  "hydra.defaultAgent": "claude",
-  "hydra.agentCommands": {
-    "claude": "claude",
-    "codex": "codex --full-auto",
-    "gemini": "gemini"
-  }
-}
-```
-
-## Getting Started
-
-1. Install the extension from [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code)
-2. Make sure `tmux` and `git` are available in PATH
-3. Open the **Hydra** panel in the Activity Bar
-
-**Launch a Copilot:** Click the Copilot button (robot icon) → pick an agent → it starts in your workspace.
-
-**Spawn a Worker:** Click the Worker button (server icon) → enter a branch name like `feat/auth` → pick an agent → it creates the branch, worktree, session, and launches the agent automatically.
-
-## Features
-
-### Agent Visibility: Sidebar Tree View
-
-The Hydra panel is your command center — see every agent's status at a glance:
-
-- **Copilot group** — your workspace AI session
-- **Worker group** — all active workers organized by branch
-- **Status indicators** — green circle (active), outline (stopped), warning (git missing)
-- **Session details** — pane count, last activity, CPU usage
-- **Git status** — commits ahead, modified/untracked/deleted file counts
-
-### Smart Attach
-
-- **Attach in Terminal** — open a session in VS Code's integrated terminal
-- **Attach in Editor** — embed a session as an editor tab
-- **Auto-attach** — automatically reconnect when opening a worktree folder
-- **Size-stable attach** — syncs PTY size before attaching to avoid 80x24 first-paint issues
-- **Prompt-stable attach** — strips VS Code shell-integration env vars to prevent rendering corruption inside tmux
-
-### Smart Paste (Image-Aware)
-
-`Cmd+V` (macOS) / `Ctrl+Shift+V` (Linux) in the terminal does the right thing:
-- Text in clipboard → normal paste
-- Image in clipboard → saves as temp `.png` and inserts the file path
-
-Works over Remote-SSH too — clipboard images are bridged from local to remote.
-
-### Session Management
-
-- Split panes and create windows from context menu
-- Copy worktree paths to clipboard
-- Open worktrees in new VS Code windows
-- Filter sessions by name
-- Create worktree from an existing branch
-
-### Orphan Cleanup
-
-Detect and remove tmux sessions that no longer have matching worktrees. One click to keep your environment tidy.
-
-### CLI Tool (`hydra`)
-
-Create workers directly from your terminal — or let your Copilot agent spawn them programmatically:
-
-```bash
-hydra worker create --repo ~/myapp --branch feat/auth --agent claude --task "implement OAuth2 login"
-```
-
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--repo` | yes | Path to the git repository |
-| `--branch` | yes | Branch name to create |
-| `--agent` | no | Agent type: `claude`, `codex`, `gemini` (default: `claude`) |
-| `--base` | no | Base branch override (default: auto-detect) |
-| `--task` | no | Initial prompt to give the agent |
-
-The CLI mirrors the full `Hydra: Create Worker` flow — branch validation, slug collision resolution, worktree creation under `.hydra/`, tmux session setup, and agent launch.
-
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| `Hydra: Create Copilot` | Launch an AI copilot in your current workspace |
-| `Hydra: Create Worker` | Create a new branch + worktree + agent session |
-| `Hydra: Attach/Create Session` | Attach to or create a session for the current worktree |
-| `Hydra: Remove Task` | Remove a worktree and its session |
-| `Hydra: Cleanup Orphans` | Remove orphaned sessions |
-| `Hydra: Smart Paste (Image Support)` | Smart paste: text or image |
-| `Hydra: Paste Image from Clipboard` | Force image paste into terminal |
-
-## Real-World Workflows
-
-### Parity Port — Parallelize a Large Migration
-
-Break a 40-feature migration into 8 parallel Workers. Your Copilot orchestrates the work while Workers implement independently. [Full example →](examples/parity-port.md)
-
-### Cross-Language Code Generation
-
-Generate TypeScript clients from Rust gRPC services. One Worker generates protobuf bindings, another builds the TS client, a third writes integration tests. [Full example →](examples/grpc-generation.md)
-
-### Reliable Subagent Lifecycle
-
-Spawn Workers from a Copilot, monitor their scrollback for completion signals, and `await` their results before proceeding. [Full example →](examples/agent-await.md)
-
-### Remote Server + Mobile Access
-
-SSH into a dev server, manage workers with Hydra, disconnect — sessions persist. Reconnect from home, a cafe, or your phone:
-
-```bash
-ssh dev-server
-tmux attach -t myapp-a1b2c3d4_feat-oauth
-```
-
-## Configuration
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `hydra.defaultAgent` | `claude` | Default agent for new copilot/worker sessions |
-| `hydra.agentCommands` | `{...}` | Map of agent type → shell command |
-| `hydra.baseBranch` | auto-detect | Override base branch for new workers |
-| `tmuxWorktree.multiplexer` | `tmux` | Backend: `tmux` |
-| `tmuxWorktree.baseBranch` | auto-detect | Override base branch (legacy) |
+- [**AGENTS.md**](AGENTS.md) — The full "Agent Operating Manual" (CLI reference, internal architecture, and advanced config).
+- [**Examples**](examples/) — Real-world scenarios like [Parity Ports](examples/parity-port.md) and [gRPC Generation](examples/grpc-generation.md).
+- [**Changelog**](CHANGELOG.md) — See what's new in the latest version.
 
 ## Requirements
-
-- **tmux** — installed and in PATH
-- **git** — installed and in PATH
-- **VS Code** 1.85.0+
-
-## How It Works
-
-```
-Repository
-├── main                → session: "project-a1b2c3d4_main"
-├── feat/auth           → session: "project-a1b2c3d4_feat-auth"    [Worker: Claude]
-└── fix/bug-123         → session: "project-a1b2c3d4_fix-bug-123"  [Worker: Codex]
-                        → session: "hydra-copilot"                  [Copilot: Claude]
-```
-
-**Workers** each get a dedicated git worktree + terminal session. Session names use a `repo-name + path-hash` namespace for collision safety across same-name repos. Worktrees are stored under `<repo>/.hydra/worktrees/` by default.
-
-**Copilot** gets a single global session (`hydra-copilot`) tied to your workspace directory — no worktree needed.
-
-Both Copilot and Worker sessions store their role and agent type as session metadata, so Hydra can display the right status in the tree view.
-
-## Security Note
-
-Worker agents run with **auto-approved permissions** (e.g., `--dangerously-skip-permissions` for Claude). This means workers can execute shell commands, read/write files, and make network requests without prompting. This is by design for autonomous operation, but you should:
-
-- Only run workers in trusted repositories
-- Review worker diffs before merging (`git diff` in the worktree)
-- Use isolated environments (containers, VMs) for untrusted workloads
+- **tmux** — The engine of persistence.
+- **git** — The foundation of isolation.
+- **VS Code 1.85.0+**
 
 ## License
-
-[MIT](LICENSE.md)
+[MIT](LICENSE.md) — Built with ❤️ for the future of AI-native development.

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -1,263 +1,121 @@
 # Hydra
 
-**指挥一支 AI 编程代理军团 — 每个代理在自己的分支、自己的终端中运行，全部通过 VS Code 可视化管控。**
+<p align="center">
+  <img src="../resources/logo.jpg" alt="Hydra" width="600" />
+</p>
+
+<p align="center">
+  <strong>多头齐进，代码狂飙。</strong><br>
+  直接在 VS Code 中编排 AI 代理军团，让并行开发成为现实。
+</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
+    <img src="https://img.shields.io/visual-studio-marketplace/v/zhoujinjing.hydra-code?label=Marketplace" alt="Marketplace" />
+  </a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
+    <img src="https://img.shields.io/visual-studio-marketplace/i/zhoujinjing.hydra-code" alt="Installs" />
+  </a>
+  <a href="../LICENSE.md">
+    <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />
+  </a>
+</p>
 
 🌏 **其他语言:** [English](../README.md) | **中文**
 
+---
+
+## 愿景
+
+在希腊神话中，Hydra（九头蛇）是一个每砍掉一个头就会长出两个头的神兽。在软件工程中，我们也面临着类似的“怪兽”：任务积压的速度永远快于代码产出的速度。
+
+**Hydra** 彻底反转了这个隐喻。我们不再与增长对抗，而是拥抱它。你将成为开发过程中的“中枢神经系统”，根据需要随时生成并编排多个 AI 代理“头”。一个头负责构建认证模块，一个头负责优化数据库，第三个头负责编写测试——所有工作同时进行，所有状态在侧边栏一目了然。
+
+**停止串行思考，开启并行时代。**
+
+---
+
+## 并行开发的故事
+
+想象一下，你需要从旧代码库平移 40 个功能。独自一人完成这件工作通常需要数周的苦战。而使用 Hydra，流程如下：
+
+1. **启动 Copilot**（指挥官）：在 `main` 分支上告诉它：“分析这 40 个功能，并将它们拆解为 8 个逻辑组。”
+2. **委派 Worker**（兵团）：只需一条指令，Copilot 就会生成 8 个 Worker。每个 Worker 拥有独立的 git 分支、隔离的工作区（worktree）以及专属的 AI 代理（Claude、Gemini 或 Codex）。
+3. **编排与监控**：你只需关注侧边栏。8 个终端正在跳动，8 个代理正在疯狂输出。你可以实时看到它们的 CPU 占用、Git Diff 以及任务进度。
+4. **审查与交付**：当 Worker 完成工作，你审查代码，合并分支，搞定收工。
+
+**原本需要数周的工作，现在只需数小时。**
+
+```text
+[ 你：首席架构师 ]
+         │
+         ▼
+ [ COPILOT (main) ] ──────────────────┐
+ (规划、监控、审查)                      │
+         │                            │
+         ├─> [ WORKER 1 (feat/auth) ] ─┼─> "正在构建 OAuth2 流程..."
+         ├─> [ WORKER 2 (feat/ui)   ] ─┼─> "正在调整看板样式..."
+         ├─> [ WORKER 3 (fix/perf)  ] ─┼─> "正在优化数据库查询..."
+         └─> [ WORKER 4 (docs/api)  ] ─┼─> "正在生成 API 文档..."
+                                      │
+                                 [ AI 军团 ]
+```
+
+---
+
 ## 为什么选择 Hydra？
 
-现代 AI 编程代理很强大 — 但一次只跑一个就是瓶颈。
-Hydra 把 VS Code 变成一个**指挥中心**，让你并行编排多个代理，每个代理隔离在自己的 git 分支上，全部在一个侧边栏中可见。
+- **串行瓶颈**：任务切换的成本极高。等待一个 AI 代理跑完再去启动下一个，是对你最宝贵资源——时间的极大浪费。
+- **环境隔离**：Hydra 为每个代理分配独立的 git worktree。不再有“代码串门”导致的幻觉，也不再有多个代理修改同一目录下的文件引发的 Git 冲突。
+- **灵魂永驻**：每个代理都运行在 `tmux` 会话中。即使你关掉 VS Code、重启电脑，甚至通过手机 SSH 连入，你的代理军团依然在为你彻夜工作。
 
-**你是指挥官。你的代理是军团。**
+---
 
-```
-项目
-├── main            → Copilot (Claude) — 编排工作、审查 PR
-├── feat/auth       → Worker (Claude) — 从零构建 OAuth
-├── feat/dashboard  → Worker (Codex) — 创建管理后台
-├── fix/perf        → Worker (Gemini) — 性能分析与瓶颈修复
-└── feat/api-tests  → Worker (Claude) — 编写集成测试
-```
+## 60 秒快速上手
 
-所有会话都在 tmux 中持久运行。关掉 VS Code、从手机 SSH 连入、明天再回来 — 代理依然在工作。
+1. **安装**：在 VS Code 应用商店搜索 **"Hydra Code"**。
+2. **环境**：确保系统中已安装 `tmux` 和 `git`。
+3. **启动 Copilot**：打开 Hydra 侧边栏（机器人图标），点击 **"Create Copilot"**。
+4. **创建第一个 Worker**：
+   - 点击 **"Create Worker"**。
+   - 输入分支名（如 `feat/my-new-idea`）。
+   - 选择代理（如 `claude`）。
+   - **见证奇迹的时刻。**
 
-## 标杆用例：功能平移
+---
 
-假设你需要将 40 个功能从一个代码库迁移到另一个。顺序执行需要几周。用 Hydra：
+## 核心能力
 
-1. **Copilot**（在 `main` 上）分析主任务，拆解为 8 个独立子任务
-2. **Copilot** 启动 8 个 Worker — 每个负责一组功能 — 各自在独立分支上
-3. 8 个 Worker **同时**实现各自的功能
-4. **Copilot** 监控进度、审查 diff、发送后续指令
-5. 你逐个合并 PR — 原本需要数周的工作，现在只需数小时
+### 🏛️ 指挥中心（侧边栏）
+侧边栏不再仅仅是文件树，它是你 AI 军团的高保真仪表盘。
+- **实时生命体征**：查看每个代理的 CPU 占用、终端活跃度和面板计数。
+- **Git 洞察**：追踪每个 Worker 领先主分支的提交数，以及精准的文件变更统计。
+- **一键触达**：快速进入任何代理的终端，或将会话直接嵌入为编辑器标签页。
 
-```
-codebase/
-├── main               → Copilot: 拆解主任务、审查 PR
-├── port/auth          → Worker: 迁移认证功能（3 个特性）
-├── port/billing       → Worker: 迁移账单流程（5 个特性）
-├── port/notifications → Worker: 迁移通知系统（4 个特性）
-├── port/search        → Worker: 迁移搜索与筛选（6 个特性）
-├── port/settings      → Worker: 迁移用户设置（3 个特性）
-├── port/analytics     → Worker: 迁移数据分析面板（5 个特性）
-├── port/export        → Worker: 迁移数据导出（4 个特性）
-└── port/onboarding    → Worker: 迁移新手引导（3 个特性）
-```
+### 💂 AI 军团（Worker 与 Worktree）
+Hydra 自动处理繁琐的 Git 管理工作。
+- **隔离工作区**：每个 Worker 在 `.hydra/worktrees/` 下都有专属目录，绝不干扰你的主工作区。
+- **自主模式**：支持以自动批准权限启动 Worker，实现“你睡觉，它干活”。
 
-> 完整演练请参阅 [examples/parity-port.md](../examples/parity-port.md)。
+### 🧠 核心大脑（Copilot）
+Copilot 是你的技术负责人。它无需独立工作区，直接运行在当前文件夹，通过 `hydra` CLI 指挥所有 Worker。
 
-## 核心概念
+### 🖇️ 智能工具
+- **CLI 优先**：通过 `hydra` 命令，你（和你的代理）可以从终端控制一切。
+- **智能粘贴**：复制了图片？在终端按 `Cmd+V`，Hydra 会自动保存并插入路径。完美解决向代理反馈 UI bug 的痛点。
 
-### 指挥官：Copilot
+---
 
-在当前工作区中运行的常驻 AI 代理会话。Copilot 充当你的**技术负责人** — 规划工作、启动 Worker、监控进度、审查产出、协调合并。
+## 参考与文档
 
-- 每个工作区一个 — 在当前分支上运行
-- 无需 worktree — 在现有目录中工作
-- 通过 tmux 在 VS Code 重启后依然存活
-- 可通过 [Hydra CLI](#cli-工具hydra) 启动和管理 Worker
-
-### 军团：Workers
-
-拥有独立 git 分支、worktree 和终端会话的一次性 AI 代理。给 Worker 一个任务，它就独立工作 — 不会与你的代码或其他 Worker 产生冲突。
-
-- 每个任务一个 — 每个分支一个隔离的 git worktree
-- 一步完成：创建分支 + worktree + 会话 + 启动代理
-- Worker 创建在 `<repo>/.hydra/worktrees/` 下，保持仓库根目录整洁
-- 以自动批准权限运行，实现自主操作
-
-### 心智模型
-
-```
-┌─────────────────────────────────────────────────┐
-│                   VS Code                        │
-│  ┌─────────────┐  ┌──────────────────────────┐  │
-│  │  Hydra       │  │  编辑器 / 终端标签页      │  │
-│  │  侧边栏     │  │                          │  │
-│  │             │  │  ┌────────────────────┐  │  │
-│  │  Copilots   │  │  │ Worker: feat/auth  │  │  │
-│  │   ● Claude  │  │  │ (Claude 运行中)    │  │  │
-│  │             │  │  └────────────────────┘  │  │
-│  │  Workers    │  │  ┌────────────────────┐  │  │
-│  │   ● auth   │  │  │ Worker: feat/api   │  │  │
-│  │   ● api    │  │  │ (Codex 运行中)     │  │  │
-│  │   ● perf   │  │  └────────────────────┘  │  │
-│  │   ○ docs   │  │                          │  │
-│  └─────────────┘  └──────────────────────────┘  │
-└─────────────────────────────────────────────────┘
-         │                      │
-         ▼                      ▼
-   实时状态：              tmux 会话
-   面板数、CPU、           独立于 VS Code
-   git diff               持久运行
-```
-
-## 支持的代理
-
-| 代理 | 命令 | 说明 |
-|------|------|------|
-| Claude | `claude` | Anthropic 的 Claude Code CLI |
-| Codex | `codex --full-auto` | OpenAI 的 Codex CLI |
-| Gemini | `gemini` | Google 的 Gemini CLI |
-| Custom | 可配置 | 任意 CLI 代理 |
-
-在设置中配置默认代理和命令：
-
-```json
-{
-  "hydra.defaultAgent": "claude",
-  "hydra.agentCommands": {
-    "claude": "claude",
-    "codex": "codex --full-auto",
-    "gemini": "gemini"
-  }
-}
-```
-
-## 快速开始
-
-1. 从 [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code) 安装扩展
-2. 确保 `tmux` 和 `git` 在 PATH 中
-3. 打开活动栏中的 **Hydra** 面板
-
-**启动 Copilot：** 点击 Copilot 按钮（机器人图标）→ 选择代理 → 在工作区中启动。
-
-**创建 Worker：** 点击 Worker 按钮（服务器图标）→ 输入分支名如 `feat/auth` → 选择代理 → 自动创建分支、worktree、会话并启动代理。
-
-## 功能
-
-### 代理可视化：侧边栏树形视图
-
-Hydra 面板是你的指挥中心 — 一目了然地查看每个代理的状态：
-
-- **Copilot 分组** — 工作区 AI 会话
-- **Worker 分组** — 按分支组织的所有 Worker
-- **状态指示** — 绿色圆点（活跃）、空心圆（已停止）、警告（缺少 git）
-- **会话详情** — 面板数、最近活动时间、CPU 使用率
-- **Git 状态** — 未推送的提交数、修改/未跟踪/已删除的文件数
-
-### 智能连接
-
-- **在终端中连接** — 在 VS Code 集成终端中打开会话
-- **在编辑器中连接** — 将会话嵌入为编辑器标签页
-- **自动连接** — 打开 worktree 文件夹时自动重连
-- **尺寸稳定连接** — 连接前同步 PTY 尺寸，避免 80x24 初始渲染问题
-- **提示符稳定连接** — 剥离 VS Code shell integration 环境变量，防止 tmux 内部渲染异常
-
-### 智能粘贴（图片感知）
-
-在终端中按 `Cmd+V`（macOS）/ `Ctrl+Shift+V`（Linux）会自动判断：
-- 剪贴板中是文本 → 正常粘贴
-- 剪贴板中是图片 → 保存为临时 `.png` 文件并插入路径
-
-在 Remote-SSH 下同样有效 — 本地剪贴板中的图片会桥接到远程。
-
-### 会话管理
-
-- 从右键菜单分割面板和创建新窗口
-- 复制 worktree 路径到剪贴板
-- 在新的 VS Code 窗口中打开 worktree
-- 按名称筛选会话
-- 从现有分支创建 worktree
-
-### 孤儿会话清理
-
-检测并移除没有对应 worktree 的会话。一键保持环境整洁。
-
-### CLI 工具（`hydra`）
-
-无需 VS Code，直接在终端中创建 Worker — 也可以让 Copilot 代理程序化地调用：
-
-```bash
-hydra worker create --repo ~/myapp --branch feat/auth --agent claude --task "实现 OAuth2 登录"
-```
-
-| 参数 | 必填 | 说明 |
-|------|------|------|
-| `--repo` | 是 | git 仓库路径 |
-| `--branch` | 是 | 要创建的分支名 |
-| `--agent` | 否 | 代理类型：`claude`、`codex`、`gemini`（默认：`claude`） |
-| `--base` | 否 | 基准分支覆盖（默认：自动检测） |
-| `--task` | 否 | 给代理的初始提示 |
-
-该脚本完整复现了 `Hydra: Create Worker` 的流程 — 分支校验、slug 冲突解决、在 `.hydra/` 下创建 worktree、tmux 会话配置、代理启动。
-
-## 命令
-
-| 命令 | 说明 |
-|------|------|
-| `Hydra: Create Copilot` | 在当前工作区启动 AI Copilot |
-| `Hydra: Create Worker` | 创建新分支 + worktree + 代理会话 |
-| `Hydra: Attach/Create Session` | 连接或创建当前 worktree 的会话 |
-| `Hydra: Remove Task` | 删除 worktree 及其会话 |
-| `Hydra: Cleanup Orphans` | 清理孤儿会话 |
-| `Hydra: Smart Paste (Image Support)` | 智能粘贴：文本或图片 |
-| `Hydra: Paste Image from Clipboard` | 强制图片粘贴 |
-
-## 实际应用场景
-
-### 功能平移 — 并行化大规模迁移
-
-将 40 个功能的迁移拆解为 8 个并行 Worker。Copilot 编排工作，Worker 独立实现。[完整示例 →](../examples/parity-port.md)
-
-### 跨语言代码生成
-
-从 Rust gRPC 服务生成 TypeScript 客户端。一个 Worker 生成 protobuf 绑定，另一个构建 TS 客户端，第三个编写集成测试。[完整示例 →](../examples/grpc-generation.md)
-
-### 可靠的子代理生命周期
-
-从 Copilot 启动 Worker，监控其滚动缓冲区的完成信号，`await` 结果后再继续。[完整示例 →](../examples/agent-await.md)
-
-### 远程服务器 + 移动端访问
-
-SSH 连接开发服务器，用 Hydra 管理 Worker，断开连接后会话依然保留。从家里、咖啡馆、手机重新连接：
-
-```bash
-ssh dev-server
-tmux attach -t myapp-a1b2c3d4_feat-oauth
-```
-
-## 配置
-
-| 设置项 | 默认值 | 说明 |
-|--------|--------|------|
-| `hydra.defaultAgent` | `claude` | 新建 Copilot/Worker 的默认代理 |
-| `hydra.agentCommands` | `{...}` | 代理类型 → 启动命令映射 |
-| `hydra.baseBranch` | 自动检测 | Worker 创建时的基准分支 |
-| `tmuxWorktree.multiplexer` | `tmux` | 后端：`tmux` |
-| `tmuxWorktree.baseBranch` | 自动检测 | 基准分支（旧版） |
+- [**AGENTS.md**](../AGENTS.md) — 完整的“代理操作手册”（CLI 参考、内部架构与高级配置）。
+- [**应用场景**](../examples/) — 真实用例，如[功能平移](../examples/parity-port.md)和 [gRPC 生成](../examples/grpc-generation.md)。
+- [**更新日志**](../CHANGELOG.md) — 查看最新版本的变化。
 
 ## 系统要求
-
-- **tmux** — 已安装且在 PATH 中
-- **git** — 已安装且在 PATH 中
-- **VS Code** 1.85.0+
-
-## 工作原理
-
-```
-仓库
-├── main                → 会话: "project-a1b2c3d4_main"
-├── feat/auth           → 会话: "project-a1b2c3d4_feat-auth"    [Worker: Claude]
-└── fix/bug-123         → 会话: "project-a1b2c3d4_fix-bug-123"  [Worker: Codex]
-                        → 会话: "hydra-copilot"                  [Copilot: Claude]
-```
-
-**Worker** 各自拥有专属的 git worktree + 终端会话。会话名称使用 `repo-name + path-hash` 命名空间，防止同名仓库之间的冲突。Worktree 默认创建在 `<repo>/.hydra/worktrees/` 下。
-
-**Copilot** 是绑定到工作区目录的单个全局会话（`hydra-copilot`）— 不需要 worktree。
-
-Copilot 和 Worker 都将角色和代理类型存储为会话元数据，以便 Hydra 在树形视图中显示正确的状态。
-
-## 安全提示
-
-Worker 代理以**自动批准权限**运行（例如 Claude 的 `--dangerously-skip-permissions`）。这意味着 Worker 可以执行 shell 命令、读写文件和发起网络请求，无需确认。这是为自主操作而设计的，但你应该：
-
-- 仅在受信任的仓库中运行 Worker
-- 合并前审查 Worker 的 diff（在 worktree 中运行 `git diff`）
-- 对不受信任的工作负载使用隔离环境（容器、虚拟机）
+- **tmux** — 持久运行的引擎。
+- **git** — 环境隔离的基础。
+- **VS Code 1.85.0+**
 
 ## 许可证
-
-[MIT](../LICENSE.md)
+[MIT](../LICENSE.md) — 为 AI 原生开发的未来倾情打造。


### PR DESCRIPTION
This PR rewrites the documentation to focus on the Hydra metaphor and the power of parallel orchestration.

### Changes
- Rebranded README.md with the 'Grow heads. Ship faster.' vision.
- Added a visual scenario showing parallel worker workflows.
- Restructured features into capability-focused sections (Command Center, The Army, etc.).
- Updated docs/README.zh.md for bi-lingual consistency.
- Moved dry technical content to AGENTS.md reference.