### PR TITLE
fix: ensure consistent Hydra icon on all terminal tabs

### DIFF
--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -45,7 +45,12 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
       // For editor locations, reuse if both are editor-area targets
       const existingIsEditor = options?.location !== vscode.TerminalLocation.Panel;
       const requestedIsEditor = resolvedLocation !== vscode.TerminalLocation.Panel;
-      if (options && existingIsEditor === requestedIsEditor) {
+      // Also verify the terminal has the Hydra icon and the expected name.
+      // Legacy terminals (created before icons were added, or restored by VS Code
+      // persistence) may lack the icon or use an outdated name format.
+      const hasCorrectIcon = Boolean(options?.iconPath);
+      const hasCorrectName = existing.name === terminalName;
+      if (options && existingIsEditor === requestedIsEditor && hasCorrectIcon && hasCorrectName) {
         existing.show();
         return existing;
       }


### PR DESCRIPTION
## Summary
- When reusing an existing terminal in `TmuxBackend.attachSession()`, also verify it has the Hydra icon (`iconPath`) and the expected name format before reusing
- Legacy terminals (created before icons were added, restored by VS Code persistence, or matching on outdated name patterns like bare `Worker:`) are now disposed and recreated with the correct icon instead of being silently reused as-is

Fixes #84

## Test plan
- [ ] Create multiple workers — all tabs should show the Hydra icon
- [ ] Reload VS Code window — after auto-attach, all tabs should still show the Hydra icon
- [ ] Click "Attach in Editor" from context menu — tab should have the Hydra icon
- [ ] Verify no regression: clicking an already-open worker tab still shows it without flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)