### PR TITLE
feat: store copilotSessionId in worker metadata

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -38,7 +38,7 @@ export function registerListCommand(program: Command): void {
             status: w.status,
             attached: w.attached,
             workdir: w.workdir || null,
-            copilotSessionId: w.copilotSessionId || null,
+            copilotSessionName: w.copilotSessionName || null,
           })),
           count: copilots.length + workers.length,
         };

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -38,6 +38,7 @@ export function registerListCommand(program: Command): void {
             status: w.status,
             attached: w.attached,
             workdir: w.workdir || null,
+            copilotSessionId: w.copilotSessionId || null,
           })),
           count: copilots.length + workers.length,
         };

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -16,6 +16,7 @@ interface WhoamiResult {
   workerId?: number;
   branch?: string;
   repo?: string;
+  copilotSessionName?: string | null;
 }
 
 export function registerWhoamiCommand(program: Command): void {
@@ -44,6 +45,7 @@ export function registerWhoamiCommand(program: Command): void {
             workerId: worker.workerId,
             branch: worker.branch,
             repo: worker.repo,
+            copilotSessionName: worker.copilotSessionName,
           };
 
           outputResult(data as unknown as Record<string, unknown>, globalOpts, () => {
@@ -91,6 +93,7 @@ function prettyPrintWorker(worker: WorkerInfo): void {
   console.log(`  Repo:        ${worker.repo}`);
   console.log(`  Agent:       ${worker.agent}`);
   console.log(`  Session ID:  ${worker.sessionId ?? '(none)'}`);
+  console.log(`  Copilot:     ${worker.copilotSessionName ?? '(none)'}`);
   console.log(`  Workdir:     ${worker.workdir}`);
   console.log(`  Status:      ${worker.status}`);
   console.log('');

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -24,6 +24,7 @@ export function registerWorkerCommands(program: Command): void {
     .option('--base <branch>', 'Base branch override')
     .option('--task <prompt>', 'Task prompt for the agent')
     .option('--task-file <path>', 'Path to a file containing the task description')
+    .option('--copilot <session>', 'Session ID of the parent copilot')
     .action(async (opts: {
       repo: string;
       branch: string;
@@ -31,6 +32,7 @@ export function registerWorkerCommands(program: Command): void {
       base?: string;
       task?: string;
       taskFile?: string;
+      copilot?: string;
     }) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -50,6 +52,7 @@ export function registerWorkerCommands(program: Command): void {
           baseBranchOverride: opts.base,
           task: opts.task,
           taskFile: opts.taskFile,
+          copilotSessionId: opts.copilot,
         });
 
         const status = branchExisted ? 'exists' : 'created';

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -1,11 +1,11 @@
 import * as path from 'path';
-import { resolve } from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
 import { getRepoRootFromPath, localBranchExists } from '../../core/git';
 import { toCanonicalPath } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
+import { detectIdentity } from '../identity';
 
 function expandPath(p: string): string {
   return toCanonicalPath(p) || path.resolve(p);
@@ -49,14 +49,9 @@ export function registerWorkerCommands(program: Command): void {
         // Auto-detect parent copilot if --copilot not explicitly set
         let copilotSessionName = opts.copilot;
         if (!copilotSessionName) {
-          const state = await sm.sync();
-          const cwd = resolve(process.cwd());
-          for (const copilot of Object.values(state.copilots)) {
-            const copilotDir = resolve(copilot.workdir);
-            if (cwd === copilotDir || cwd.startsWith(copilotDir + '/')) {
-              copilotSessionName = copilot.sessionName;
-              break;
-            }
+          const identity = detectIdentity();
+          if (identity?.role === 'copilot') {
+            copilotSessionName = identity.sessionName;
           }
         }
 

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { resolve } from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
@@ -24,7 +25,7 @@ export function registerWorkerCommands(program: Command): void {
     .option('--base <branch>', 'Base branch override')
     .option('--task <prompt>', 'Task prompt for the agent')
     .option('--task-file <path>', 'Path to a file containing the task description')
-    .option('--copilot <session>', 'Session ID of the parent copilot')
+    .option('--copilot <session>', 'Session name of the parent copilot (auto-detected if inside a copilot)')
     .action(async (opts: {
       repo: string;
       branch: string;
@@ -45,6 +46,20 @@ export function registerWorkerCommands(program: Command): void {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
 
+        // Auto-detect parent copilot if --copilot not explicitly set
+        let copilotSessionName = opts.copilot;
+        if (!copilotSessionName) {
+          const state = await sm.sync();
+          const cwd = resolve(process.cwd());
+          for (const copilot of Object.values(state.copilots)) {
+            const copilotDir = resolve(copilot.workdir);
+            if (cwd === copilotDir || cwd.startsWith(copilotDir + '/')) {
+              copilotSessionName = copilot.sessionName;
+              break;
+            }
+          }
+        }
+
         const { workerInfo, postCreatePromise } = await sm.createWorker({
           repoRoot,
           branchName: opts.branch,
@@ -52,7 +67,7 @@ export function registerWorkerCommands(program: Command): void {
           baseBranchOverride: opts.base,
           task: opts.task,
           taskFile: opts.taskFile,
-          copilotSessionName: opts.copilot,
+          copilotSessionName,
         });
 
         const status = branchExisted ? 'exists' : 'created';

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -52,7 +52,7 @@ export function registerWorkerCommands(program: Command): void {
           baseBranchOverride: opts.base,
           task: opts.task,
           taskFile: opts.taskFile,
-          copilotSessionId: opts.copilot,
+          copilotSessionName: opts.copilot,
         });
 
         const status = branchExisted ? 'exists' : 'created';

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,86 @@
+import { resolve } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import * as os from 'os';
+
+const SESSIONS_FILE = join(os.homedir(), '.hydra', 'sessions.json');
+
+export interface HydraIdentity {
+  role: 'worker' | 'copilot';
+  sessionName: string;
+  displayName: string;
+  agent: string;
+  sessionId: string | null;
+  workdir: string;
+  /** Worker-specific fields */
+  workerId?: number;
+  branch?: string;
+  repo?: string;
+  copilotSessionName?: string | null;
+}
+
+/**
+ * Lightweight identity detection — reads sessions.json (no tmux sync)
+ * and matches cwd against known session workdirs.
+ * Returns null if not running inside a known Hydra session.
+ */
+export function detectIdentity(cwd?: string): HydraIdentity | null {
+  const dir = resolve(cwd || process.cwd());
+
+  interface RawSession {
+    sessionName?: string;
+    displayName?: string;
+    agent?: string;
+    sessionId?: string | null;
+    workdir?: string;
+    status?: string;
+    workerId?: number;
+    branch?: string;
+    repo?: string;
+    copilotSessionName?: string | null;
+  }
+
+  let state: { copilots?: Record<string, RawSession>; workers?: Record<string, RawSession> };
+  try {
+    if (!existsSync(SESSIONS_FILE)) return null;
+    state = JSON.parse(readFileSync(SESSIONS_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  // Check copilots first (a copilot spawning workers is the primary use case)
+  for (const copilot of Object.values(state.copilots || {})) {
+    const copilotDir = resolve(copilot.workdir || '');
+    if (dir === copilotDir || dir.startsWith(copilotDir + '/')) {
+      return {
+        role: 'copilot',
+        sessionName: copilot.sessionName || '',
+        displayName: copilot.displayName || copilot.sessionName || '',
+        agent: copilot.agent || 'unknown',
+        sessionId: copilot.sessionId ?? null,
+        workdir: copilot.workdir || '',
+      };
+    }
+  }
+
+  // Check workers
+  for (const worker of Object.values(state.workers || {})) {
+    const workerDir = resolve(worker.workdir || '');
+    if (dir === workerDir || dir.startsWith(workerDir + '/')) {
+      return {
+        role: 'worker',
+        sessionName: worker.sessionName || '',
+        displayName: worker.displayName || worker.sessionName || '',
+        agent: worker.agent || 'unknown',
+        sessionId: worker.sessionId ?? null,
+        workdir: worker.workdir || '',
+        workerId: worker.workerId,
+        branch: worker.branch,
+        repo: worker.repo,
+        copilotSessionName: worker.copilotSessionName ?? null,
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -48,6 +48,8 @@ export interface WorkerInfo {
   createdAt: string;
   lastSeenAt: string;
   sessionId: string | null;
+  /** Session ID of the copilot that spawned this worker, if any. */
+  copilotSessionId: string | null;
 }
 
 export interface CopilotInfo {
@@ -95,6 +97,8 @@ export interface CreateWorkerOpts {
   agentCommand?: string;
   /** When set, launch the agent with --resume instead of a fresh session. */
   resumeSessionId?: string;
+  /** Session ID of the copilot that spawned this worker. */
+  copilotSessionId?: string;
 }
 
 export interface CreateCopilotOpts {
@@ -197,6 +201,7 @@ export class SessionManager {
           createdAt: now,
           lastSeenAt: now,
           sessionId: null,
+          copilotSessionId: null,
         };
       } else if (role === 'copilot') {
         state.copilots[session.name] = {
@@ -356,6 +361,7 @@ export class SessionManager {
       createdAt: now,
       lastSeenAt: now,
       sessionId: preAssignedSessionId,
+      copilotSessionId: opts.copilotSessionId || null,
     };
 
     state.workers[sessionName] = workerInfo;
@@ -1091,6 +1097,7 @@ export class SessionManager {
         createdAt: now,
         lastSeenAt: now,
         sessionId: existingWorker?.sessionId ?? null,
+        copilotSessionId: existingWorker?.copilotSessionId ?? null,
       };
 
       state.workers[sessionName] = workerInfo;
@@ -1166,6 +1173,7 @@ export class SessionManager {
         createdAt: now,
         lastSeenAt: now,
         sessionId,
+        copilotSessionId: existingWorker?.copilotSessionId ?? null,
       };
 
       state.workers[sessionName] = workerInfo;

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -48,8 +48,8 @@ export interface WorkerInfo {
   createdAt: string;
   lastSeenAt: string;
   sessionId: string | null;
-  /** Session ID of the copilot that spawned this worker, if any. */
-  copilotSessionId: string | null;
+  /** Session name of the copilot that spawned this worker, if any. */
+  copilotSessionName: string | null;
 }
 
 export interface CopilotInfo {
@@ -97,8 +97,8 @@ export interface CreateWorkerOpts {
   agentCommand?: string;
   /** When set, launch the agent with --resume instead of a fresh session. */
   resumeSessionId?: string;
-  /** Session ID of the copilot that spawned this worker. */
-  copilotSessionId?: string;
+  /** Session name of the copilot that spawned this worker. */
+  copilotSessionName?: string;
 }
 
 export interface CreateCopilotOpts {
@@ -201,7 +201,7 @@ export class SessionManager {
           createdAt: now,
           lastSeenAt: now,
           sessionId: null,
-          copilotSessionId: null,
+          copilotSessionName: null,
         };
       } else if (role === 'copilot') {
         state.copilots[session.name] = {
@@ -361,7 +361,7 @@ export class SessionManager {
       createdAt: now,
       lastSeenAt: now,
       sessionId: preAssignedSessionId,
-      copilotSessionId: opts.copilotSessionId || null,
+      copilotSessionName: opts.copilotSessionName || null,
     };
 
     state.workers[sessionName] = workerInfo;
@@ -1097,7 +1097,7 @@ export class SessionManager {
         createdAt: now,
         lastSeenAt: now,
         sessionId: existingWorker?.sessionId ?? null,
-        copilotSessionId: existingWorker?.copilotSessionId ?? null,
+        copilotSessionName: existingWorker?.copilotSessionName ?? null,
       };
 
       state.workers[sessionName] = workerInfo;
@@ -1173,7 +1173,7 @@ export class SessionManager {
         createdAt: now,
         lastSeenAt: now,
         sessionId,
-        copilotSessionId: existingWorker?.copilotSessionId ?? null,
+        copilotSessionName: existingWorker?.copilotSessionName ?? null,
       };
 
       state.workers[sessionName] = workerInfo;


### PR DESCRIPTION
## Summary
- Add `copilotSessionId` field to `WorkerInfo` interface so workers know which copilot spawned them
- Accept `--copilot <session>` flag in `hydra worker create` CLI command
- Expose the field in `hydra list --json` output for workers
- Preserve the field through worker resume/restart flows

## Test plan
- [ ] Run `hydra worker create --repo . --branch test --copilot <session-id>` and verify `sessions.json` contains the copilotSessionId
- [ ] Run `hydra list --json` and verify the copilotSessionId appears in worker entries
- [ ] Resume a worker and confirm copilotSessionId is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)