### PR TITLE
fix: replace retired shields.io VS Marketplace badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
-    <img src="https://img.shields.io/visual-studio-marketplace/v/zhoujinjing.hydra-code?label=Marketplace" alt="Marketplace" />
+    <img src="https://vsmarketplacebadges.dev/version/zhoujinjing.hydra-code.svg" alt="Marketplace" />
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/zhoujinjing.hydra-code" alt="Installs" />
+    <img src="https://vsmarketplacebadges.dev/installs/zhoujinjing.hydra-code.svg" alt="Installs" />
   </a>
   <a href="LICENSE.md">
     <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -11,10 +11,10 @@
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
-    <img src="https://img.shields.io/visual-studio-marketplace/v/zhoujinjing.hydra-code?label=Marketplace" alt="Marketplace" />
+    <img src="https://vsmarketplacebadges.dev/version/zhoujinjing.hydra-code.svg" alt="Marketplace" />
   </a>
   <a href="https://marketplace.visualstudio.com/items?itemName=zhoujinjing.hydra-code">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/zhoujinjing.hydra-code" alt="Installs" />
+    <img src="https://vsmarketplacebadges.dev/installs/zhoujinjing.hydra-code.svg" alt="Installs" />
   </a>
   <a href="../LICENSE.md">
     <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />


### PR DESCRIPTION
## Summary
- Replace retired shields.io Visual Studio Marketplace badges (version + installs) with vsmarketplacebadges.dev equivalents in both `README.md` and `docs/README.zh.md`
- License badge (shields.io/github/license) is unaffected

## Test plan
- [ ] Verify badge images render correctly on the GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)