### PR TITLE
feat: move worktree location outside the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ To test the extension in a VS Code Extension Development Host, use the `/test-hy
 
 ## Key Patterns
 
-- **Worktree Location**: Extension-managed worktrees go under `<repo>/.hydra/worktrees/` (auto-added to `.gitignore`). Legacy worktrees under `~/.tmux-worktrees/<hash>/` are still recognized.
+- **Worktree Location**: Extension-managed worktrees go under `~/.hydra/worktrees/<repo-identifier>/` (outside the repo to avoid tool/config leakage from parent). Legacy worktrees under `<repo>/.hydra/worktrees/` and `~/.tmux-worktrees/<hash>/` are still recognized.
 - **Session Namespace**: `{repoName}-{pathHash}_{branchSlug}` for collision safety across same-name repos in different directories.
 - **Root Detection**: Compare worktree path to primary via `git rev-parse --git-common-dir` — never infer from branch name or folder basename.
 - **Slug Collision**: basename → parent dir disambiguation → short path hash. Reserve `main` for the primary worktree.
@@ -122,7 +122,7 @@ hydra list --json
     { "session": "hydra-copilot-claude", "agent": "claude", "status": "running", "attached": false, "workdir": "/path" }
   ],
   "workers": [
-    { "session": "hydra-ab12_feat-auth", "repo": "myapp", "branch": "feat/auth", "agent": "claude", "status": "running", "attached": false, "workdir": "/path/.hydra/worktrees/feat-auth" }
+    { "session": "hydra-ab12_feat-auth", "repo": "myapp", "branch": "feat/auth", "agent": "claude", "status": "running", "attached": false, "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth" }
   ],
   "count": 2
 }
@@ -146,7 +146,7 @@ hydra worker create --repo <path> --branch <name> [--agent claude|codex|gemini] 
 | `--task-file` | no | | Path to markdown file with task details |
 
 ```json
-{ "status": "created", "session": "hydra-ab12_feat-auth", "branch": "feat/auth", "agent": "claude", "workdir": "/repo/.hydra/worktrees/feat-auth" }
+{ "status": "created", "session": "hydra-ab12_feat-auth", "branch": "feat/auth", "agent": "claude", "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth" }
 ```
 
 If the branch already exists, returns `"status": "exists"` and resumes.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Your sidebar is no longer just a file explorer. It's a high-fidelity dashboard f
 
 ### 💂 The Army (Workers & Worktrees)
 Hydra automates the heavy lifting of git management.
-- **Isolated Worktrees:** Every worker gets a dedicated directory under `.hydra/worktrees/`. They won't mess with your primary workspace.
+- **Isolated Worktrees:** Every worker gets a dedicated directory under `~/.hydra/worktrees/` (outside the repo). They won't mess with your primary workspace.
 - **Autonomous Mode:** Workers can be launched with auto-approved permissions, letting them work while you sleep.
 
 ### 🧠 The Brain (Copilots)

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -104,31 +104,60 @@ export async function localBranchExists(repoRoot: string, branchName: string): P
 }
 
 export function getManagedWorktreesRoot(): string {
-  return path.join(os.homedir(), '.tmux-worktrees');
+  return path.join(os.homedir(), '.hydra', 'worktrees');
+}
+
+/**
+ * Derive a filesystem-safe repo identifier: <basename>-<sha1(canonicalPath)[0:8]>
+ */
+export function getRepoIdentifier(repoRoot: string): string {
+  const canonicalRoot = toCanonicalPath(repoRoot) || path.resolve(repoRoot);
+  const basename = path.basename(canonicalRoot) || 'repo';
+  // Sanitize basename for filesystem safety (keep alphanumeric, hyphens, underscores)
+  const safeName = basename.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-');
+  const rootHash = createHash('sha1').update(canonicalRoot).digest('hex').slice(0, 8);
+  return `${safeName}-${rootHash}`;
 }
 
 export function getManagedRepoWorktreesDir(repoRoot: string): string {
+  return path.join(getManagedWorktreesRoot(), getRepoIdentifier(repoRoot));
+}
+
+/** Legacy location inside the repo: <repo>/.hydra/worktrees/ */
+export function getInRepoWorktreesDir(repoRoot: string): string {
   return path.join(repoRoot, '.hydra', 'worktrees');
 }
 
+/** Legacy location under ~/.tmux-worktrees/<namespace>/ */
+export function getLegacyTmuxWorktreesDir(repoRoot: string, backend: MultiplexerBackendCore): string {
+  return path.join(os.homedir(), '.tmux-worktrees', getRepoSessionNamespace(repoRoot, backend));
+}
+
+/** @deprecated Use getLegacyTmuxWorktreesDir instead */
 export function getLegacyManagedRepoWorktreesDir(repoRoot: string, backend: MultiplexerBackendCore): string {
-  return path.join(getManagedWorktreesRoot(), getRepoSessionNamespace(repoRoot, backend));
+  return getLegacyTmuxWorktreesDir(repoRoot, backend);
 }
 
 export function isManagedWorktreePath(repoRoot: string, worktreePath: string, backend?: MultiplexerBackendCore): boolean {
   const candidatePath = toCanonicalPath(worktreePath);
   if (!candidatePath) return false;
 
-  // Check new location: <repo>/.hydra/worktrees/
-  const hydraDir = toCanonicalPath(getManagedRepoWorktreesDir(repoRoot));
-  if (hydraDir && (candidatePath === hydraDir || candidatePath.startsWith(`${hydraDir}${path.sep}`))) {
+  const isUnder = (dir: string | undefined) =>
+    dir && (candidatePath === dir || candidatePath.startsWith(`${dir}${path.sep}`));
+
+  // Check current location: ~/.hydra/worktrees/<repo-identifier>/
+  if (isUnder(toCanonicalPath(getManagedRepoWorktreesDir(repoRoot)))) {
     return true;
   }
 
-  // Check legacy location: ~/.tmux-worktrees/<namespace>/
+  // Check legacy in-repo location: <repo>/.hydra/worktrees/
+  if (isUnder(toCanonicalPath(getInRepoWorktreesDir(repoRoot)))) {
+    return true;
+  }
+
+  // Check legacy ~/.tmux-worktrees/<namespace>/
   if (backend) {
-    const legacyDir = toCanonicalPath(getLegacyManagedRepoWorktreesDir(repoRoot, backend));
-    if (legacyDir && (candidatePath === legacyDir || candidatePath.startsWith(`${legacyDir}${path.sep}`))) {
+    if (isUnder(toCanonicalPath(getLegacyTmuxWorktreesDir(repoRoot, backend)))) {
       return true;
     }
   }
@@ -142,21 +171,42 @@ export async function ensureWorktreesDir(repoRoot: string): Promise<string> {
     await fs.promises.mkdir(worktreesDir, { recursive: true });
   }
 
-  // Add .hydra to .gitignore if not already there
-  const gitignorePath = path.join(repoRoot, '.gitignore');
+  // Write .repo-root marker so we can discover the repo root from a worktree path
+  const markerPath = path.join(worktreesDir, '.repo-root');
+  const canonicalRoot = toCanonicalPath(repoRoot) || path.resolve(repoRoot);
   try {
-    const content = fs.existsSync(gitignorePath)
-      ? fs.readFileSync(gitignorePath, 'utf-8')
-      : '';
-    if (!content.split('\n').some(line => line.trim() === '.hydra' || line.trim() === '.hydra/')) {
-      const newline = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
-      fs.writeFileSync(gitignorePath, `${content}${newline}.hydra\n`, 'utf-8');
-    }
+    fs.writeFileSync(markerPath, canonicalRoot, 'utf-8');
   } catch {
-    // ignore gitignore errors
+    // ignore marker write errors
   }
 
   return worktreesDir;
+}
+
+/**
+ * Resolve repo root from a worktree path by reading the .repo-root marker.
+ * Works for worktrees at ~/.hydra/worktrees/<repo-id>/<slug>.
+ * Returns undefined if not resolvable.
+ */
+export function resolveRepoRootFromWorktreePath(worktreePath: string): string | undefined {
+  // New location: ~/.hydra/worktrees/<repo-id>/<slug> → parent has .repo-root
+  const parent = path.dirname(worktreePath);
+  const markerPath = path.join(parent, '.repo-root');
+  try {
+    if (fs.existsSync(markerPath)) {
+      return fs.readFileSync(markerPath, 'utf-8').trim();
+    }
+  } catch {
+    // fall through
+  }
+
+  // Legacy in-repo location: <repo>/.hydra/worktrees/<slug>
+  const hydraIdx = worktreePath.indexOf(`${path.sep}.hydra${path.sep}worktrees${path.sep}`);
+  if (hydraIdx >= 0) {
+    return worktreePath.substring(0, hydraIdx);
+  }
+
+  return undefined;
 }
 
 async function getMainWorktreePath(repoRoot: string): Promise<string> {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -152,13 +152,10 @@ export class SessionManager {
       const workdir = await this.backend.getSessionWorkdir(session.name) || '';
 
       if (role === 'worker') {
-        // Derive repoRoot from workdir path: workdir is <repoRoot>/.hydra/worktrees/<slug>
+        // Derive repoRoot from workdir path via .repo-root marker or legacy path pattern
         let repoRoot = '';
         if (workdir) {
-          const hydraIdx = workdir.indexOf('/.hydra/worktrees/');
-          if (hydraIdx >= 0) {
-            repoRoot = workdir.substring(0, hydraIdx);
-          }
+          repoRoot = coreGit.resolveRepoRootFromWorktreePath(workdir) || '';
         }
         state.workers[session.name] = {
           sessionName: session.name,
@@ -886,9 +883,17 @@ export class SessionManager {
       return { workerInfo, postCreatePromise: Promise.resolve() };
     }
 
-    // Worktree exists but tmux is dead
+    // Worktree exists but tmux is dead — check new and legacy locations
     const worktreesDir = coreGit.getManagedRepoWorktreesDir(repoRoot);
-    const worktreePath = path.join(worktreesDir, slug);
+    let worktreePath = path.join(worktreesDir, slug);
+    if (!fs.existsSync(worktreePath)) {
+      // Fallback: check legacy in-repo location
+      const legacyDir = coreGit.getInRepoWorktreesDir(repoRoot);
+      const legacyPath = path.join(legacyDir, slug);
+      if (fs.existsSync(legacyPath)) {
+        worktreePath = legacyPath;
+      }
+    }
     if (fs.existsSync(worktreePath)) {
       await this.backend.createSession(sessionName, worktreePath);
       await this.backend.setSessionWorkdir(sessionName, worktreePath);

--- a/src/resources/COPILOT_AGENTS.md
+++ b/src/resources/COPILOT_AGENTS.md
@@ -46,7 +46,7 @@ tmux capture-pane -t <session_name> -p -S -200 | tail -200
 
 ## Reviewing Changes
 
-Worker worktrees live at `<repo>/.hydra/worktrees/<slug>/`.
+Worker worktrees live at `~/.hydra/worktrees/<repo-identifier>/<slug>/`.
 
 ```bash
 git -C <worktree_path> diff --stat

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -7,7 +7,8 @@ import { getActiveBackend } from './multiplexer';
 
 // Re-export pure functions directly
 export { isGitRepo, findGitReposInDir, validateBranchName, localBranchExists } from '../core/git';
-export { getRepoName, getManagedWorktreesRoot, getManagedRepoWorktreesDir } from '../core/git';
+export { getRepoName, getManagedWorktreesRoot, getManagedRepoWorktreesDir, getRepoIdentifier } from '../core/git';
+export { getInRepoWorktreesDir, resolveRepoRootFromWorktreePath } from '../core/git';
 export { ensureWorktreesDir, listWorktrees, getWorktreeBranch } from '../core/git';
 export { addWorktree, removeWorktree } from '../core/git';
 export type { Worktree } from '../core/types';
@@ -27,6 +28,10 @@ export function isSlugTaken(slug: string, repoSessionNamespace: string, repoRoot
 
 export function getLegacyManagedRepoWorktreesDir(repoRoot: string): string {
   return coreGit.getLegacyManagedRepoWorktreesDir(repoRoot, getActiveBackend());
+}
+
+export function getLegacyTmuxWorktreesDir(repoRoot: string): string {
+  return coreGit.getLegacyTmuxWorktreesDir(repoRoot, getActiveBackend());
 }
 
 export function isManagedWorktreePath(repoRoot: string, worktreePath: string): boolean {


### PR DESCRIPTION
## Summary

- Moves managed worktrees from `<repo>/.hydra/worktrees/` to `~/.hydra/worktrees/<repo-identifier>/<slug>/`
- Solves tools (Claude Code, bundlers, linters) discovering parent repo config/skills twice, parent `node_modules`/`.env` leaking via path resolution, and defeating the purpose of isolation
- Maintains backwards compatibility with legacy in-repo (`.hydra/worktrees/`) and `~/.tmux-worktrees/` locations

## Changes

- **`src/core/git.ts`**: New `getRepoIdentifier()` function, updated `getManagedRepoWorktreesDir()` to point outside repo, added `getInRepoWorktreesDir()` for legacy, `resolveRepoRootFromWorktreePath()` using `.repo-root` marker file
- **`src/core/sessionManager.ts`**: Updated repo-root discovery to use marker file, added legacy location fallback in `resumeWorker()`
- **`src/utils/git.ts`**: Re-exports new functions
- **Docs**: Updated AGENTS.md, README.md, COPILOT_AGENTS.md

## Test plan

- [ ] Create a new worker — verify worktree appears at `~/.hydra/worktrees/<repo-id>/<slug>/`
- [ ] Verify `.repo-root` marker file is written in the repo-identifier directory
- [ ] Stop and restart the worker — verify it resumes correctly
- [ ] Rename a worker — verify worktree moves to new slug under the external directory
- [ ] Delete a worker — verify worktree is removed from external location
- [ ] Test with existing in-repo worktrees — verify they are still discovered and usable (backwards compat)
- [ ] Compile and lint pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)