### PR TITLE
chore: release v0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.1.30] - 2026-05-05
+
+### Added
+- Auto-reveal sidebar item when terminal tab is focused (#93)
+- Store copilotSessionId in worker metadata (#83)
+- `hydra whoami` CLI subcommand (#86)
+- `hydra doctor` CLI subcommand (#82)
+- Fetch latest from remote before creating worker/copilot (#70)
+
+### Changed
+- Route all session lifecycle through SessionManager (#91)
+- Split session creation into Phase 1 and Phase 2 (#87)
+- Use PAT for auto-tag to trigger publish workflow (#81)
+
+### Fixed
+- Use displayName for worker labels in sidebar (#89)
+- Ensure consistent Hydra icon on all worker/copilot terminal tabs (#85)
+- Poll for agent readiness before sending task prompt (#80)
+
 ## [0.1.29] - 2026-05-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Release v0.1.30

### Added
- Auto-reveal sidebar item when terminal tab is focused (#93)
- Store copilotSessionId in worker metadata (#83)
- `hydra whoami` CLI subcommand (#86)
- `hydra doctor` CLI subcommand (#82)
- Fetch latest from remote before creating worker/copilot (#70)

### Changed
- Route all session lifecycle through SessionManager (#91)
- Split session creation into Phase 1 and Phase 2 (#87)
- Use PAT for auto-tag to trigger publish workflow (#81)

### Fixed
- Use displayName for worker labels in sidebar (#89)
- Ensure consistent Hydra icon on all worker/copilot terminal tabs (#85)
- Poll for agent readiness before sending task prompt (#80)