### PR TITLE
feat: clean up right-click context menu in sidebar panels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ code --extensionDevelopmentPath="<absolute-path-to-worktree-or-repo>" /tmp/hydra
 - **Slug Collision**: basename → parent dir disambiguation → short path hash. Reserve `main` for the primary worktree.
 - **Canonical Path Matching**: Normalize to absolute paths with `~` expansion for equality checks. Do not collapse symlinks via `realpath`.
 - **Unpublished Task Branches**: Don't set `branch.<name>.remote`/`.merge` before first push — VS Code SCM would try to sync against a non-existent remote. Set only `branch.<name>.vscode-merge-base`.
-- **Tree Context Menu**: Use a single `contextValue` (`tmuxItem`) for levels 2/3/4.
+- **Tree Context Menu**: Use per-type `contextValue` — `copilotItem`, `workerItem`, `inactiveWorkerItem`, `detailItem`, `gitStatusItem` — to scope right-click actions to relevant item types.
 - **No-Git Workspace**: Show one primary item labeled `current project (no git)` mapped to workspace path.
 - **Polymorphism**: Commands must handle `TmuxItem` base class and variants (`TmuxSessionItem`, `InactiveWorktreeItem`, etc.). Use `getWorktreePath(item)` helper.
 - **Legacy Compatibility**: Centralized in `src/utils/sessionCompatibility.ts`.

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       },
       {
         "command": "tmux.removeTask",
-        "title": "Hydra: Remove Task"
+        "title": "Hydra: Remove"
       },
       {
         "command": "tmux.refresh",
@@ -120,7 +120,7 @@
       },
       {
         "command": "tmux.attach",
-        "title": "Attach in Terminal"
+        "title": "Open in Terminal"
       },
       {
         "command": "tmux.attachInEditor",
@@ -128,11 +128,11 @@
       },
       {
         "command": "tmux.openWorktree",
-        "title": "Open Worktree in New Window"
+        "title": "Open in New Window"
       },
       {
         "command": "tmux.copyPath",
-        "title": "Copy Worktree Path"
+        "title": "Copy Path"
       },
       {
         "command": "tmux.newPane",
@@ -250,43 +250,23 @@
       "view/item/context": [
         {
           "command": "tmux.attach",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "1_attach"
-        },
-        {
-          "command": "tmux.attachInEditor",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "1_attach"
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'copilotItem')",
+          "group": "1_open"
         },
         {
           "command": "tmux.openWorktree",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "2_open"
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
+          "group": "1_open"
         },
         {
           "command": "tmux.copyPath",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "2_open"
-        },
-        {
-          "command": "tmux.newPane",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "3_tmux"
-        },
-        {
-          "command": "tmux.newWindow",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "3_tmux"
-        },
-        {
-          "command": "tmux.createWorktreeFromBranch",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "4_create"
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
+          "group": "2_copy"
         },
         {
           "command": "tmux.removeTask",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && viewItem == tmuxItem",
-          "group": "5_danger"
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'copilotItem')",
+          "group": "9_danger"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,10 @@
         "title": "Create Worktree from This Branch"
       },
       {
+        "command": "hydra.openPR",
+        "title": "Hydra: Open PR"
+      },
+      {
         "command": "hydra.createCopilot",
         "title": "Hydra: Create Copilot",
         "icon": "$(hubot)"
@@ -251,11 +255,6 @@
         {
           "command": "tmux.attach",
           "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'copilotItem')",
-          "group": "1_open"
-        },
-        {
-          "command": "tmux.openWorktree",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
           "group": "1_open"
         },
         {

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -11,6 +11,7 @@ import {
 } from '../providers/tmuxSessionProvider';
 import { getActiveBackend, HydraRole } from '../utils/multiplexer';
 import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
+import { exec } from '../utils/exec';
 
 function getWorktreePath(item: TmuxItem): string | undefined {
   if (item instanceof CopilotItem) return item.worktreePath;
@@ -148,5 +149,22 @@ export async function newWindow(item: TmuxItem): Promise<void> {
     vscode.window.showInformationMessage(`New window created in ${item.sessionName}`);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to create window: ${err}`);
+  }
+}
+
+export async function openPR(item: TmuxItem): Promise<void> {
+  if (!(item instanceof GitStatusItem) || !item.prNumber || !item.worktreePath) {
+    return;
+  }
+  try {
+    const url = (await exec(
+      `gh pr view ${item.prNumber} --json url -q .url`,
+      { cwd: item.worktreePath }
+    )).trim();
+    if (url) {
+      await vscode.env.openExternal(vscode.Uri.parse(url));
+    }
+  } catch (err) {
+    vscode.window.showErrorMessage(`Failed to open PR: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,8 @@ import {
   openWorktree,
   copyPath,
   newPane,
-  newWindow
+  newWindow,
+  openPR
 } from './commands/contextMenu';
 import { terminalSmartPaste, pasteImageForce, cleanupTempImages } from './commands/pasteImage';
 import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
@@ -44,6 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
+    vscode.commands.registerCommand('hydra.openPR', openPR),
     vscode.commands.registerCommand('hydra.createCopilot', createCopilot),
     vscode.commands.registerCommand('hydra.createWorker', createWorker),
     vscode.commands.registerCommand('hydra.startCopilotClaude', () => createCopilotWithAgent('claude')),

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -300,7 +300,7 @@ export class CopilotItem extends TmuxItem {
     this.agentType = opts.agentType;
     this.classification = opts.classification;
     this.description = description;
-    this.contextValue = 'tmuxItem';
+    this.contextValue = 'copilotItem';
 
     // Blue circle: filled=attached, outline=idle
     if (opts.classification === 'attached') {
@@ -368,7 +368,7 @@ export class WorktreeItem extends TmuxItem {
     this.isMainWorktree = Boolean(opts.isMainWorktree);
     this.description = description;
 
-    this.contextValue = 'tmuxItem';
+    this.contextValue = 'workerItem';
 
     if (!opts.hasGit) {
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
@@ -432,7 +432,7 @@ export class TmuxDetailItem extends TmuxItem {
     const label = parts.join(' · ');
     super(label, vscode.TreeItemCollapsibleState.None, repoName, session.name);
 
-    this.contextValue = 'tmuxItem';
+    this.contextValue = 'detailItem';
 
     if (extensionUri) {
       const iconPath = vscode.Uri.joinPath(
@@ -462,7 +462,7 @@ export class InactiveDetailItem extends TmuxItem {
   ) {
     super('0p · stopped', vscode.TreeItemCollapsibleState.None, repoName, targetSessionName);
 
-    this.contextValue = 'tmuxItem';
+    this.contextValue = 'detailItem';
 
     if (extensionUri) {
       const iconPath = vscode.Uri.joinPath(extensionUri, 'resources', 'tmux-inactive.svg');
@@ -501,7 +501,7 @@ export class GitStatusItem extends TmuxItem {
     const label = parts.join(' · ');
     super(label, vscode.TreeItemCollapsibleState.None, repoName, sessionName);
 
-    this.contextValue = 'tmuxItem';
+    this.contextValue = 'gitStatusItem';
 
     let iconColor: vscode.ThemeColor;
     if (status.prState === 'merged') {
@@ -598,6 +598,7 @@ export class InactiveWorktreeItem extends WorktreeItem {
       isMainWorktree: worktree.isMain
     });
 
+    this.contextValue = 'inactiveWorkerItem';
     this.worktree = worktree;
     this.targetSessionName = targetSessionName;
     this.detailItem = new InactiveDetailItem(worktree, repoName, targetSessionName, extensionUri);

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -301,6 +301,11 @@ export class CopilotItem extends TmuxItem {
     this.classification = opts.classification;
     this.description = description;
     this.contextValue = 'copilotItem';
+    this.command = {
+      command: 'tmux.attachCreate',
+      title: 'Open Session',
+      arguments: [this]
+    };
 
     // Blue circle: filled=attached, outline=idle
     if (opts.classification === 'attached') {
@@ -369,6 +374,11 @@ export class WorktreeItem extends TmuxItem {
     this.description = description;
 
     this.contextValue = 'workerItem';
+    this.command = {
+      command: 'tmux.attachCreate',
+      title: 'Open Session',
+      arguments: [this]
+    };
 
     if (!opts.hasGit) {
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
@@ -445,11 +455,6 @@ export class TmuxDetailItem extends TmuxItem {
       this.iconPath = new vscode.ThemeIcon('terminal-tmux');
     }
 
-    this.command = {
-      command: 'tmux.attachCreate',
-      title: 'Attach Session',
-      arguments: [this]
-    };
   }
 }
 
@@ -471,16 +476,12 @@ export class InactiveDetailItem extends TmuxItem {
       this.iconPath = new vscode.ThemeIcon('terminal-tmux');
     }
 
-    this.command = {
-      command: 'tmux.attachCreate',
-      title: 'Launch Session',
-      arguments: [this]
-    };
   }
 }
 
 export class GitStatusItem extends TmuxItem {
   public readonly worktreePath?: string;
+  public readonly prNumber?: number;
 
   constructor(
     status: SessionStatus,
@@ -513,6 +514,15 @@ export class GitStatusItem extends TmuxItem {
     }
     this.iconPath = new vscode.ThemeIcon('git-commit', iconColor);
     this.worktreePath = worktreePath;
+    this.prNumber = status.prNumber;
+
+    if (status.prNumber && worktreePath) {
+      this.command = {
+        command: 'hydra.openPR',
+        title: 'Open PR',
+        arguments: [this]
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Differentiate `contextValue` per item type** — `copilotItem`, `workerItem`, `inactiveWorkerItem`, `detailItem`, `gitStatusItem` — so each tree node only shows relevant context menu actions
- **Click agent row to open session** in editor area (previously required expanding + clicking detail row)
- **Click git status row with PR** to open the PR on GitHub
- **Remove clutter** — drop Attach in Editor (redundant with click), New Pane, New Window, Open in New Window, Create Worktree from This Branch from context menu
- **Rename actions** to plain language: Open in Terminal, Copy Path, Remove
- **Detail/git rows** show no context menu (purely informational)

### Final context menu

| Right-click on | Actions |
|---|---|
| Worker | Open in Terminal, Copy Path, Remove |
| Copilot | Open in Terminal, Remove |
| Detail / Git status | (none) |

### Click behavior

| Click on | Action |
|---|---|
| Agent row (level 2) | Opens session in editor area |
| Git status with PR | Opens PR on GitHub |
| Tmux detail row | (none — informational) |

## Test plan

- [x] Right-click worker → only shows Open in Terminal, Copy Path, Remove
- [x] Right-click copilot → only shows Open in Terminal, Remove
- [x] Right-click detail/git rows → no context menu
- [x] Click agent row → opens session in editor area
- [x] Click git status with PR → opens PR in browser
- [x] `npm run compile && npm run lint` passes

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)