### PR TITLE
feat: auto-reveal sidebar item when terminal tab is focused

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { CopilotProvider, WorkerProvider } from './providers/tmuxSessionProvider';
+import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
 import { attachCreate } from './commands/attachCreate';
 import { removeTask } from './commands/removeTask';
 import { autoAttachOnStartup } from './commands/autoAttach';
@@ -18,6 +18,8 @@ import { createCopilot, createCopilotWithAgent } from './commands/createCopilot'
 import { ensureHydraGlobalConfig } from './utils/hydraGlobalConfig';
 import { installCli, ensurePathInShellProfile } from './core/cliInstaller';
 import { detectAvailableAgents } from './utils/agentConfig';
+import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } from './utils/hydraEditorGroup';
+import { lookupWorkerId } from './core/sessionManager';
 
 export function activate(context: vscode.ExtensionContext) {
   const copilotProvider = new CopilotProvider();
@@ -73,6 +75,10 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.window.onDidChangeWindowState((e) => {
         if (e.focused) refreshAll();
+    }),
+    vscode.window.onDidChangeActiveTerminal((terminal) => {
+      if (!terminal) return;
+      revealSidebarItem(terminal, copilotProvider, workerProvider, copilotView, workerView);
     })
   );
 
@@ -83,6 +89,47 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push({
       dispose: () => clearInterval(intervalId)
   });
+}
+
+function getShortName(sessionName: string): string {
+  const parts = sessionName.split('_');
+  return parts.length > 1 ? parts.slice(1).join('_') : sessionName;
+}
+
+function revealSidebarItem(
+  terminal: vscode.Terminal,
+  copilotProvider: CopilotProvider,
+  workerProvider: WorkerProvider,
+  copilotView: vscode.TreeView<TmuxItem>,
+  workerView: vscode.TreeView<TmuxItem>
+): void {
+  const name = terminal.name;
+
+  if (name.startsWith(HYDRA_PREFIX_COPILOT)) {
+    const items = copilotProvider.getRootItemsCached();
+    const found = items.find(item => {
+      if (!item.sessionName) return false;
+      const shortName = getShortName(item.sessionName);
+      return name === buildHydraTerminalName(shortName, 'copilot');
+    });
+    if (found) {
+      copilotView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
+    }
+    return;
+  }
+
+  if (name.startsWith(HYDRA_PREFIX_WORKER)) {
+    const items = workerProvider.getWorkerItems();
+    const found = items.find(item => {
+      if (!item.sessionName) return false;
+      const shortName = getShortName(item.sessionName);
+      const workerId = lookupWorkerId(item.sessionName);
+      return name === buildHydraTerminalName(shortName, 'worker', workerId);
+    });
+    if (found) {
+      workerView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
+    }
+  }
 }
 
 async function detectAndSetAgentContext(): Promise<void> {

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -693,10 +693,18 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
   private _onDidChangeTreeData = new vscode.EventEmitter<TmuxItem | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private _extensionUri: vscode.Uri | undefined;
+  private _rootItems: CopilotItem[] = [];
 
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
   refresh(): void { this._onDidChangeTreeData.fire(undefined); }
   getTreeItem(element: TmuxItem): vscode.TreeItem { return element; }
+  getParent(element: TmuxItem): TmuxItem | undefined {
+    if (element instanceof CopilotItem) return undefined;
+    // Detail items are children of CopilotItems
+    return this._rootItems.find(c => c.sessionName === element.sessionName);
+  }
+
+  getRootItemsCached(): CopilotItem[] { return this._rootItems; }
 
   async getChildren(element?: TmuxItem): Promise<TmuxItem[]> {
     if (!element) return this.getRootItems();
@@ -711,10 +719,11 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
       const copilots = await sm.listCopilots();
 
       if (copilots.length === 0) {
+        this._rootItems = [];
         return [];  // triggers viewsWelcome
       }
 
-      const items: TmuxItem[] = [];
+      const items: CopilotItem[] = [];
       for (const c of copilots) {
         let classification: Classification;
         if (c.status !== 'running') {
@@ -733,8 +742,10 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
         }));
       }
 
+      this._rootItems = items;
       return items;
     } catch {
+      this._rootItems = [];
       return [];
     }
   }
@@ -765,10 +776,39 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
   private _onDidChangeTreeData = new vscode.EventEmitter<TmuxItem | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private _extensionUri: vscode.Uri | undefined;
+  private _repoGroups: RepoGroupItem[] = [];
+  private _workerItemsByRepo = new Map<string, TmuxItem[]>();
 
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
   refresh(): void { this._onDidChangeTreeData.fire(undefined); }
   getTreeItem(element: TmuxItem): vscode.TreeItem { return element; }
+  getParent(element: TmuxItem): TmuxItem | undefined {
+    if (element instanceof RepoGroupItem) return undefined;
+    // WorktreeItem/TmuxSessionItem/InactiveWorktreeItem are children of a RepoGroupItem
+    if (element instanceof WorktreeItem || element instanceof InactiveWorktreeItem) {
+      return this._repoGroups.find(g => g.repoName === element.repoName);
+    }
+    // Detail items (TmuxDetailItem, GitStatusItem) are children of a WorktreeItem
+    for (const items of this._workerItemsByRepo.values()) {
+      for (const item of items) {
+        if (item instanceof TmuxSessionItem) {
+          if (item.detailItem === element || item.gitStatusItem === element) return item;
+        }
+        if (item instanceof InactiveWorktreeItem) {
+          if (item.detailItem === element || item.gitStatusItem === element) return item;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  getWorkerItems(): TmuxItem[] {
+    const all: TmuxItem[] = [];
+    for (const items of this._workerItemsByRepo.values()) {
+      all.push(...items);
+    }
+    return all;
+  }
 
   async getChildren(element?: TmuxItem): Promise<TmuxItem[]> {
     if (!element) return this.getRootItems();
@@ -793,6 +833,8 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       const workers = await sm.listWorkers();
 
       if (workers.length === 0) {
+        this._repoGroups = [];
+        this._workerItemsByRepo.clear();
         const hint = new TmuxItem('No workers', vscode.TreeItemCollapsibleState.None);
         hint.iconPath = new vscode.ThemeIcon('info');
         hint.description = 'Ask your copilot to create a worker';
@@ -812,14 +854,17 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
 
       // Always show RepoGroupItem per repo
-      const items: TmuxItem[] = [];
+      const items: RepoGroupItem[] = [];
       for (const group of byRepo.values()) {
         let baseBranch: string | undefined;
         try { baseBranch = await getBaseBranch(group.repoRoot); } catch { /* */ }
         items.push(new RepoGroupItem(group.repoName, group.repoRoot, baseBranch));
       }
+      this._repoGroups = items;
       return items;
     } catch {
+      this._repoGroups = [];
+      this._workerItemsByRepo.clear();
       return [];
     }
   }
@@ -829,7 +874,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       const backend = getActiveBackend();
       const sm = new SessionManager(backend);
       const workers = await sm.listWorkers(group.repoRoot);
-      return this.buildWorkerItems(workers, group.repoName, group.repoRoot);
+      const items = await this.buildWorkerItems(workers, group.repoName, group.repoRoot);
+      this._workerItemsByRepo.set(group.repoRoot, items);
+      return items;
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary
- Registers `onDidChangeActiveTerminal` listener to detect when a Hydra terminal tab gains focus
- Matches the terminal name against cached Copilot/Worker tree items using `buildHydraTerminalName`
- Calls `treeView.reveal()` to highlight the corresponding item in the sidebar
- Adds `getParent()` to both `CopilotProvider` and `WorkerProvider` (required by VS Code's reveal API)

## Test plan
- [ ] Open multiple copilot/worker terminal tabs
- [ ] Click between them and verify the sidebar highlights the matching item
- [ ] Verify non-Hydra terminals are ignored (no errors, no sidebar changes)
- [ ] Verify behavior when sidebar panel is collapsed (should auto-show)

🤖 Generated with [Claude Code](https://claude.com/claude-code)