### PR TITLE
feat: archive deleted sessions to ~/.hydra/archive.json

### DIFF
--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -1,0 +1,147 @@
+import { Command } from 'commander';
+import { TmuxBackendCore } from '../../core/tmux';
+import { SessionManager } from '../../core/sessionManager';
+import { outputResult, outputError, type OutputOpts } from '../output';
+
+export function registerArchiveCommands(program: Command): void {
+  const archive = program
+    .command('archive')
+    .description('View and manage archived (deleted) sessions');
+
+  archive
+    .command('list')
+    .description('List all archived sessions')
+    .action(async () => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const entries = sm.listArchived();
+
+        const data = {
+          entries: entries.map(e => ({
+            sessionName: e.sessionName,
+            type: e.type,
+            agentSessionId: e.agentSessionId,
+            archivedAt: e.archivedAt,
+            agent: e.data.agent,
+            branch: e.type === 'worker' ? (e.data as { branch?: string }).branch || null : null,
+          })),
+          count: entries.length,
+        };
+
+        outputResult(data, globalOpts, () => {
+          if (entries.length === 0) {
+            console.log('No archived sessions.');
+            return;
+          }
+
+          console.log('\nArchived Sessions:');
+          console.log('\u2500'.repeat(60));
+          for (const entry of entries) {
+            const branch = entry.type === 'worker'
+              ? ` (${(entry.data as { branch?: string }).branch || 'unknown'})`
+              : '';
+            console.log(`  [${entry.type}] ${entry.sessionName}${branch}`);
+            console.log(`    Agent:      ${entry.data.agent}`);
+            console.log(`    Session ID: ${entry.agentSessionId || 'none'}`);
+            console.log(`    Archived:   ${entry.archivedAt}`);
+          }
+          console.log('');
+        });
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  archive
+    .command('view <session>')
+    .description('View full metadata for an archived session')
+    .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const entry = sm.getArchived(sessionName);
+
+        if (!entry) {
+          throw new Error(`Archived session "${sessionName}" not found`);
+        }
+
+        outputResult(entry as unknown as Record<string, unknown>, globalOpts, () => {
+          console.log(`\nArchived ${entry.type}: ${entry.sessionName}`);
+          console.log('\u2500'.repeat(60));
+          console.log(`  Type:            ${entry.type}`);
+          console.log(`  Agent Session ID: ${entry.agentSessionId || 'none'}`);
+          console.log(`  Archived At:     ${entry.archivedAt}`);
+          console.log('');
+          console.log('  Metadata:');
+          for (const [key, value] of Object.entries(entry.data)) {
+            if (value != null) {
+              console.log(`    ${key}: ${value}`);
+            }
+          }
+          console.log('');
+        });
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  archive
+    .command('restore <session>')
+    .description('Restore a worker or copilot from the archive')
+    .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const entry = sm.getArchived(sessionName);
+
+        if (!entry) {
+          throw new Error(`Archived session "${sessionName}" not found`);
+        }
+
+        if (entry.type === 'worker') {
+          const { workerInfo, postCreatePromise } = await sm.restoreWorker(sessionName);
+          outputResult(
+            {
+              status: 'restored',
+              type: 'worker',
+              session: workerInfo.sessionName,
+              branch: workerInfo.branch,
+              agent: workerInfo.agent,
+              workdir: workerInfo.workdir,
+            },
+            globalOpts,
+            () => {
+              console.log(`Restored worker: ${workerInfo.sessionName}`);
+              console.log(`  Branch:  ${workerInfo.branch}`);
+              console.log(`  Agent:   ${workerInfo.agent}`);
+              console.log(`  Workdir: ${workerInfo.workdir}`);
+            },
+          );
+          await postCreatePromise;
+        } else {
+          const copilotInfo = await sm.restoreCopilot(sessionName);
+          outputResult(
+            {
+              status: 'restored',
+              type: 'copilot',
+              session: copilotInfo.sessionName,
+              agent: copilotInfo.agent,
+              workdir: copilotInfo.workdir,
+            },
+            globalOpts,
+            () => {
+              console.log(`Restored copilot: ${copilotInfo.sessionName}`);
+              console.log(`  Agent:   ${copilotInfo.agent}`);
+              console.log(`  Workdir: ${copilotInfo.workdir}`);
+            },
+          );
+        }
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+}

--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -1,7 +1,28 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
-import { SessionManager } from '../../core/sessionManager';
+import { SessionManager, ArchivedSessionInfo } from '../../core/sessionManager';
 import { outputResult, outputError, type OutputOpts } from '../output';
+
+function formatEntry(entry: ArchivedSessionInfo): Record<string, unknown> {
+  return {
+    sessionName: entry.sessionName,
+    type: entry.type,
+    agentSessionId: entry.agentSessionId,
+    archivedAt: entry.archivedAt,
+    agent: entry.data.agent,
+    branch: entry.type === 'worker' ? (entry.data as { branch?: string }).branch || null : null,
+  };
+}
+
+function printEntry(entry: ArchivedSessionInfo): void {
+  const branch = entry.type === 'worker'
+    ? ` (${(entry.data as { branch?: string }).branch || 'unknown'})`
+    : '';
+  console.log(`  [${entry.type}] ${entry.sessionName}${branch}`);
+  console.log(`    Agent:      ${entry.data.agent}`);
+  console.log(`    Session ID: ${entry.agentSessionId || 'none'}`);
+  console.log(`    Archived:   ${entry.archivedAt}`);
+}
 
 export function registerArchiveCommands(program: Command): void {
   const archive = program
@@ -10,23 +31,17 @@ export function registerArchiveCommands(program: Command): void {
 
   archive
     .command('list')
-    .description('List all archived sessions')
-    .action(async () => {
+    .description('List archived sessions (most recent per session by default)')
+    .option('--all', 'Show every archive entry including duplicates')
+    .action(async (opts: { all?: boolean }) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const entries = sm.listArchived();
+        const entries = opts.all ? sm.listArchived() : sm.listArchivedLatest();
 
         const data = {
-          entries: entries.map(e => ({
-            sessionName: e.sessionName,
-            type: e.type,
-            agentSessionId: e.agentSessionId,
-            archivedAt: e.archivedAt,
-            agent: e.data.agent,
-            branch: e.type === 'worker' ? (e.data as { branch?: string }).branch || null : null,
-          })),
+          entries: entries.map(formatEntry),
           count: entries.length,
         };
 
@@ -39,13 +54,7 @@ export function registerArchiveCommands(program: Command): void {
           console.log('\nArchived Sessions:');
           console.log('\u2500'.repeat(60));
           for (const entry of entries) {
-            const branch = entry.type === 'worker'
-              ? ` (${(entry.data as { branch?: string }).branch || 'unknown'})`
-              : '';
-            console.log(`  [${entry.type}] ${entry.sessionName}${branch}`);
-            console.log(`    Agent:      ${entry.data.agent}`);
-            console.log(`    Session ID: ${entry.agentSessionId || 'none'}`);
-            console.log(`    Archived:   ${entry.archivedAt}`);
+            printEntry(entry);
           }
           console.log('');
         });
@@ -56,29 +65,39 @@ export function registerArchiveCommands(program: Command): void {
 
   archive
     .command('view <session>')
-    .description('View full metadata for an archived session')
+    .description('View full history for an archived session (all entries)')
     .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const entry = sm.getArchived(sessionName);
+        const entries = sm.getArchivedAll(sessionName);
 
-        if (!entry) {
+        if (entries.length === 0) {
           throw new Error(`Archived session "${sessionName}" not found`);
         }
 
-        outputResult(entry as unknown as Record<string, unknown>, globalOpts, () => {
-          console.log(`\nArchived ${entry.type}: ${entry.sessionName}`);
+        const data = {
+          sessionName,
+          entries: entries.map(e => ({
+            ...formatEntry(e),
+            data: e.data,
+          })),
+          count: entries.length,
+        };
+
+        outputResult(data, globalOpts, () => {
+          console.log(`\nArchive history for: ${sessionName} (${entries.length} entries)`);
           console.log('\u2500'.repeat(60));
-          console.log(`  Type:            ${entry.type}`);
-          console.log(`  Agent Session ID: ${entry.agentSessionId || 'none'}`);
-          console.log(`  Archived At:     ${entry.archivedAt}`);
-          console.log('');
-          console.log('  Metadata:');
-          for (const [key, value] of Object.entries(entry.data)) {
-            if (value != null) {
-              console.log(`    ${key}: ${value}`);
+          for (let i = 0; i < entries.length; i++) {
+            const entry = entries[i];
+            console.log(`\n  #${i + 1} [${entry.type}] archived ${entry.archivedAt}`);
+            console.log(`    Agent Session ID: ${entry.agentSessionId || 'none'}`);
+            console.log('    Metadata:');
+            for (const [key, value] of Object.entries(entry.data)) {
+              if (value != null) {
+                console.log(`      ${key}: ${value}`);
+              }
             }
           }
           console.log('');
@@ -90,7 +109,7 @@ export function registerArchiveCommands(program: Command): void {
 
   archive
     .command('restore <session>')
-    .description('Restore a worker or copilot from the archive')
+    .description('Restore a worker or copilot from the most recent archive entry')
     .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -112,13 +131,15 @@ export function registerArchiveCommands(program: Command): void {
               branch: workerInfo.branch,
               agent: workerInfo.agent,
               workdir: workerInfo.workdir,
+              agentSessionId: workerInfo.sessionId,
             },
             globalOpts,
             () => {
               console.log(`Restored worker: ${workerInfo.sessionName}`);
-              console.log(`  Branch:  ${workerInfo.branch}`);
-              console.log(`  Agent:   ${workerInfo.agent}`);
-              console.log(`  Workdir: ${workerInfo.workdir}`);
+              console.log(`  Branch:     ${workerInfo.branch}`);
+              console.log(`  Agent:      ${workerInfo.agent}`);
+              console.log(`  Workdir:    ${workerInfo.workdir}`);
+              console.log(`  Session ID: ${workerInfo.sessionId || 'none'}`);
             },
           );
           await postCreatePromise;
@@ -131,12 +152,14 @@ export function registerArchiveCommands(program: Command): void {
               session: copilotInfo.sessionName,
               agent: copilotInfo.agent,
               workdir: copilotInfo.workdir,
+              agentSessionId: copilotInfo.sessionId,
             },
             globalOpts,
             () => {
               console.log(`Restored copilot: ${copilotInfo.sessionName}`);
-              console.log(`  Agent:   ${copilotInfo.agent}`);
-              console.log(`  Workdir: ${copilotInfo.workdir}`);
+              console.log(`  Agent:      ${copilotInfo.agent}`);
+              console.log(`  Workdir:    ${copilotInfo.workdir}`);
+              console.log(`  Session ID: ${copilotInfo.sessionId || 'none'}`);
             },
           );
         }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { registerListCommand } from './commands/list';
 import { registerWorkerCommands } from './commands/worker';
 import { registerCopilotCommands } from './commands/copilot';
+import { registerArchiveCommands } from './commands/archive';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
 
@@ -26,5 +27,6 @@ if (!process.stdout.isTTY) {
 registerListCommand(program);
 registerWorkerCommands(program);
 registerCopilotCommands(program);
+registerArchiveCommands(program);
 
 program.parse();

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -704,8 +704,22 @@ export class SessionManager {
     return this.readArchiveState().entries;
   }
 
+  getArchivedAll(sessionName: string): ArchivedSessionInfo[] {
+    return this.readArchiveState().entries.filter(e => e.sessionName === sessionName);
+  }
+
   getArchived(sessionName: string): ArchivedSessionInfo | undefined {
-    return this.readArchiveState().entries.find(e => e.sessionName === sessionName);
+    const all = this.getArchivedAll(sessionName);
+    return all.length > 0 ? all[all.length - 1] : undefined;
+  }
+
+  listArchivedLatest(): ArchivedSessionInfo[] {
+    const entries = this.readArchiveState().entries;
+    const latest = new Map<string, ArchivedSessionInfo>();
+    for (const entry of entries) {
+      latest.set(entry.sessionName, entry);
+    }
+    return [...latest.values()];
   }
 
   async restoreWorker(sessionName: string): Promise<CreateWorkerResult> {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -731,24 +731,72 @@ export class SessionManager {
       throw new Error(`Archived session "${sessionName}" is a copilot, not a worker`);
     }
 
+    ensureHydraGlobalConfig();
+
     const worker = entry.data as WorkerInfo;
     const agentSessionId = entry.agentSessionId;
+    const agentType = worker.agent || 'claude';
+    const repoRoot = worker.repoRoot;
+    const branchName = worker.branch;
 
-    // Create worktree and branch (createWorker handles "branch exists" via resume path)
-    const { workerInfo, postCreatePromise } = await this.createWorker({
-      repoRoot: worker.repoRoot,
-      branchName: worker.branch,
-      agentType: worker.agent,
-    });
-
-    // Overwrite the freshly assigned sessionId with the archived one so that
-    // future startWorker/resume calls use --resume with the original conversation
-    if (agentSessionId) {
-      this.updateSessionId(workerInfo.sessionName, agentSessionId);
-      workerInfo.sessionId = agentSessionId;
+    const validationError = coreGit.validateBranchName(branchName);
+    if (validationError) {
+      throw new Error(validationError);
     }
 
-    return { workerInfo, postCreatePromise };
+    const repoSessionNamespace = coreGit.getRepoSessionNamespace(repoRoot, this.backend);
+    const slug = coreGit.branchNameToSlug(branchName, this.backend);
+    let finalSlug = slug;
+    let suffix = 1;
+    while (await coreGit.isSlugTaken(finalSlug, repoSessionNamespace, repoRoot, this.backend)) {
+      suffix++;
+      finalSlug = `${slug}-${suffix}`;
+    }
+
+    // Create worktree if branch doesn't exist yet
+    const branchExists = await coreGit.localBranchExists(repoRoot, branchName);
+    let worktreePath: string;
+    if (!branchExists) {
+      const baseBranch = await coreGit.getBaseBranchFromRepo(repoRoot);
+      worktreePath = await coreGit.addWorktree(repoRoot, branchName, finalSlug, baseBranch);
+      this.resolveImports(path.join(worktreePath, 'CLAUDE.md'), repoRoot);
+      this.resolveImports(path.join(worktreePath, 'AGENTS.md'), repoRoot);
+      this.resolveImports(path.join(worktreePath, 'GEMINI.md'), repoRoot);
+      injectWorkerInstructions(worktreePath, agentType);
+    } else {
+      const worktreesDir = coreGit.getManagedRepoWorktreesDir(repoRoot);
+      worktreePath = path.join(worktreesDir, finalSlug);
+    }
+
+    // Register session entry with the archived agentSessionId
+    const newSessionName = this.backend.buildSessionName(repoSessionNamespace, finalSlug);
+    const state = this.readSessionState();
+    const workerId = state.nextWorkerId++;
+    const now = new Date().toISOString();
+
+    const workerInfo: WorkerInfo = {
+      sessionName: newSessionName,
+      workerId,
+      repo: coreGit.getRepoName(repoRoot),
+      repoRoot,
+      branch: branchName,
+      slug: finalSlug,
+      status: 'stopped',
+      attached: false,
+      agent: agentType,
+      workdir: worktreePath,
+      tmuxSession: newSessionName,
+      createdAt: now,
+      lastSeenAt: now,
+      sessionId: agentSessionId, // Archived session ID for --resume
+    };
+
+    state.workers[newSessionName] = workerInfo;
+    state.updatedAt = now;
+    this.writeSessionState(state);
+
+    // startWorker sees the stored sessionId and uses buildAgentResumeCommand (--resume)
+    return this.startWorker(newSessionName);
   }
 
   async restoreCopilot(sessionName: string): Promise<CopilotInfo> {
@@ -760,20 +808,51 @@ export class SessionManager {
       throw new Error(`Archived session "${sessionName}" is a worker, not a copilot`);
     }
 
+    ensureHydraGlobalConfig();
+
     const copilot = entry.data as CopilotInfo;
     const agentSessionId = entry.agentSessionId;
+    const agentType = copilot.agent || 'claude';
+    const agentCommand = DEFAULT_AGENT_COMMANDS[agentType] || agentType;
+    const copilotSessionName = copilot.sessionName;
 
-    const copilotInfo = await this.createCopilot({
-      workdir: copilot.workdir,
-      agentType: copilot.agent,
-      sessionName: copilot.sessionName,
-    });
-
-    // Overwrite freshly assigned sessionId with the archived one
-    if (agentSessionId) {
-      this.updateSessionId(copilotInfo.sessionName, agentSessionId);
-      copilotInfo.sessionId = agentSessionId;
+    const exists = await this.backend.hasSession(copilotSessionName);
+    if (exists) {
+      throw new Error(`Session "${copilotSessionName}" already exists`);
     }
+
+    await this.backend.createSession(copilotSessionName, copilot.workdir);
+    await this.backend.setSessionWorkdir(copilotSessionName, copilot.workdir);
+    await this.backend.setSessionRole(copilotSessionName, 'copilot');
+    await this.backend.setSessionAgent(copilotSessionName, agentType);
+
+    // Use --resume with the archived agentSessionId if available
+    let launchCmd: string;
+    if (agentSessionId) {
+      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, agentSessionId);
+      launchCmd = resumeCmd || buildAgentLaunchCommand(agentType, agentCommand);
+    } else {
+      launchCmd = buildAgentLaunchCommand(agentType, agentCommand);
+    }
+    await this.backend.sendKeys(copilotSessionName, launchCmd);
+
+    const now = new Date().toISOString();
+    const copilotInfo: CopilotInfo = {
+      sessionName: copilotSessionName,
+      status: 'running',
+      attached: false,
+      agent: agentType,
+      workdir: copilot.workdir,
+      tmuxSession: copilotSessionName,
+      createdAt: now,
+      lastSeenAt: now,
+      sessionId: agentSessionId,
+    };
+
+    const state = this.readSessionState();
+    state.copilots[copilotSessionName] = copilotInfo;
+    state.updatedAt = now;
+    this.writeSessionState(state);
 
     return copilotInfo;
   }

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -93,6 +93,8 @@ export interface CreateWorkerOpts {
   task?: string;
   taskFile?: string;
   agentCommand?: string;
+  /** When set, launch the agent with --resume instead of a fresh session. */
+  resumeSessionId?: string;
 }
 
 export interface CreateCopilotOpts {
@@ -102,6 +104,8 @@ export interface CreateCopilotOpts {
   name?: string;
   sessionName?: string;
   agentCommand?: string;
+  /** When set, launch the agent with --resume instead of a fresh session. */
+  resumeSessionId?: string;
 }
 
 export interface CreateWorkerResult {
@@ -301,14 +305,22 @@ export class SessionManager {
     await this.backend.setSessionRole(sessionName, 'worker');
     await this.backend.setSessionAgent(sessionName, agentType);
 
-    // For Claude, pre-assign session ID via --session-id flag (guaranteed correct).
-    // For other agents, capture from filesystem after launch.
-    const preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
+    // If resuming an archived session, use --resume; otherwise fresh launch.
+    let preAssignedSessionId: string | null;
     const snapshot = this.snapshotAgentSessions(agentType, worktreePath);
 
-    // Launch agent without task (task sent after session ID capture)
-    const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
-    await this.backend.sendKeys(sessionName, launchCmd);
+    if (opts.resumeSessionId) {
+      preAssignedSessionId = opts.resumeSessionId;
+      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, opts.resumeSessionId);
+      const launchCmd = resumeCmd || buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
+      await this.backend.sendKeys(sessionName, launchCmd);
+    } else {
+      // For Claude, pre-assign session ID via --session-id flag (guaranteed correct).
+      // For other agents, capture from filesystem after launch.
+      preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
+      const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
+      await this.backend.sendKeys(sessionName, launchCmd);
+    }
 
     const now = new Date().toISOString();
     const state = this.readSessionState();
@@ -465,14 +477,22 @@ export class SessionManager {
     await this.backend.setSessionRole(sessionName, 'copilot');
     await this.backend.setSessionAgent(sessionName, agentType);
 
-    const preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
+    let preAssignedSessionId: string | null;
     const snapshot = this.snapshotAgentSessions(agentType, opts.workdir);
 
-    // For Claude, launch with --session-id; for others, use agentCommand as-is
-    const launchCmd = agentType === 'claude'
-      ? buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined)
-      : agentCommand;
-    await this.backend.sendKeys(sessionName, launchCmd);
+    if (opts.resumeSessionId) {
+      preAssignedSessionId = opts.resumeSessionId;
+      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, opts.resumeSessionId);
+      const launchCmd = resumeCmd || buildAgentLaunchCommand(agentType, agentCommand);
+      await this.backend.sendKeys(sessionName, launchCmd);
+    } else {
+      // For Claude, launch with --session-id; for others, use agentCommand as-is
+      preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
+      const launchCmd = agentType === 'claude'
+        ? buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined)
+        : agentCommand;
+      await this.backend.sendKeys(sessionName, launchCmd);
+    }
 
     const now = new Date().toISOString();
     const copilotInfo: CopilotInfo = {
@@ -731,72 +751,13 @@ export class SessionManager {
       throw new Error(`Archived session "${sessionName}" is a copilot, not a worker`);
     }
 
-    ensureHydraGlobalConfig();
-
     const worker = entry.data as WorkerInfo;
-    const agentSessionId = entry.agentSessionId;
-    const agentType = worker.agent || 'claude';
-    const repoRoot = worker.repoRoot;
-    const branchName = worker.branch;
-
-    const validationError = coreGit.validateBranchName(branchName);
-    if (validationError) {
-      throw new Error(validationError);
-    }
-
-    const repoSessionNamespace = coreGit.getRepoSessionNamespace(repoRoot, this.backend);
-    const slug = coreGit.branchNameToSlug(branchName, this.backend);
-    let finalSlug = slug;
-    let suffix = 1;
-    while (await coreGit.isSlugTaken(finalSlug, repoSessionNamespace, repoRoot, this.backend)) {
-      suffix++;
-      finalSlug = `${slug}-${suffix}`;
-    }
-
-    // Create worktree if branch doesn't exist yet
-    const branchExists = await coreGit.localBranchExists(repoRoot, branchName);
-    let worktreePath: string;
-    if (!branchExists) {
-      const baseBranch = await coreGit.getBaseBranchFromRepo(repoRoot);
-      worktreePath = await coreGit.addWorktree(repoRoot, branchName, finalSlug, baseBranch);
-      this.resolveImports(path.join(worktreePath, 'CLAUDE.md'), repoRoot);
-      this.resolveImports(path.join(worktreePath, 'AGENTS.md'), repoRoot);
-      this.resolveImports(path.join(worktreePath, 'GEMINI.md'), repoRoot);
-      injectWorkerInstructions(worktreePath, agentType);
-    } else {
-      const worktreesDir = coreGit.getManagedRepoWorktreesDir(repoRoot);
-      worktreePath = path.join(worktreesDir, finalSlug);
-    }
-
-    // Register session entry with the archived agentSessionId
-    const newSessionName = this.backend.buildSessionName(repoSessionNamespace, finalSlug);
-    const state = this.readSessionState();
-    const workerId = state.nextWorkerId++;
-    const now = new Date().toISOString();
-
-    const workerInfo: WorkerInfo = {
-      sessionName: newSessionName,
-      workerId,
-      repo: coreGit.getRepoName(repoRoot),
-      repoRoot,
-      branch: branchName,
-      slug: finalSlug,
-      status: 'stopped',
-      attached: false,
-      agent: agentType,
-      workdir: worktreePath,
-      tmuxSession: newSessionName,
-      createdAt: now,
-      lastSeenAt: now,
-      sessionId: agentSessionId, // Archived session ID for --resume
-    };
-
-    state.workers[newSessionName] = workerInfo;
-    state.updatedAt = now;
-    this.writeSessionState(state);
-
-    // startWorker sees the stored sessionId and uses buildAgentResumeCommand (--resume)
-    return this.startWorker(newSessionName);
+    return this.createWorker({
+      repoRoot: worker.repoRoot,
+      branchName: worker.branch,
+      agentType: worker.agent,
+      resumeSessionId: entry.agentSessionId || undefined,
+    });
   }
 
   async restoreCopilot(sessionName: string): Promise<CopilotInfo> {
@@ -808,53 +769,13 @@ export class SessionManager {
       throw new Error(`Archived session "${sessionName}" is a worker, not a copilot`);
     }
 
-    ensureHydraGlobalConfig();
-
     const copilot = entry.data as CopilotInfo;
-    const agentSessionId = entry.agentSessionId;
-    const agentType = copilot.agent || 'claude';
-    const agentCommand = DEFAULT_AGENT_COMMANDS[agentType] || agentType;
-    const copilotSessionName = copilot.sessionName;
-
-    const exists = await this.backend.hasSession(copilotSessionName);
-    if (exists) {
-      throw new Error(`Session "${copilotSessionName}" already exists`);
-    }
-
-    await this.backend.createSession(copilotSessionName, copilot.workdir);
-    await this.backend.setSessionWorkdir(copilotSessionName, copilot.workdir);
-    await this.backend.setSessionRole(copilotSessionName, 'copilot');
-    await this.backend.setSessionAgent(copilotSessionName, agentType);
-
-    // Use --resume with the archived agentSessionId if available
-    let launchCmd: string;
-    if (agentSessionId) {
-      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, agentSessionId);
-      launchCmd = resumeCmd || buildAgentLaunchCommand(agentType, agentCommand);
-    } else {
-      launchCmd = buildAgentLaunchCommand(agentType, agentCommand);
-    }
-    await this.backend.sendKeys(copilotSessionName, launchCmd);
-
-    const now = new Date().toISOString();
-    const copilotInfo: CopilotInfo = {
-      sessionName: copilotSessionName,
-      status: 'running',
-      attached: false,
-      agent: agentType,
+    return this.createCopilot({
       workdir: copilot.workdir,
-      tmuxSession: copilotSessionName,
-      createdAt: now,
-      lastSeenAt: now,
-      sessionId: agentSessionId,
-    };
-
-    const state = this.readSessionState();
-    state.copilots[copilotSessionName] = copilotInfo;
-    state.updatedAt = now;
-    this.writeSessionState(state);
-
-    return copilotInfo;
+      agentType: copilot.agent,
+      sessionName: copilot.sessionName,
+      resumeSessionId: entry.agentSessionId || undefined,
+    });
   }
 
   // ── Private helpers ──

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -718,11 +718,23 @@ export class SessionManager {
     }
 
     const worker = entry.data as WorkerInfo;
-    return this.createWorker({
+    const agentSessionId = entry.agentSessionId;
+
+    // Create worktree and branch (createWorker handles "branch exists" via resume path)
+    const { workerInfo, postCreatePromise } = await this.createWorker({
       repoRoot: worker.repoRoot,
       branchName: worker.branch,
       agentType: worker.agent,
     });
+
+    // Overwrite the freshly assigned sessionId with the archived one so that
+    // future startWorker/resume calls use --resume with the original conversation
+    if (agentSessionId) {
+      this.updateSessionId(workerInfo.sessionName, agentSessionId);
+      workerInfo.sessionId = agentSessionId;
+    }
+
+    return { workerInfo, postCreatePromise };
   }
 
   async restoreCopilot(sessionName: string): Promise<CopilotInfo> {
@@ -735,11 +747,21 @@ export class SessionManager {
     }
 
     const copilot = entry.data as CopilotInfo;
-    return this.createCopilot({
+    const agentSessionId = entry.agentSessionId;
+
+    const copilotInfo = await this.createCopilot({
       workdir: copilot.workdir,
       agentType: copilot.agent,
       sessionName: copilot.sessionName,
     });
+
+    // Overwrite freshly assigned sessionId with the archived one
+    if (agentSessionId) {
+      this.updateSessionId(copilotInfo.sessionName, agentSessionId);
+      copilotInfo.sessionId = agentSessionId;
+    }
+
+    return copilotInfo;
   }
 
   // ── Private helpers ──

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -11,6 +11,7 @@ import { shellQuote } from './shell';
 
 const HYDRA_DIR = path.join(os.homedir(), '.hydra');
 const SESSIONS_FILE = path.join(HYDRA_DIR, 'sessions.json');
+const ARCHIVE_FILE = path.join(HYDRA_DIR, 'archive.json');
 
 /**
  * Look up a worker's numeric ID from sessions.json.
@@ -68,6 +69,18 @@ export interface SessionState {
   workers: Record<string, WorkerInfo>;
   nextWorkerId: number;
   updatedAt: string;
+}
+
+export interface ArchivedSessionInfo {
+  type: 'worker' | 'copilot';
+  sessionName: string;
+  agentSessionId: string | null;
+  archivedAt: string;
+  data: WorkerInfo | CopilotInfo;
+}
+
+export interface ArchiveState {
+  entries: ArchivedSessionInfo[];
 }
 
 type SessionSnapshot = Record<string, never>;
@@ -337,6 +350,11 @@ export class SessionManager {
 
     const state = this.readSessionState();
     const worker = state.workers[sessionName];
+
+    // Archive before removing
+    if (worker) {
+      this.archiveEntry('worker', worker.sessionName, worker.sessionId, worker);
+    }
 
     if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
       try {
@@ -628,6 +646,13 @@ export class SessionManager {
     } catch { /* Already dead */ }
 
     const state = this.readSessionState();
+    const copilot = state.copilots[sessionName];
+
+    // Archive before removing
+    if (copilot) {
+      this.archiveEntry('copilot', copilot.sessionName, copilot.sessionId, copilot);
+    }
+
     delete state.copilots[sessionName];
     state.updatedAt = new Date().toISOString();
     this.writeSessionState(state);
@@ -673,7 +698,88 @@ export class SessionManager {
     this.updateSessionId(sessionName, sessionId);
   }
 
+  // ── Archive ──
+
+  listArchived(): ArchivedSessionInfo[] {
+    return this.readArchiveState().entries;
+  }
+
+  getArchived(sessionName: string): ArchivedSessionInfo | undefined {
+    return this.readArchiveState().entries.find(e => e.sessionName === sessionName);
+  }
+
+  async restoreWorker(sessionName: string): Promise<CreateWorkerResult> {
+    const entry = this.getArchived(sessionName);
+    if (!entry) {
+      throw new Error(`Archived session "${sessionName}" not found`);
+    }
+    if (entry.type !== 'worker') {
+      throw new Error(`Archived session "${sessionName}" is a copilot, not a worker`);
+    }
+
+    const worker = entry.data as WorkerInfo;
+    return this.createWorker({
+      repoRoot: worker.repoRoot,
+      branchName: worker.branch,
+      agentType: worker.agent,
+    });
+  }
+
+  async restoreCopilot(sessionName: string): Promise<CopilotInfo> {
+    const entry = this.getArchived(sessionName);
+    if (!entry) {
+      throw new Error(`Archived session "${sessionName}" not found`);
+    }
+    if (entry.type !== 'copilot') {
+      throw new Error(`Archived session "${sessionName}" is a worker, not a copilot`);
+    }
+
+    const copilot = entry.data as CopilotInfo;
+    return this.createCopilot({
+      workdir: copilot.workdir,
+      agentType: copilot.agent,
+      sessionName: copilot.sessionName,
+    });
+  }
+
   // ── Private helpers ──
+
+  private archiveEntry(
+    type: 'worker' | 'copilot',
+    sessionName: string,
+    agentSessionId: string | null,
+    data: WorkerInfo | CopilotInfo,
+  ): void {
+    const archive = this.readArchiveState();
+    archive.entries.push({
+      type,
+      sessionName,
+      agentSessionId,
+      archivedAt: new Date().toISOString(),
+      data: { ...data },
+    });
+    this.writeArchiveState(archive);
+  }
+
+  private readArchiveState(): ArchiveState {
+    try {
+      if (fs.existsSync(ARCHIVE_FILE)) {
+        const raw = fs.readFileSync(ARCHIVE_FILE, 'utf-8');
+        const parsed = JSON.parse(raw);
+        return { entries: parsed.entries || [] };
+      }
+    } catch {
+      // Corrupted file — start fresh
+    }
+    return { entries: [] };
+  }
+
+  private writeArchiveState(archive: ArchiveState): void {
+    if (!fs.existsSync(HYDRA_DIR)) {
+      fs.mkdirSync(HYDRA_DIR, { recursive: true });
+    }
+    fs.writeFileSync(ARCHIVE_FILE, JSON.stringify(archive, null, 2), 'utf-8');
+  }
 
   private readSessionState(): SessionState {
     try {


### PR DESCRIPTION
## Summary
- When a worker or copilot is deleted, its full metadata is archived to `~/.hydra/archive.json` (append-only, never auto-pruned)
- Archived data includes: session name, agent session ID (for resuming conversations), branch, repo, agent type, workdir, timestamps
- Adds `resumeSessionId` option to `CreateWorkerOpts`/`CreateCopilotOpts` — when set, the agent is launched with `--resume <id>` instead of a fresh session
- `restoreWorker`/`restoreCopilot` pass the archived `agentSessionId` through this option, enabling full conversation recovery

## CLI Commands
- `hydra archive list` — most recent entry per session (use `--all` for full history)
- `hydra archive view <session>` — full chronological history of all entries for a session
- `hydra archive restore <session>` — recreate worker/copilot using `--resume` with archived session ID
- All commands support `--json`

## Tested
- Created a worker, had a conversation, deleted it, restored from archive
- Verified `claude --resume <id>` is used on restore
- Confirmed the agent retains full conversation context after restore

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (0 errors)
- [x] Delete a worker → entry appears in archive with correct agentSessionId
- [x] `hydra archive list` / `view` / `restore` work correctly
- [x] Restored worker launches with `--resume` and recovers conversation history
- [x] `--json` flag works for all archive commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)