### PR TITLE
feat: open shell via tmux split-window instead of VS Code terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       },
       {
         "command": "tmux.attach",
-        "title": "Open in Terminal"
+        "title": "Open Shell"
       },
       {
         "command": "tmux.attachInEditor",

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -59,11 +59,11 @@ export async function attach(item: TmuxItem): Promise<void> {
     const worktreePath = getWorktreePath(item);
     await ensureSessionExists(item.sessionName, worktreePath);
 
-    const workdir = worktreePath || await backend.getSessionWorkdir(item.sessionName);
-    const role = getRoleFromItem(item);
-    backend.attachSession(item.sessionName, workdir, vscode.TerminalLocation.Panel, role);
+    const cwd = worktreePath || await backend.getSessionWorkdir(item.sessionName);
+    await backend.splitPane(item.sessionName, cwd);
+    vscode.window.showInformationMessage(`Opened terminal pane in ${item.sessionName}`);
   } catch (err) {
-    vscode.window.showErrorMessage(`Failed to attach: ${err instanceof Error ? err.message : String(err)}`);
+    vscode.window.showErrorMessage(`Failed to open terminal: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -214,7 +214,7 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async splitPane(sessionName: string, cwd?: string): Promise<void> {
     const cwdArg = cwd ? `-c ${shellQuote(cwd)}` : '';
-    await exec(`tmux split-window -t ${shellQuote(sessionName)} ${cwdArg}`);
+    await exec(`tmux split-window -v -t ${shellQuote(sessionName)} ${cwdArg}`);
   }
 
   async newWindow(sessionName: string, cwd?: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Renamed "Open in Terminal" context menu action to **"Open Shell"** for clarity
- Changed the action to split the worker's existing tmux session (`tmux split-window -v`) instead of opening a VS Code integrated terminal
- The new pane lands in the worker's worktree directory, giving the user a shell alongside the AI agent

## Test plan

- [x] Right-click a worker/copilot → "Open Shell" appears in context menu
- [x] Clicking it creates a new tmux pane below in the worker's session
- [x] The pane's working directory is the worker's worktree path
- [x] `npm run compile` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)