### PR TITLE
[codex] limit whoami to worker worktrees

### DIFF
--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander';
 import { resolve } from 'path';
 import { type OutputOpts, outputResult } from '../output';
-import { SessionManager, type WorkerInfo, type CopilotInfo } from '../../core/sessionManager';
+import { SessionManager, type WorkerInfo } from '../../core/sessionManager';
 import { TmuxBackendCore } from '../../core/tmux';
 
 interface WhoamiResult {
-  role: 'worker' | 'copilot';
+  role: 'worker';
   sessionName: string;
   displayName: string;
   agent: string;
@@ -22,7 +22,7 @@ interface WhoamiResult {
 export function registerWhoamiCommand(program: Command): void {
   program
     .command('whoami')
-    .description('Report the copilot/worker/worktree context of the current working directory')
+    .description('Report the Hydra worker context of the current working directory')
     .action(async () => {
       const globalOpts = program.opts() as OutputOpts;
       const cwd = resolve(process.cwd());
@@ -55,31 +55,11 @@ export function registerWhoamiCommand(program: Command): void {
         }
       }
 
-      // Match cwd against copilot workdirs
-      for (const copilot of Object.values(state.copilots)) {
-        if (cwd === resolve(copilot.workdir) || cwd.startsWith(resolve(copilot.workdir) + '/')) {
-          const data: WhoamiResult = {
-            role: 'copilot',
-            sessionName: copilot.sessionName,
-            displayName: copilot.displayName,
-            agent: copilot.agent,
-            sessionId: copilot.sessionId,
-            workdir: copilot.workdir,
-            status: copilot.status,
-          };
-
-          outputResult(data as unknown as Record<string, unknown>, globalOpts, () => {
-            prettyPrintCopilot(copilot);
-          });
-          return;
-        }
-      }
-
-      // Not in a hydra session
+      // Not in a Hydra worker workdir
       if (globalOpts.json) {
-        console.log(JSON.stringify({ role: null, message: 'Not running inside a Hydra session.' }));
+        console.log(JSON.stringify({ role: null, message: 'Current directory is not inside a Hydra worker workdir.' }));
       } else if (!globalOpts.quiet) {
-        console.log('Not running inside a Hydra session.');
+        console.log('Current directory is not inside a Hydra worker workdir.');
       }
     });
 }
@@ -96,16 +76,5 @@ function prettyPrintWorker(worker: WorkerInfo): void {
   console.log(`  Copilot:     ${worker.copilotSessionName ?? '(none)'}`);
   console.log(`  Workdir:     ${worker.workdir}`);
   console.log(`  Status:      ${worker.status}`);
-  console.log('');
-}
-
-function prettyPrintCopilot(copilot: CopilotInfo): void {
-  console.log('');
-  console.log(`  Role:        copilot`);
-  console.log(`  Session:     ${copilot.sessionName}`);
-  console.log(`  Agent:       ${copilot.agent}`);
-  console.log(`  Session ID:  ${copilot.sessionId ?? '(none)'}`);
-  console.log(`  Workdir:     ${copilot.workdir}`);
-  console.log(`  Status:      ${copilot.status}`);
   console.log('');
 }


### PR DESCRIPTION
## Summary
- refactor `hydra whoami` to match only managed worker workdirs
- remove copilot-specific matching and reporting logic from the command
- update command text and fallback messaging to reflect worker-only behavior

## Why
`whoami` only makes sense for workers because only workers have managed worktrees. The previous implementation also matched copilot workdirs, which was too broad and could produce false positives when a copilot was started from a directory like `$HOME`.

## Impact
- `hydra whoami` now reports context only when the current directory is inside a managed worker workdir
- directories that merely fall under a copilot workdir now correctly report that they are not inside a Hydra worker workdir

## Root Cause
The command scanned both `state.workers` and `state.copilots`, even though only worker sessions have the managed worktree context that `whoami` is supposed to describe.

## Validation
- `npm run compile`
- `npm run lint` (passes with 2 pre-existing warnings in `src/providers/tmuxSessionProvider.ts` for unused `getRepoName` and unused `CopilotInfo`)
