### PR TITLE
ci: use PAT for auto-tag to trigger publish workflow

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Detect version change
         id: version


### PR DESCRIPTION
## Summary
- Tags pushed with the default `GITHUB_TOKEN` don't trigger other workflows (GitHub Actions limitation)
- Use `RELEASE_TOKEN` (a fine-grained PAT) in the checkout step so `git push` uses it for tag creation
- This ensures the publish workflow fires automatically when a version bump lands on main

## Test plan
- [x] Added `RELEASE_TOKEN` secret to the repo
- [ ] Next release PR merge should trigger both auto-tag AND publish workflows automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)