### PR TITLE
feat: add `hydra whoami` CLI subcommand

### DIFF
--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,0 +1,108 @@
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { type OutputOpts, outputResult } from '../output';
+import { SessionManager, type WorkerInfo, type CopilotInfo } from '../../core/sessionManager';
+import { TmuxBackendCore } from '../../core/tmux';
+
+interface WhoamiResult {
+  role: 'worker' | 'copilot';
+  sessionName: string;
+  displayName: string;
+  agent: string;
+  sessionId: string | null;
+  workdir: string;
+  status: string;
+  // Worker-specific
+  workerId?: number;
+  branch?: string;
+  repo?: string;
+}
+
+export function registerWhoamiCommand(program: Command): void {
+  program
+    .command('whoami')
+    .description('Report the copilot/worker/worktree context of the current working directory')
+    .action(async () => {
+      const globalOpts = program.opts() as OutputOpts;
+      const cwd = resolve(process.cwd());
+
+      const backend = new TmuxBackendCore();
+      const sm = new SessionManager(backend);
+      const state = await sm.sync();
+
+      // Match cwd against worker workdirs
+      for (const worker of Object.values(state.workers)) {
+        if (cwd === resolve(worker.workdir) || cwd.startsWith(resolve(worker.workdir) + '/')) {
+          const data: WhoamiResult = {
+            role: 'worker',
+            sessionName: worker.sessionName,
+            displayName: worker.displayName,
+            agent: worker.agent,
+            sessionId: worker.sessionId,
+            workdir: worker.workdir,
+            status: worker.status,
+            workerId: worker.workerId,
+            branch: worker.branch,
+            repo: worker.repo,
+          };
+
+          outputResult(data as unknown as Record<string, unknown>, globalOpts, () => {
+            prettyPrintWorker(worker);
+          });
+          return;
+        }
+      }
+
+      // Match cwd against copilot workdirs
+      for (const copilot of Object.values(state.copilots)) {
+        if (cwd === resolve(copilot.workdir) || cwd.startsWith(resolve(copilot.workdir) + '/')) {
+          const data: WhoamiResult = {
+            role: 'copilot',
+            sessionName: copilot.sessionName,
+            displayName: copilot.displayName,
+            agent: copilot.agent,
+            sessionId: copilot.sessionId,
+            workdir: copilot.workdir,
+            status: copilot.status,
+          };
+
+          outputResult(data as unknown as Record<string, unknown>, globalOpts, () => {
+            prettyPrintCopilot(copilot);
+          });
+          return;
+        }
+      }
+
+      // Not in a hydra session
+      if (globalOpts.json) {
+        console.log(JSON.stringify({ role: null, message: 'Not running inside a Hydra session.' }));
+      } else if (!globalOpts.quiet) {
+        console.log('Not running inside a Hydra session.');
+      }
+    });
+}
+
+function prettyPrintWorker(worker: WorkerInfo): void {
+  console.log('');
+  console.log(`  Role:        worker`);
+  console.log(`  Session:     ${worker.sessionName}`);
+  console.log(`  Worker #:    ${worker.workerId}`);
+  console.log(`  Branch:      ${worker.branch}`);
+  console.log(`  Repo:        ${worker.repo}`);
+  console.log(`  Agent:       ${worker.agent}`);
+  console.log(`  Session ID:  ${worker.sessionId ?? '(none)'}`);
+  console.log(`  Workdir:     ${worker.workdir}`);
+  console.log(`  Status:      ${worker.status}`);
+  console.log('');
+}
+
+function prettyPrintCopilot(copilot: CopilotInfo): void {
+  console.log('');
+  console.log(`  Role:        copilot`);
+  console.log(`  Session:     ${copilot.sessionName}`);
+  console.log(`  Agent:       ${copilot.agent}`);
+  console.log(`  Session ID:  ${copilot.sessionId ?? '(none)'}`);
+  console.log(`  Workdir:     ${copilot.workdir}`);
+  console.log(`  Status:      ${copilot.status}`);
+  console.log('');
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { registerWorkerCommands } from './commands/worker';
 import { registerCopilotCommands } from './commands/copilot';
 import { registerArchiveCommands } from './commands/archive';
 import { registerDoctorCommand } from './commands/doctor';
+import { registerWhoamiCommand } from './commands/whoami';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
 
@@ -30,5 +31,6 @@ registerWorkerCommands(program);
 registerCopilotCommands(program);
 registerArchiveCommands(program);
 registerDoctorCommand(program);
+registerWhoamiCommand(program);
 
 program.parse();


### PR DESCRIPTION
## Summary

- Adds `hydra whoami` command that reports the copilot/worker/worktree context of the current working directory
- Matches cwd against sessions.json worker/copilot workdir paths to determine identity
- Supports `--json` flag for programmatic access by agents needing to discover their own session name, ID, role, etc.

## Test plan

- [ ] Run `hydra whoami` inside a worker worktree — should show worker info
- [ ] Run `hydra whoami` inside a copilot workdir — should show copilot info
- [ ] Run `hydra whoami` outside any session — should print "Not running inside a Hydra session."
- [ ] Run `hydra whoami --json` — should output structured JSON
- [ ] Pipe output (non-TTY) — should auto-enable JSON mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)