### PR TITLE
fix: exclude .claude/ and skills/ from VSIX to fix secret scanner

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,3 +18,5 @@ CLAUDE.md
 README.ai-ready.md
 eslint.config.js
 .hydra-task*
+.claude/**
+skills/**


### PR DESCRIPTION
The vsce secret scanner fails on content in skill files. These directories are not needed in the extension package.