### PR TITLE
Add copilot lifecycle CLI and harden tmux sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,175 +108,25 @@ hydra worker delete <session>                        # Clean up
 
 All commands support `--json` (auto-enabled when piped), `--quiet`, and `--no-interactive`.
 
-## CLI reference
+## CLI overview
 
-### `hydra list`
+- `hydra list` shows active copilots and workers.
+- `hydra worker ...` creates, inspects, messages, restarts, and deletes worker sessions.
+- `hydra copilot ...` creates, inspects, messages, renames, restores, and deletes copilot sessions.
+- `hydra archive ...` inspects archived sessions and restores them by name.
 
-List all copilots and workers.
+## CLI discovery
 
-```bash
-hydra list --json
-```
-
-```json
-{
-  "copilots": [
-    { "session": "hydra-copilot-claude", "agent": "claude", "status": "running", "attached": false, "workdir": "/path", "agentSessionId": "30a66510-bdf7-4942-8125-527005870bc9" }
-  ],
-  "workers": [
-    { "session": "hydra-ab12_feat-auth", "repo": "myapp", "branch": "feat/auth", "agent": "claude", "status": "running", "attached": false, "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
-  ],
-  "count": 2
-}
-```
-
-### `hydra worker create`
-
-Create a new worker (or resume if branch exists).
+Use the CLI itself as the source of truth:
 
 ```bash
-hydra worker create --repo <path> --branch <name> [--agent claude|codex|gemini] [--base <branch>] [--task "<prompt>"] [--task-file <path>]
+hydra --help
+hydra worker --help
+hydra copilot --help
+hydra archive --help
 ```
 
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--repo` | yes | | Path to the repository |
-| `--branch` | yes | | Branch name to create |
-| `--agent` | no | `claude` | Agent type |
-| `--base` | no | main/master | Base branch to fork from |
-| `--task` | no | | Task prompt sent to agent |
-| `--task-file` | no | | Path to markdown file with task details |
-
-```json
-{ "status": "created", "session": "hydra-ab12_feat-auth", "branch": "feat/auth", "agent": "claude", "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth" }
-```
-
-If the branch already exists, returns `"status": "exists"` and resumes.
-
-### `hydra worker logs <session>`
-
-Read terminal output from a worker.
-
-```bash
-hydra worker logs <session> --lines 50
-```
-
-```json
-{ "session": "hydra-ab12_feat-auth", "lines": 50, "output": "..." }
-```
-
-Default: 50 lines. Use `--lines 200` for deeper scrollback.
-
-### `hydra worker send <session> <message>`
-
-Send a message to a worker. Uses double-Enter for reliable delivery.
-
-```bash
-hydra worker send <session> "fix the type error in auth.ts"
-hydra worker send --all "run the test suite and report status"
-```
-
-```json
-{ "status": "sent", "session": "hydra-ab12_feat-auth", "message": "..." }
-{ "status": "sent", "sessions": ["session1", "session2"], "message": "..." }
-```
-
-### `hydra worker stop <session>`
-
-Kill the tmux session but keep the worktree (can restart later).
-
-```json
-{ "status": "stopped", "session": "hydra-ab12_feat-auth" }
-```
-
-### `hydra worker start <session>`
-
-Restart a stopped worker.
-
-```bash
-hydra worker start <session> [--agent <type>]
-```
-
-```json
-{ "status": "started", "session": "hydra-ab12_feat-auth", "agent": "claude", "workdir": "/path" }
-```
-
-### `hydra worker delete <session>`
-
-Kill session + remove worktree + delete branch. Irreversible.
-
-```json
-{ "status": "deleted", "session": "hydra-ab12_feat-auth" }
-```
-
-### `hydra copilot create`
-
-Create a new copilot.
-
-```bash
-hydra copilot create [--workdir <path>] [--agent claude|codex|gemini] [--name <display-name>] [--session <name>]
-```
-
-```json
-{ "status": "created", "session": "hydra-copilot-codex", "agent": "codex", "workdir": "/path", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
-```
-
-### `hydra copilot delete <session>`
-
-Delete a copilot (kill the tmux session and archive its metadata).
-
-```json
-{ "status": "deleted", "session": "hydra-copilot-codex" }
-```
-
-### `hydra copilot restore <session>`
-
-Restore an archived copilot by session name.
-
-```json
-{ "status": "restored", "type": "copilot", "session": "hydra-copilot-codex", "agent": "codex", "workdir": "/path", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
-```
-
-### `hydra copilot logs <session>`
-
-Read terminal output from a copilot.
-
-```bash
-hydra copilot logs <session> --lines 50
-```
-
-```json
-{ "session": "hydra-copilot-claude", "lines": 50, "output": "..." }
-```
-
-Default: 50 lines. Use `--lines 200` for deeper scrollback.
-
-### `hydra copilot send <session> <message>`
-
-Send a message to a copilot.
-
-```bash
-hydra copilot send <session> "review the workers and report status"
-```
-
-```json
-{ "status": "sent", "session": "hydra-copilot-claude", "message": "..." }
-```
-
-## Exit codes
-
-| Code | Meaning | Retryable |
-|------|---------|-----------|
-| 0 | Success | — |
-| 1 | Internal error | yes |
-| 2 | Validation error (bad input) | no |
-| 4 | Not found (session/worker) | no |
-| 5 | Conflict (already exists) | no |
-
-Error JSON (stderr):
-```json
-{ "error": { "code": 4, "message": "Worker not found", "retryable": false, "hint": "Use \"hydra list --json\" to see available sessions." } }
-```
+Prefer `--json` when scripting or when another agent will parse the output.
 
 ## Copilot workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ hydra copilot create --agent codex --workdir .      # Launch a copilot in the cu
 hydra worker create --repo . --branch feat/foo       # Spawn a worker
 hydra worker logs <session> --lines 30               # Read its output
 hydra worker send <session> "fix the failing test"   # Send instructions
-hydra copilot restore                                # Restore the most recent archived copilot
+hydra copilot restore <session>                      # Restore an archived copilot by session name
 hydra worker delete <session>                        # Clean up
 ```
 
@@ -229,9 +229,9 @@ Delete a copilot (kill the tmux session and archive its metadata).
 { "status": "deleted", "session": "hydra-copilot-codex" }
 ```
 
-### `hydra copilot restore`
+### `hydra copilot restore <session>`
 
-Restore the most recent archived copilot.
+Restore an archived copilot by session name.
 
 ```json
 { "status": "restored", "type": "copilot", "session": "hydra-copilot-codex", "agent": "codex", "workdir": "/path", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,9 +98,11 @@ The CLI is a thin wrapper that delegates to the extension's bundled Node.js code
 
 ```bash
 hydra list --json                                    # What's running?
+hydra copilot create --agent codex --workdir .      # Launch a copilot in the current directory
 hydra worker create --repo . --branch feat/foo       # Spawn a worker
 hydra worker logs <session> --lines 30               # Read its output
 hydra worker send <session> "fix the failing test"   # Send instructions
+hydra copilot restore                                # Restore the most recent archived copilot
 hydra worker delete <session>                        # Clean up
 ```
 
@@ -119,10 +121,10 @@ hydra list --json
 ```json
 {
   "copilots": [
-    { "session": "hydra-copilot-claude", "agent": "claude", "status": "running", "attached": false, "workdir": "/path" }
+    { "session": "hydra-copilot-claude", "agent": "claude", "status": "running", "attached": false, "workdir": "/path", "agentSessionId": "30a66510-bdf7-4942-8125-527005870bc9" }
   ],
   "workers": [
-    { "session": "hydra-ab12_feat-auth", "repo": "myapp", "branch": "feat/auth", "agent": "claude", "status": "running", "attached": false, "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth" }
+    { "session": "hydra-ab12_feat-auth", "repo": "myapp", "branch": "feat/auth", "agent": "claude", "status": "running", "attached": false, "workdir": "~/.hydra/worktrees/myapp-ab12cd34/feat-auth", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
   ],
   "count": 2
 }
@@ -205,6 +207,34 @@ Kill session + remove worktree + delete branch. Irreversible.
 
 ```json
 { "status": "deleted", "session": "hydra-ab12_feat-auth" }
+```
+
+### `hydra copilot create`
+
+Create a new copilot.
+
+```bash
+hydra copilot create [--workdir <path>] [--agent claude|codex|gemini] [--name <display-name>] [--session <name>]
+```
+
+```json
+{ "status": "created", "session": "hydra-copilot-codex", "agent": "codex", "workdir": "/path", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
+```
+
+### `hydra copilot delete <session>`
+
+Delete a copilot (kill the tmux session and archive its metadata).
+
+```json
+{ "status": "deleted", "session": "hydra-copilot-codex" }
+```
+
+### `hydra copilot restore`
+
+Restore the most recent archived copilot.
+
+```json
+{ "status": "restored", "type": "copilot", "session": "hydra-copilot-codex", "agent": "codex", "workdir": "/path", "agentSessionId": "019df6bd-8773-72a1-a0f1-eb5fc3ae6dbf" }
 ```
 
 ### `hydra copilot logs <session>`

--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -144,22 +144,25 @@ export function registerArchiveCommands(program: Command): void {
           );
           await postCreatePromise;
         } else {
-          const copilotInfo = await sm.restoreCopilot(sessionName);
+          const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(sessionName);
+          await postCreatePromise;
+          const state = await sm.sync();
+          const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;
           outputResult(
             {
               status: 'restored',
               type: 'copilot',
-              session: copilotInfo.sessionName,
-              agent: copilotInfo.agent,
-              workdir: copilotInfo.workdir,
-              agentSessionId: copilotInfo.sessionId,
+              session: finalCopilot.sessionName,
+              agent: finalCopilot.agent,
+              workdir: finalCopilot.workdir,
+              agentSessionId: finalCopilot.sessionId,
             },
             globalOpts,
             () => {
-              console.log(`Restored copilot: ${copilotInfo.sessionName}`);
-              console.log(`  Agent:      ${copilotInfo.agent}`);
-              console.log(`  Workdir:    ${copilotInfo.workdir}`);
-              console.log(`  Session ID: ${copilotInfo.sessionId || 'none'}`);
+              console.log(`Restored copilot: ${finalCopilot.sessionName}`);
+              console.log(`  Agent:      ${finalCopilot.agent}`);
+              console.log(`  Workdir:    ${finalCopilot.workdir}`);
+              console.log(`  Session ID: ${finalCopilot.sessionId || 'none'}`);
             },
           );
         }

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -6,7 +6,25 @@ import { toCanonicalPath } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 
 function expandPath(p: string): string {
-  return toCanonicalPath(p) || path.resolve(p);
+  const canonical = toCanonicalPath(p);
+  if (canonical) {
+    return canonical;
+  }
+
+  const trimmed = p.trim();
+  if (trimmed.startsWith('~')) {
+    throw new Error(`Could not resolve home-relative path: ${p}`);
+  }
+
+  return path.resolve(trimmed);
+}
+
+function requireSessionName(sessionName: string): string {
+  const trimmed = sessionName.trim();
+  if (!trimmed) {
+    throw new Error('Session name is required');
+  }
+  return trimmed;
 }
 
 export function registerCopilotCommands(program: Command): void {
@@ -62,14 +80,15 @@ export function registerCopilotCommands(program: Command): void {
     .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
+        const validatedSessionName = requireSessionName(sessionName);
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        await sm.deleteCopilot(sessionName);
+        await sm.deleteCopilot(validatedSessionName);
 
         outputResult(
-          { status: 'deleted', session: sessionName },
+          { status: 'deleted', session: validatedSessionName },
           globalOpts,
-          () => console.log(`Deleted copilot: ${sessionName}`),
+          () => console.log(`Deleted copilot: ${validatedSessionName}`),
         );
       } catch (error) {
         outputError(error, globalOpts);
@@ -82,12 +101,10 @@ export function registerCopilotCommands(program: Command): void {
     .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
+        const validatedSessionName = requireSessionName(sessionName);
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(sessionName);
-        await postCreatePromise;
-        const state = await sm.sync();
-        const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;
+        const finalCopilot = await sm.restoreCopilotAndFinalize(validatedSessionName);
 
         outputResult(
           {

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -1,12 +1,125 @@
+import * as path from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
+import { toCanonicalPath } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
+
+function expandPath(p: string): string {
+  return toCanonicalPath(p) || path.resolve(p);
+}
 
 export function registerCopilotCommands(program: Command): void {
   const copilot = program
     .command('copilot')
     .description('Manage Hydra copilots');
+
+  copilot
+    .command('create')
+    .description('Create a new copilot')
+    .option('--workdir <path>', 'Working directory for the copilot', process.cwd())
+    .option('--agent <type>', 'Agent type (claude, codex, gemini)', 'claude')
+    .option('--name <name>', 'Display name for the copilot session')
+    .option('--session <name>', 'Explicit tmux session name')
+    .action(async (opts: { workdir: string; agent: string; name?: string; session?: string }) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const requestedSession = opts.session || opts.name || `hydra-copilot-${opts.agent}`;
+        const sessionName = backend.sanitizeSessionName(requestedSession);
+        const { copilotInfo, postCreatePromise } = await sm.createCopilot({
+          workdir: expandPath(opts.workdir),
+          agentType: opts.agent,
+          name: opts.name,
+          sessionName,
+        });
+
+        await postCreatePromise;
+        const state = await sm.sync();
+        const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;
+
+        outputResult(
+          {
+            status: 'created',
+            session: finalCopilot.sessionName,
+            agent: finalCopilot.agent,
+            workdir: finalCopilot.workdir,
+            agentSessionId: finalCopilot.sessionId,
+          },
+          globalOpts,
+          () => {
+            console.log(`Created copilot: ${finalCopilot.sessionName}`);
+            console.log(`  Agent:      ${finalCopilot.agent}`);
+            console.log(`  Workdir:    ${finalCopilot.workdir}`);
+            console.log(`  Session ID: ${finalCopilot.sessionId || 'none'}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  copilot
+    .command('delete <session>')
+    .description('Delete a copilot (kill session + archive metadata)')
+    .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        await sm.deleteCopilot(sessionName);
+
+        outputResult(
+          { status: 'deleted', session: sessionName },
+          globalOpts,
+          () => console.log(`Deleted copilot: ${sessionName}`),
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  copilot
+    .command('restore')
+    .description('Restore the most recent archived copilot')
+    .action(async () => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const entry = [...sm.listArchived()].reverse().find((candidate) => candidate.type === 'copilot');
+
+        if (!entry) {
+          throw new Error('No archived copilot found');
+        }
+
+        const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(entry.sessionName);
+        await postCreatePromise;
+        const state = await sm.sync();
+        const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;
+
+        outputResult(
+          {
+            status: 'restored',
+            type: 'copilot',
+            session: finalCopilot.sessionName,
+            agent: finalCopilot.agent,
+            workdir: finalCopilot.workdir,
+            agentSessionId: finalCopilot.sessionId,
+          },
+          globalOpts,
+          () => {
+            console.log(`Restored copilot: ${finalCopilot.sessionName}`);
+            console.log(`  Agent:      ${finalCopilot.agent}`);
+            console.log(`  Workdir:    ${finalCopilot.workdir}`);
+            console.log(`  Session ID: ${finalCopilot.sessionId || 'none'}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
 
   copilot
     .command('rename <session> <new-name>')

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -28,16 +28,12 @@ export function registerCopilotCommands(program: Command): void {
         const sm = new SessionManager(backend);
         const requestedSession = opts.session || opts.name || `hydra-copilot-${opts.agent}`;
         const sessionName = backend.sanitizeSessionName(requestedSession);
-        const { copilotInfo, postCreatePromise } = await sm.createCopilot({
+        const finalCopilot = await sm.createCopilotAndFinalize({
           workdir: expandPath(opts.workdir),
           agentType: opts.agent,
           name: opts.name,
           sessionName,
         });
-
-        await postCreatePromise;
-        const state = await sm.sync();
-        const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;
 
         outputResult(
           {

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -81,20 +81,14 @@ export function registerCopilotCommands(program: Command): void {
     });
 
   copilot
-    .command('restore')
-    .description('Restore the most recent archived copilot')
-    .action(async () => {
+    .command('restore <session>')
+    .description('Restore an archived copilot by session name')
+    .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const entry = [...sm.listArchived()].reverse().find((candidate) => candidate.type === 'copilot');
-
-        if (!entry) {
-          throw new Error('No archived copilot found');
-        }
-
-        const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(entry.sessionName);
+        const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(sessionName);
         await postCreatePromise;
         const state = await sm.sync();
         const finalCopilot = state.copilots[copilotInfo.sessionName] || copilotInfo;

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -27,6 +27,7 @@ export function registerListCommand(program: Command): void {
             status: c.status,
             attached: c.attached,
             workdir: c.workdir || null,
+            agentSessionId: c.sessionId,
           })),
           workers: workers.map(w => ({
             number: w.workerId,
@@ -39,6 +40,7 @@ export function registerListCommand(program: Command): void {
             attached: w.attached,
             workdir: w.workdir || null,
             copilotSessionName: w.copilotSessionName || null,
+            agentSessionId: w.sessionId,
           })),
           count: copilots.length + workers.length,
         };

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -56,15 +56,14 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
 
   try {
     const sm = new SessionManager(new TmuxBackendCore());
-    const { copilotInfo, postCreatePromise } = await sm.createCopilot({
+    const copilotInfo = await sm.createCopilotAndFinalize({
       workdir: os.homedir(),
       agentType,
       sessionName,
     });
-    void postCreatePromise;
 
-    sendCopilotOnboarding(backend, sessionName);
-    backend.attachSession(sessionName, copilotInfo.workdir, undefined, 'copilot');
+    sendCopilotOnboarding(backend, copilotInfo.sessionName);
+    backend.attachSession(copilotInfo.sessionName, copilotInfo.workdir, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');
@@ -112,16 +111,15 @@ export async function createCopilot(): Promise<void> {
 
   try {
     const sm = new SessionManager(new TmuxBackendCore());
-    const { copilotInfo, postCreatePromise } = await sm.createCopilot({
+    const copilotInfo = await sm.createCopilotAndFinalize({
       workdir: os.homedir(),
       agentType,
       sessionName,
       name: nameInput.trim(),
     });
-    void postCreatePromise;
 
-    sendCopilotOnboarding(backend, sessionName);
-    backend.attachSession(sessionName, copilotInfo.workdir, undefined, 'copilot');
+    sendCopilotOnboarding(backend, copilotInfo.sessionName);
+    backend.attachSession(copilotInfo.sessionName, copilotInfo.workdir, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -56,14 +56,15 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
 
   try {
     const sm = new SessionManager(new TmuxBackendCore());
-    const copilot = await sm.createCopilot({
+    const { copilotInfo, postCreatePromise } = await sm.createCopilot({
       workdir: os.homedir(),
       agentType,
       sessionName,
     });
+    void postCreatePromise;
 
     sendCopilotOnboarding(backend, sessionName);
-    backend.attachSession(sessionName, copilot.workdir, undefined, 'copilot');
+    backend.attachSession(sessionName, copilotInfo.workdir, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');
@@ -111,15 +112,16 @@ export async function createCopilot(): Promise<void> {
 
   try {
     const sm = new SessionManager(new TmuxBackendCore());
-    const copilot = await sm.createCopilot({
+    const { copilotInfo, postCreatePromise } = await sm.createCopilot({
       workdir: os.homedir(),
       agentType,
       sessionName,
       name: nameInput.trim(),
     });
+    void postCreatePromise;
 
     sendCopilotOnboarding(backend, sessionName);
-    backend.attachSession(sessionName, copilot.workdir, undefined, 'copilot');
+    backend.attachSession(sessionName, copilotInfo.workdir, undefined, 'copilot');
 
     vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
     vscode.commands.executeCommand('tmux.refresh');

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -12,6 +12,7 @@ import { shellQuote } from './shell';
 const HYDRA_DIR = path.join(os.homedir(), '.hydra');
 const SESSIONS_FILE = path.join(HYDRA_DIR, 'sessions.json');
 const ARCHIVE_FILE = path.join(HYDRA_DIR, 'archive.json');
+const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 15000;
 
 /**
  * Look up a worker's numeric ID from sessions.json.
@@ -383,7 +384,7 @@ export class SessionManager {
     this.writeSessionState(state);
 
     // Async post-create
-    const postCreatePromise = (async () => {
+    const postCreatePromise = this.withPostCreateTimeout((async () => {
       if (isResume) {
         // Resume: skip Phase 1 (sessionId already known), just wait for readiness
         await this.waitForAgentReady(sessionName, agentType);
@@ -393,7 +394,7 @@ export class SessionManager {
       }
       // Phase 2: Send task prompt (only after sessions.json is up to date)
       await this.sendInitialPrompt(sessionName, task);
-    })();
+    })(), sessionName, 'worker startup');
 
     return { workerInfo, postCreatePromise };
   }
@@ -499,7 +500,10 @@ export class SessionManager {
       postCreatePromise = this.waitForReadyAndCaptureSessionId(sessionName, agent, preAssignedSessionId);
     }
 
-    return { workerInfo: worker, postCreatePromise };
+    return {
+      workerInfo: worker,
+      postCreatePromise: this.withPostCreateTimeout(postCreatePromise, sessionName, 'worker startup'),
+    };
   }
 
   // ── Copilot Lifecycle ──
@@ -564,13 +568,21 @@ export class SessionManager {
 
     // Match worker lifecycle semantics: wait for readiness and persist any deferred
     // session ID capture before the CLI treats creation as complete.
-    postCreatePromise = this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId);
+    postCreatePromise = this.withPostCreateTimeout(
+      this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId),
+      sessionName,
+      'copilot startup',
+    );
 
     return { copilotInfo, postCreatePromise };
   }
 
   async createCopilotAndFinalize(opts: CreateCopilotOpts): Promise<CopilotInfo> {
     return this.finalizeCopilotResult(await this.createCopilot(opts));
+  }
+
+  async restoreCopilotAndFinalize(sessionName: string): Promise<CopilotInfo> {
+    return this.finalizeCopilotResult(await this.restoreCopilot(sessionName));
   }
 
   async renameWorker(oldSessionName: string, newBranchName: string): Promise<WorkerInfo> {
@@ -837,6 +849,29 @@ export class SessionManager {
     await result.postCreatePromise;
     const state = await this.sync();
     return state.copilots[result.copilotInfo.sessionName] || result.copilotInfo;
+  }
+
+  private withPostCreateTimeout(
+    promise: Promise<void>,
+    sessionName: string,
+    operation: string,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error(`Timed out waiting for ${operation} for "${sessionName}" after ${POST_CREATE_TIMEOUT_MS}ms`));
+      }, POST_CREATE_TIMEOUT_MS);
+
+      promise.then(
+        () => {
+          clearTimeout(timeoutId);
+          resolve();
+        },
+        (error) => {
+          clearTimeout(timeoutId);
+          reject(error);
+        },
+      );
+    });
   }
 
   private archiveEntry(
@@ -1153,7 +1188,10 @@ export class SessionManager {
       state.workers[sessionName] = workerInfo;
       state.updatedAt = now;
       this.writeSessionState(state);
-      return { workerInfo, postCreatePromise: Promise.resolve() };
+      return {
+        workerInfo,
+        postCreatePromise: this.withPostCreateTimeout(Promise.resolve(), sessionName, 'worker startup'),
+      };
     }
 
     // Worktree exists but tmux is dead — check new and legacy locations
@@ -1233,7 +1271,10 @@ export class SessionManager {
       state.updatedAt = now;
       this.writeSessionState(state);
 
-      return { workerInfo, postCreatePromise };
+      return {
+        workerInfo,
+        postCreatePromise: this.withPostCreateTimeout(postCreatePromise, sessionName, 'worker startup'),
+      };
     }
 
     throw new Error(`Branch "${branchName}" exists but has no managed worktree. Delete the branch first or use a different name.`);

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -569,6 +569,10 @@ export class SessionManager {
     return { copilotInfo, postCreatePromise };
   }
 
+  async createCopilotAndFinalize(opts: CreateCopilotOpts): Promise<CopilotInfo> {
+    return this.finalizeCopilotResult(await this.createCopilot(opts));
+  }
+
   async renameWorker(oldSessionName: string, newBranchName: string): Promise<WorkerInfo> {
     const state = this.readSessionState();
     const worker = state.workers[oldSessionName];
@@ -828,6 +832,12 @@ export class SessionManager {
   }
 
   // ── Private helpers ──
+
+  private async finalizeCopilotResult(result: CreateCopilotResult): Promise<CopilotInfo> {
+    await result.postCreatePromise;
+    const state = await this.sync();
+    return state.copilots[result.copilotInfo.sessionName] || result.copilotInfo;
+  }
 
   private archiveEntry(
     type: 'worker' | 'copilot',

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -116,6 +116,12 @@ export interface CreateWorkerResult {
   postCreatePromise: Promise<void>;
 }
 
+export interface CreateCopilotResult {
+  copilotInfo: CopilotInfo;
+  /** Resolves after the agent is ready and any deferred session ID capture has completed. */
+  postCreatePromise: Promise<void>;
+}
+
 // ── SessionManager Class ──
 
 export class SessionManager {
@@ -498,7 +504,7 @@ export class SessionManager {
 
   // ── Copilot Lifecycle ──
 
-  async createCopilot(opts: CreateCopilotOpts): Promise<CopilotInfo> {
+  async createCopilot(opts: CreateCopilotOpts): Promise<CreateCopilotResult> {
     ensureHydraGlobalConfig();
 
     const agentType = opts.agentType || 'claude';
@@ -521,6 +527,8 @@ export class SessionManager {
     const isResume = !!opts.resumeSessionId;
     let sessionId: string | null;
 
+    let postCreatePromise = Promise.resolve();
+
     if (isResume) {
       sessionId = opts.resumeSessionId!;
       const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId);
@@ -530,9 +538,7 @@ export class SessionManager {
       await this.backend.sendKeys(sessionName, resumeCmd);
     } else {
       sessionId = agentType === 'claude' ? randomUUID() : null;
-      const launchCmd = agentType === 'claude'
-        ? buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined)
-        : agentCommand;
+      const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined);
       await this.backend.sendKeys(sessionName, launchCmd);
     }
 
@@ -556,13 +562,11 @@ export class SessionManager {
     state.updatedAt = now;
     this.writeSessionState(state);
 
-    // Phase 1 (background): capture session ID for non-Claude fresh sessions
-    // Phase 2 (onboarding prompt) is handled by the VS Code extension caller
-    if (!isResume && !sessionId) {
-      this.waitForReadyAndCaptureSessionId(sessionName, agentType, null).catch(() => {});
-    }
+    // Match worker lifecycle semantics: wait for readiness and persist any deferred
+    // session ID capture before the CLI treats creation as complete.
+    postCreatePromise = this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId);
 
-    return copilotInfo;
+    return { copilotInfo, postCreatePromise };
   }
 
   async renameWorker(oldSessionName: string, newBranchName: string): Promise<WorkerInfo> {
@@ -804,7 +808,7 @@ export class SessionManager {
     });
   }
 
-  async restoreCopilot(sessionName: string): Promise<CopilotInfo> {
+  async restoreCopilot(sessionName: string): Promise<CreateCopilotResult> {
     const entry = this.getArchived(sessionName);
     if (!entry) {
       throw new Error(`Archived session "${sessionName}" not found`);
@@ -817,6 +821,7 @@ export class SessionManager {
     return this.createCopilot({
       workdir: copilot.workdir,
       agentType: copilot.agent,
+      name: copilot.displayName,
       sessionName: copilot.sessionName,
       resumeSessionId: entry.agentSessionId || undefined,
     });

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -3,6 +3,11 @@ import { toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 import { MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo, HydraRole } from './types';
 
+interface ExecFailure extends Error {
+  stderr?: string;
+  stdout?: string;
+}
+
 const TMUX_ENV_KEYS_TO_STRIP = [
   'ELECTRON_RUN_AS_NODE',
   'TERM_PROGRAM',
@@ -58,6 +63,30 @@ async function scrubStoredTmuxEnvironment(sessionName?: string): Promise<void> {
   }
 }
 
+function getExecFailureText(error: unknown): string {
+  if (error instanceof Error) {
+    const failure = error as ExecFailure;
+    return [failure.message, failure.stderr, failure.stdout]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join('\n')
+      .trim();
+  }
+  return String(error);
+}
+
+function isTmuxNoServerError(error: unknown): boolean {
+  const text = getExecFailureText(error).toLowerCase();
+  return text.includes('no server running')
+    || (text.includes('error connecting to') && text.includes('no such file or directory'));
+}
+
+export class TmuxUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TmuxUnavailableError';
+  }
+}
+
 export class TmuxBackendCore implements MultiplexerBackendCore {
   readonly type = 'tmux' as const;
   readonly displayName = 'tmux';
@@ -83,8 +112,11 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
           attached: attached === '1'
         };
       });
-    } catch {
-      return [];
+    } catch (error) {
+      if (isTmuxNoServerError(error)) {
+        return [];
+      }
+      throw new TmuxUnavailableError(`Unable to access tmux sessions: ${getExecFailureText(error)}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add `hydra copilot create`, `hydra copilot delete`, and `hydra copilot restore`
- wait for copilot post-create session-id capture so Codex/Gemini session IDs persist before CLI completion
- stop treating tmux access failures as an empty session list so Hydra no longer falsely marks live sessions as stopped
- surface `agentSessionId` in list JSON output and document the new copilot CLI commands

## Verification
- npm run compile
- node out/cli/index.js copilot --help
- node out/cli/index.js list --json
