### PR TITLE
feat: display worker numbers in CLI list output

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -28,6 +28,7 @@ export function registerListCommand(program: Command): void {
             workdir: c.workdir || null,
           })),
           workers: workers.map(w => ({
+            number: w.workerId,
             session: w.sessionName || w.tmuxSession,
             repo: w.repo || null,
             branch: w.branch || null,
@@ -91,7 +92,8 @@ export function registerListCommand(program: Command): void {
                 const attached = w.attached ? ' (attached)' : '';
                 const branch = w.branch ? ` (${w.branch})` : '';
                 const name = w.sessionName || w.tmuxSession;
-                console.log(`    ${statusIcon} ${name}${branch}  [${w.agent}]${attached}`);
+                const num = w.workerId != null ? `#${w.workerId} ` : '';
+                console.log(`    ${statusIcon} ${num}${name}${branch}  [${w.agent}]${attached}`);
                 if (w.workdir) console.log(`      workdir: ${w.workdir}`);
               }
             }


### PR DESCRIPTION
## Summary
- Show the persistent `workerId` (from `sessions.json`) in `hydra list` pretty-print output as `#N` prefix
- Add `number` field to `hydra list --json` worker objects

Example pretty-print:
```
Workers:
  hydra:
    ● #22 hydra-ad84c436_feat-worktrees-outside-repo (feat/worktrees-outside-repo)  [claude]
    ● #23 hydra-ad84c436_feat-archive-sessions (feat/archive-sessions)  [claude]
```

Example JSON:
```json
{ "number": 22, "session": "hydra-ad84c436_feat-worktrees-outside-repo", ... }
```

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (no new warnings)
- [x] `hydra list` shows worker numbers in pretty-print
- [x] `hydra list --json` includes `number` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)