### PR TITLE
fix: remove --add-dir flag from worker agent launch commands

### DIFF
--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -83,7 +83,7 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
     // For Claude, pre-assign session ID via --session-id flag
     const preAssignedSessionId = agentType === 'claude' ? randomUUID() : undefined;
     const agentBinary = getAgentCommand(agentType);
-    const launchCmd = buildAgentLaunchCommand(agentType, agentBinary, undefined, undefined, preAssignedSessionId);
+    const launchCmd = buildAgentLaunchCommand(agentType, agentBinary, undefined, preAssignedSessionId);
     await backend.sendKeys(sessionName, launchCmd);
 
     // Persist copilot with session ID to sessions.json
@@ -157,7 +157,7 @@ export async function createCopilot(): Promise<void> {
     // For Claude, pre-assign session ID via --session-id flag
     const preAssignedSessionId = agentType === 'claude' ? randomUUID() : undefined;
     const agentBinary = getAgentCommand(agentType);
-    const launchCmd = buildAgentLaunchCommand(agentType, agentBinary, undefined, undefined, preAssignedSessionId);
+    const launchCmd = buildAgentLaunchCommand(agentType, agentBinary, undefined, preAssignedSessionId);
     await backend.sendKeys(sessionName, launchCmd);
 
     // Persist copilot with session ID to sessions.json

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -59,14 +59,11 @@ export function buildAgentResumeCommand(
   agentType: string,
   agentBinary: string,
   sessionId: string,
-  repoRoot?: string,
 ): string | null {
   const binary = agentBinary.split(/\s+/)[0]; // strip flags from default command
   switch (agentType) {
     case 'claude': {
-      let cmd = `${binary} --resume ${sessionId}`;
-      if (repoRoot) cmd += ` --add-dir ${repoRoot}`;
-      return cmd;
+      return `${binary} --resume ${sessionId}`;
     }
     case 'codex':
       return `${binary} resume ${sessionId}`;
@@ -82,7 +79,6 @@ export function buildAgentLaunchCommand(
   agentType: string,
   agentBinary: string,
   task?: string,
-  repoRoot?: string,
   sessionId?: string,
 ): string {
   const yolo = AGENT_YOLO_FLAGS[agentType] || '';
@@ -91,7 +87,6 @@ export function buildAgentLaunchCommand(
     case 'claude': {
       let flags = yolo;
       if (sessionId) flags += ` --session-id ${sessionId}`;
-      if (repoRoot) flags += ` --add-dir ${repoRoot}`;
       return task ? `${agentBinary} ${flags} -- ${shellQuoteForDisplay(task)}` : `${agentBinary} ${flags}`;
     }
     case 'codex':

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -291,7 +291,7 @@ export class SessionManager {
     const snapshot = this.snapshotAgentSessions(agentType, worktreePath);
 
     // Launch agent without task (task sent after session ID capture)
-    const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, repoRoot, preAssignedSessionId ?? undefined);
+    const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
     await this.backend.sendKeys(sessionName, launchCmd);
 
     const now = new Date().toISOString();
@@ -387,7 +387,7 @@ export class SessionManager {
     // Resume from stored session ID if available; otherwise fresh start
     const storedSessionId = worker.sessionId;
     const resumeCmd = storedSessionId
-      ? buildAgentResumeCommand(agent, command, storedSessionId, worker.repoRoot)
+      ? buildAgentResumeCommand(agent, command, storedSessionId)
       : null;
 
     let postCreatePromise: Promise<void>;
@@ -406,7 +406,7 @@ export class SessionManager {
       // Fresh start — capture new session ID
       const preAssignedSessionId = agent === 'claude' ? randomUUID() : null;
       const snapshot = this.snapshotAgentSessions(agent, worker.workdir);
-      const launchCmd = buildAgentLaunchCommand(agent, command, undefined, worker.repoRoot, preAssignedSessionId ?? undefined);
+      const launchCmd = buildAgentLaunchCommand(agent, command, undefined, preAssignedSessionId ?? undefined);
       await this.backend.sendKeys(sessionName, launchCmd);
 
       worker.status = 'running';
@@ -447,7 +447,7 @@ export class SessionManager {
 
     // For Claude, launch with --session-id; for others, use agentCommand as-is
     const launchCmd = agentType === 'claude'
-      ? buildAgentLaunchCommand(agentType, agentCommand, undefined, undefined, preAssignedSessionId ?? undefined)
+      ? buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined)
       : agentCommand;
     await this.backend.sendKeys(sessionName, launchCmd);
 
@@ -904,7 +904,7 @@ export class SessionManager {
 
       // Resume from stored session ID if available; otherwise fresh start
       const resumeCmd = storedSessionId
-        ? buildAgentResumeCommand(agentType, agentCommand, storedSessionId, repoRoot)
+        ? buildAgentResumeCommand(agentType, agentCommand, storedSessionId)
         : null;
 
       let postCreatePromise: Promise<void>;
@@ -923,7 +923,7 @@ export class SessionManager {
         // Fresh start — capture new session ID
         const preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
         const snapshot = this.snapshotAgentSessions(agentType, worktreePath);
-        const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, repoRoot, preAssignedSessionId ?? undefined);
+        const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
         await this.backend.sendKeys(sessionName, launchCmd);
         sessionId = preAssignedSessionId;
         postCreatePromise = this.postCreate(sessionName, agentType, worktreePath, snapshot, task, preAssignedSessionId);


### PR DESCRIPTION
## Summary
- Remove the `--add-dir` flag that pointed workers back to the original repo root
- Worktrees now live outside the repo (`~/.hydra/worktrees/`), so both directories have their own `.claude/skills/`, causing duplicate skill registration
- The worktree already contains all the code — `--add-dir` is unnecessary
- Remove the now-unused `repoRoot` parameter from `buildAgentLaunchCommand` and `buildAgentResumeCommand`

## Test plan
- [ ] Create a worker and verify `--add-dir` is no longer in the launch command
- [ ] Confirm `/skills` output shows no duplicates
- [ ] Verify copilots still launch correctly (they already didn't use `--add-dir`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)