### PR TITLE
feat: cleaner session name display for copilots and workers

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -21,6 +21,7 @@ export function registerListCommand(program: Command): void {
 
         const data = {
           copilots: copilots.map(c => ({
+            name: c.displayName || c.sessionName || c.tmuxSession,
             session: c.sessionName || c.tmuxSession,
             agent: c.agent,
             status: c.status,
@@ -29,6 +30,7 @@ export function registerListCommand(program: Command): void {
           })),
           workers: workers.map(w => ({
             number: w.workerId,
+            name: w.displayName || w.slug || w.sessionName || w.tmuxSession,
             session: w.sessionName || w.tmuxSession,
             repo: w.repo || null,
             branch: w.branch || null,
@@ -57,7 +59,7 @@ export function registerListCommand(program: Command): void {
                 ? (c.status === 'running' ? '\x1b[32m\u25CF\x1b[0m' : '\u25CB')
                 : `[${c.status}]`;
               const attached = c.attached ? ' (attached)' : '';
-              const name = c.sessionName || c.tmuxSession;
+              const name = c.displayName || c.sessionName || c.tmuxSession;
               console.log(`  ${statusIcon} ${name}  [${c.agent}]${attached}`);
               if (c.workdir) console.log(`    workdir: ${c.workdir}`);
             }
@@ -91,7 +93,7 @@ export function registerListCommand(program: Command): void {
                   : `[${w.status}]`;
                 const attached = w.attached ? ' (attached)' : '';
                 const branch = w.branch ? ` (${w.branch})` : '';
-                const name = w.sessionName || w.tmuxSession;
+                const name = w.displayName || w.slug || w.sessionName || w.tmuxSession;
                 const num = w.workerId != null ? `#${w.workerId} ` : '';
                 console.log(`    ${statusIcon} ${num}${name}${branch}  [${w.agent}]${attached}`);
                 if (w.workdir) console.log(`      workdir: ${w.workdir}`);

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -32,6 +32,8 @@ export function lookupWorkerId(sessionName: string): number | undefined {
 
 export interface WorkerInfo {
   sessionName: string;
+  /** Human-friendly name for display (the branch slug without the hash prefix). */
+  displayName: string;
   workerId: number;
   repo: string;
   repoRoot: string;
@@ -49,6 +51,8 @@ export interface WorkerInfo {
 
 export interface CopilotInfo {
   sessionName: string;
+  /** Human-friendly name for display (the user-given copilot name). */
+  displayName: string;
   status: 'running' | 'stopped';
   attached: boolean;
   agent: string;
@@ -81,6 +85,8 @@ export interface CreateWorkerOpts {
 export interface CreateCopilotOpts {
   workdir: string;
   agentType?: string;
+  /** User-given name for the copilot (used as displayName). */
+  name?: string;
   sessionName?: string;
   agentCommand?: string;
 }
@@ -157,13 +163,15 @@ export class SessionManager {
         if (workdir) {
           repoRoot = coreGit.resolveRepoRootFromWorktreePath(workdir) || '';
         }
+        const slug = this.extractSlugFromSessionName(session.name);
         state.workers[session.name] = {
           sessionName: session.name,
+          displayName: slug,
           workerId: state.nextWorkerId++,
           repo: repoRoot ? path.basename(repoRoot) : 'unknown',
           repoRoot,
           branch: '',
-          slug: this.extractSlugFromSessionName(session.name),
+          slug,
           status: 'running',
           attached: session.attached,
           agent,
@@ -176,6 +184,7 @@ export class SessionManager {
       } else if (role === 'copilot') {
         state.copilots[session.name] = {
           sessionName: session.name,
+          displayName: session.name,
           status: 'running',
           attached: session.attached,
           agent,
@@ -298,6 +307,7 @@ export class SessionManager {
 
     const workerInfo: WorkerInfo = {
       sessionName,
+      displayName: finalSlug,
       workerId,
       repo: coreGit.getRepoName(repoRoot),
       repoRoot,
@@ -427,6 +437,7 @@ export class SessionManager {
 
     const agentType = opts.agentType || 'claude';
     const agentCommand = opts.agentCommand || DEFAULT_AGENT_COMMANDS[agentType] || agentType;
+    const displayName = opts.name || opts.sessionName || `hydra-copilot-${agentType}`;
     const sessionName = opts.sessionName || this.backend.sanitizeSessionName(`hydra-copilot-${agentType}`);
 
     const exists = await this.backend.hasSession(sessionName);
@@ -451,6 +462,7 @@ export class SessionManager {
     const now = new Date().toISOString();
     const copilotInfo: CopilotInfo = {
       sessionName,
+      displayName,
       status: 'running',
       attached: false,
       agent: agentType,
@@ -563,6 +575,7 @@ export class SessionManager {
     const worktreeMoved = newSlug !== worker.slug && fs.existsSync(newWorktreePath);
     delete state.workers[oldSessionName];
     worker.sessionName = newSessionName;
+    worker.displayName = newSlug;
     worker.tmuxSession = newSessionName;
     worker.branch = newBranchName;
     worker.slug = newSlug;
@@ -603,6 +616,7 @@ export class SessionManager {
     // Update sessions.json
     delete state.copilots[oldSessionName];
     copilot.sessionName = newSessionName;
+    copilot.displayName = newSessionName;
     copilot.tmuxSession = newSessionName;
     state.copilots[newSessionName] = copilot;
     state.updatedAt = new Date().toISOString();
@@ -633,11 +647,13 @@ export class SessionManager {
     agentType: string,
     workdir: string,
     sessionId: string | null,
+    displayName?: string,
   ): void {
     const state = this.readSessionState();
     const now = new Date().toISOString();
     state.copilots[sessionName] = {
       sessionName,
+      displayName: displayName || state.copilots[sessionName]?.displayName || sessionName,
       status: 'running',
       attached: false,
       agent: agentType,
@@ -673,12 +689,14 @@ export class SessionManager {
           nextWorkerId: parsed.nextWorkerId || 1,
           updatedAt: parsed.updatedAt || new Date().toISOString(),
         };
-        // Backward compat: ensure sessionId field exists for legacy entries
+        // Backward compat: ensure sessionId and displayName fields exist for legacy entries
         for (const w of Object.values(state.workers)) {
           w.sessionId ??= null;
+          w.displayName ??= w.slug || this.extractSlugFromSessionName(w.sessionName);
         }
         for (const c of Object.values(state.copilots)) {
           c.sessionId ??= null;
+          c.displayName ??= c.sessionName;
         }
         return state;
       }
@@ -862,6 +880,7 @@ export class SessionManager {
 
       const workerInfo: WorkerInfo = {
         sessionName,
+        displayName: slug,
         workerId,
         repo: coreGit.getRepoName(repoRoot),
         repoRoot,
@@ -936,6 +955,7 @@ export class SessionManager {
 
       const workerInfo: WorkerInfo = {
         sessionName,
+        displayName: slug,
         workerId,
         repo: coreGit.getRepoName(repoRoot),
         repoRoot,

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -288,12 +288,13 @@ export class CopilotItem extends TmuxItem {
 
   constructor(opts: {
     sessionName: string;
+    displayName?: string;
     agentType: string;
     worktreePath?: string;
     classification: Classification;
   }) {
-    const label = `${opts.agentType}`;
-    const description = opts.worktreePath ? path.basename(opts.worktreePath) : undefined;
+    const label = opts.displayName || opts.sessionName;
+    const description = `[${opts.agentType}]`;
     super(label, vscode.TreeItemCollapsibleState.Expanded, undefined, opts.sessionName);
 
     this.worktreePath = opts.worktreePath;
@@ -720,6 +721,7 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
         }
         items.push(new CopilotItem({
           sessionName: c.sessionName,
+          displayName: c.displayName,
           agentType: c.agent,
           worktreePath: c.workdir,
           classification,


### PR DESCRIPTION
## Summary
- Add `displayName` field to `WorkerInfo` and `CopilotInfo` interfaces for human-friendly display
- Copilots now show their given name (e.g. `hydra-copilot-claude`) instead of just the agent type (`claude`) in both CLI and sidebar
- Workers now show just the branch slug (e.g. `feat-auth`) instead of the full session name with hash prefix (e.g. `hydra-ab12cd34_feat-auth`) in CLI list output
- Internal session names with hash prefix are preserved for tmux collision safety
- Backward-compatible: legacy entries without `displayName` are backfilled from existing fields

## Test plan
- [ ] Run `hydra list` — copilots should show their name, workers should show slug not full session name
- [ ] Create a new worker — verify `displayName` is set to the slug
- [ ] Create a new copilot — verify `displayName` is the given name
- [ ] Rename a worker — verify `displayName` updates to new slug
- [ ] Check sidebar — copilot label should be the display name with `[agent]` as description

🤖 Generated with [Claude Code](https://claude.com/claude-code)