### PR TITLE
feat: add isolated e2e Hydra infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,9 @@
   "scripts": {
     "compile": "tsc -p ./ && node scripts/postcompile.js",
     "watch": "tsc -watch -p ./",
-    "lint": "eslint src --ext ts"
+    "lint": "eslint src --ext ts",
+    "e2e:isolated": "node scripts/e2e-isolated-runner.js",
+    "e2e:isolated:shell": "node scripts/e2e-isolated-runner.js --shell --keep"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/scripts/e2e-isolated-runner.js
+++ b/scripts/e2e-isolated-runner.js
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_ROOT_PREFIX = path.join(os.tmpdir(), 'hydra-e2e-');
+const CLI_ENTRY = path.join(REPO_ROOT, 'out', 'cli', 'index.js');
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function printUsage() {
+  const lines = [
+    'Usage:',
+    '  node scripts/e2e-isolated-runner.js [options] [-- <command> [args...]]',
+    '',
+    'Options:',
+    '  --keep          Preserve the isolated temp root after exit.',
+    '  --cleanup       Remove the isolated temp root even when it would normally be kept.',
+    '  --root <path>   Reuse or create a specific isolated root directory.',
+    '  --shell         Launch an interactive shell inside the isolated environment.',
+    '  --help          Show this help.',
+    '',
+    'Examples:',
+    '  npm run e2e:isolated',
+    '  npm run e2e:isolated -- --keep -- hydra list --json',
+    '  npm run e2e:isolated -- --keep -- code --extensionDevelopmentPath=. /tmp/hydra-test-$(date +%s)',
+    '  npm run e2e:isolated:shell',
+  ];
+  console.error(lines.join('\n'));
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const commandIndex = args.indexOf('--');
+  const command = commandIndex >= 0 ? args.slice(commandIndex + 1) : [];
+  const optionArgs = commandIndex >= 0 ? args.slice(0, commandIndex) : args;
+  const options = {
+    cleanup: false,
+    keep: false,
+    root: undefined,
+    shell: false,
+    command,
+  };
+
+  for (let index = 0; index < optionArgs.length; index += 1) {
+    const arg = optionArgs[index];
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+    if (arg === '--keep') {
+      options.keep = true;
+      continue;
+    }
+    if (arg === '--cleanup') {
+      options.cleanup = true;
+      continue;
+    }
+    if (arg === '--shell') {
+      options.shell = true;
+      continue;
+    }
+    if (arg === '--root') {
+      const next = optionArgs[index + 1];
+      if (!next) {
+        throw new Error('--root requires a path');
+      }
+      options.root = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (options.shell && options.command.length > 0) {
+    throw new Error('--shell cannot be combined with a command after --');
+  }
+
+  return options;
+}
+
+function detectExecutable(command) {
+  const lookup = spawnSync('/bin/sh', ['-lc', `command -v ${shellQuote(command)}`], {
+    encoding: 'utf8',
+  });
+  if (lookup.status !== 0) {
+    return '';
+  }
+  return lookup.stdout.trim();
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function ensureSymlink(linkPath, targetPath) {
+  try {
+    const stats = fs.lstatSync(linkPath);
+    if (stats.isSymbolicLink() && fs.readlinkSync(linkPath) === targetPath) {
+      return;
+    }
+    fs.rmSync(linkPath, { recursive: true, force: true });
+  } catch (error) {
+    if (!error || error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+  fs.symlinkSync(targetPath, linkPath);
+}
+
+function writeExecutable(filePath, contents) {
+  fs.writeFileSync(filePath, contents, 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function ensureJsonFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, '{}\n', 'utf8');
+  }
+}
+
+function readJsonObject(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return {};
+    }
+    throw error;
+  }
+}
+
+function writeJsonObject(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function createIsolatedEnvironment(requestedRoot) {
+  const root = requestedRoot
+    ? path.resolve(requestedRoot)
+    : fs.mkdtempSync(DEFAULT_ROOT_PREFIX);
+
+  const homeDir = path.join(root, 'home');
+  const hydraHome = path.join(root, 'hydra-home');
+  const hydraConfigPath = path.join(root, 'config.json');
+  const hydraBinDir = path.join(hydraHome, 'bin');
+  const shimBinDir = path.join(root, 'bin');
+  const tmuxDir = path.join(hydraHome, 'tmux');
+  const tmpDir = path.join(root, 'tmp');
+  const vscodeUserDataDir = path.join(root, 'vscode-user-data');
+  const vscodeUserDir = path.join(vscodeUserDataDir, 'User');
+  const vscodeSettingsPath = path.join(vscodeUserDir, 'settings.json');
+  const tmuxSocket = path.join(tmuxDir, 'hydra.sock');
+  const activateScript = path.join(root, 'activate.sh');
+  const metadataFile = path.join(root, 'context.json');
+  const realTmuxPath = detectExecutable('tmux');
+  const realCodePath = detectExecutable('code');
+  const nodePath = process.execPath;
+
+  ensureDir(root);
+  ensureDir(homeDir);
+  ensureDir(hydraHome);
+  ensureDir(hydraBinDir);
+  ensureDir(shimBinDir);
+  ensureDir(tmuxDir);
+  ensureDir(tmpDir);
+  ensureDir(vscodeUserDir);
+  ensureSymlink(path.join(homeDir, '.hydra'), hydraHome);
+  ensureJsonFile(hydraConfigPath);
+  writeJsonObject(vscodeSettingsPath, {
+    ...readJsonObject(vscodeSettingsPath),
+    'security.workspace.trust.enabled': false,
+    'security.workspace.trust.startupPrompt': 'never',
+    'security.workspace.trust.untrustedFiles': 'open',
+    'security.workspace.trust.emptyWindow': true,
+  });
+
+  writeExecutable(
+    path.join(hydraBinDir, 'hydra'),
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `CLI_ENTRY=${shellQuote(CLI_ENTRY)}`,
+      `NODE_BIN=${shellQuote(nodePath)}`,
+      'if [ ! -f "$CLI_ENTRY" ]; then',
+      '  echo "Hydra CLI build output is missing. Run npm run compile first." >&2',
+      '  exit 1',
+      'fi',
+      'exec "$NODE_BIN" "$CLI_ENTRY" "$@"',
+      '',
+    ].join('\n'),
+  );
+
+  writeExecutable(
+    path.join(shimBinDir, 'tmux'),
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `REAL_TMUX=${shellQuote(realTmuxPath)}`,
+      'if [ -z "$REAL_TMUX" ]; then',
+      '  echo "tmux is not installed or not on PATH." >&2',
+      '  exit 127',
+      'fi',
+      'has_custom_socket=0',
+      'previous=""',
+      'for arg in "$@"; do',
+      '  if [ "$previous" = "-S" ] || [ "$previous" = "-L" ]; then',
+      '    has_custom_socket=1',
+      '    break',
+      '  fi',
+      '  case "$arg" in',
+      '    -S|-L)',
+      '      has_custom_socket=1',
+      '      break',
+      '      ;;',
+      '  esac',
+      '  previous="$arg"',
+      'done',
+      'if [ "$has_custom_socket" -eq 0 ] && [ -n "${HYDRA_TMUX_SOCKET:-}" ]; then',
+      '  exec "$REAL_TMUX" -S "$HYDRA_TMUX_SOCKET" "$@"',
+      'fi',
+      'exec "$REAL_TMUX" "$@"',
+      '',
+    ].join('\n'),
+  );
+
+  writeExecutable(
+    path.join(shimBinDir, 'code'),
+    [
+      '#!/bin/sh',
+      'set -eu',
+      `REAL_CODE=${shellQuote(realCodePath)}`,
+      `VSCODE_USER_DATA_DIR=${shellQuote(vscodeUserDataDir)}`,
+      'if [ -z "$REAL_CODE" ]; then',
+      '  echo "VS Code CLI (code) is not installed or not on PATH." >&2',
+      '  exit 127',
+      'fi',
+      'has_user_data_dir=0',
+      'previous=""',
+      'for arg in "$@"; do',
+      '  if [ "$previous" = "--user-data-dir" ]; then',
+      '    has_user_data_dir=1',
+      '    break',
+      '  fi',
+      '  case "$arg" in',
+      '    --user-data-dir)',
+      '      has_user_data_dir=1',
+      '      break',
+      '      ;;',
+      '    --user-data-dir=*)',
+      '      has_user_data_dir=1',
+      '      break',
+      '      ;;',
+      '  esac',
+      '  previous="$arg"',
+      'done',
+      'if [ "$has_user_data_dir" -eq 0 ]; then',
+      '  exec "$REAL_CODE" --user-data-dir "$VSCODE_USER_DATA_DIR" "$@"',
+      'fi',
+      'exec "$REAL_CODE" "$@"',
+      '',
+    ].join('\n'),
+  );
+
+  const env = {
+    ...process.env,
+    HYDRA_HOME: hydraHome,
+    HYDRA_CONFIG_PATH: hydraConfigPath,
+    HYDRA_TMUX_SOCKET: tmuxSocket,
+    HYDRA_E2E_ROOT: root,
+    PATH: [hydraBinDir, shimBinDir, process.env.PATH || ''].filter(Boolean).join(':'),
+    TMPDIR: tmpDir,
+    TMP: tmpDir,
+    TEMP: tmpDir,
+  };
+  delete env.TMUX;
+  delete env.TMUX_PANE;
+
+  writeExecutable(
+    activateScript,
+    [
+      '#!/bin/sh',
+      `export HYDRA_HOME=${shellQuote(hydraHome)}`,
+      `export HYDRA_CONFIG_PATH=${shellQuote(hydraConfigPath)}`,
+      `export HYDRA_TMUX_SOCKET=${shellQuote(tmuxSocket)}`,
+      `export HYDRA_E2E_ROOT=${shellQuote(root)}`,
+      `export TMPDIR=${shellQuote(tmpDir)}`,
+      `export TMP=${shellQuote(tmpDir)}`,
+      `export TEMP=${shellQuote(tmpDir)}`,
+      `export PATH=${shellQuote(env.PATH)}`,
+      'unset TMUX',
+      'unset TMUX_PANE',
+      '',
+    ].join('\n'),
+  );
+
+  const sampleInvocation = `npm run e2e:isolated -- --root ${shellQuote(root)} -- hydra list --json`;
+  const context = {
+    root,
+    homeDir,
+    hydraHome,
+    hydraConfigPath,
+    tmuxSocket,
+    vscodeUserDataDir,
+    activateScript,
+    sampleInvocation,
+  };
+  fs.writeFileSync(metadataFile, `${JSON.stringify(context, null, 2)}\n`, 'utf8');
+
+  return {
+    context,
+    env,
+    rootWasProvided: Boolean(requestedRoot),
+  };
+}
+
+function printSummary(context) {
+  const lines = [
+    'Hydra isolated env ready',
+    `  root: ${context.root}`,
+    `  HYDRA_HOME: ${context.hydraHome}`,
+    `  HYDRA_CONFIG_PATH: ${context.hydraConfigPath}`,
+    `  HYDRA_TMUX_SOCKET: ${context.tmuxSocket}`,
+    `  VS Code user data: ${context.vscodeUserDataDir}`,
+    `  activate: source ${shellQuote(context.activateScript)}`,
+    `  sample: ${context.sampleInvocation}`,
+  ];
+  console.error(lines.join('\n'));
+}
+
+function cleanupRoot(root) {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+function runChild(options, env) {
+  if (options.shell) {
+    const shellPath = process.env.SHELL || '/bin/sh';
+    return spawnSync(shellPath, {
+      cwd: process.cwd(),
+      env,
+      stdio: 'inherit',
+    });
+  }
+  if (options.command.length === 0) {
+    return null;
+  }
+  const [command, ...args] = options.command;
+  return spawnSync(command, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: 'inherit',
+  });
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const isolated = createIsolatedEnvironment(options.root);
+  const hasChild = options.shell || options.command.length > 0;
+  const preserveByDefault = options.keep || isolated.rootWasProvided || !hasChild;
+
+  printSummary(isolated.context);
+
+  let exitCode = 0;
+  const result = runChild(options, isolated.env);
+
+  if (result && result.error) {
+    console.error(result.error.message);
+    exitCode = typeof result.status === 'number' ? result.status : 1;
+  } else if (result && result.signal) {
+    console.error(`Child process exited from signal ${result.signal}`);
+    exitCode = 1;
+  } else if (result && typeof result.status === 'number') {
+    exitCode = result.status;
+  }
+
+  const shouldPreserve = options.cleanup
+    ? false
+    : preserveByDefault || exitCode !== 0;
+
+  if (shouldPreserve) {
+    console.error(`Preserved isolated env at ${isolated.context.root}`);
+  } else {
+    cleanupRoot(isolated.context.root);
+    console.error(`Cleaned up isolated env at ${isolated.context.root}`);
+  }
+
+  process.exit(exitCode);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/skills/test-hydra/SKILL.md
+++ b/skills/test-hydra/SKILL.md
@@ -36,10 +36,10 @@ Launch the Hydra VS Code extension in a Development Host for manual testing.
 3. **Launch the Extension Development Host**
 
    ```bash
-   code --extensionDevelopmentPath="<absolute-path-to-repo-or-worktree>" /tmp/hydra-test-<timestamp>
+   npm run e2e:isolated -- --keep -- code --extensionDevelopmentPath="<absolute-path-to-repo-or-worktree>" /tmp/hydra-test-<timestamp>
    ```
 
-   This opens a new VS Code window with the locally-compiled Hydra extension loaded.
+   This opens a new VS Code window with the locally-compiled Hydra extension loaded inside an isolated Hydra environment. The isolated runner also provides a private VS Code user-data directory so temporary test workspaces open without the workspace trust prompt.
 
 4. **Inform the user**
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, constants, accessSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
+import { getHydraBinDir, getHydraConfigPath, getHydraHome } from '../../core/path';
 import { type OutputOpts } from '../output';
 
 interface CheckResult {
@@ -50,9 +50,10 @@ export function registerDoctorCommand(program: Command): void {
     .action(async () => {
       const globalOpts = program.opts() as OutputOpts;
       const checks: CheckResult[] = [];
-      const hydraDir = join(homedir(), '.hydra');
-      const hydraBin = join(hydraDir, 'bin', 'hydra');
-      const hydraBinDir = join(hydraDir, 'bin');
+      const hydraDir = getHydraHome();
+      const hydraConfigPath = getHydraConfigPath();
+      const hydraBinDir = getHydraBinDir();
+      const hydraBin = join(hydraBinDir, 'hydra');
 
       // 1. git
       checks.push(checkOnPath('git')
@@ -69,39 +70,46 @@ export function registerDoctorCommand(program: Command): void {
         ? { name: 'code', status: 'pass', message: 'VS Code CLI is installed' }
         : { name: 'code', status: 'fail', message: 'code CLI not found — install from https://code.visualstudio.com then run "Shell Command: Install code"' });
 
-      // 4. ~/.hydra directory
+      // 4. Hydra home directory
       if (existsSync(hydraDir)) {
-        checks.push({ name: '~/.hydra', status: 'pass', message: '~/.hydra directory exists' });
+        checks.push({ name: 'hydra-home', status: 'pass', message: `Hydra home directory exists: ${hydraDir}` });
       } else {
         mkdirSync(hydraDir, { recursive: true });
-        checks.push({ name: '~/.hydra', status: 'warn', message: '~/.hydra was missing — created automatically' });
+        checks.push({ name: 'hydra-home', status: 'warn', message: `Hydra home was missing — created automatically at ${hydraDir}` });
       }
 
-      // 5. Hydra CLI binary
+      // 5. Hydra config path
+      if (existsSync(hydraConfigPath)) {
+        checks.push({ name: 'hydra-config', status: 'pass', message: `Hydra config exists: ${hydraConfigPath}` });
+      } else {
+        checks.push({ name: 'hydra-config', status: 'warn', message: `Hydra config not found yet: ${hydraConfigPath}` });
+      }
+
+      // 6. Hydra CLI binary
       if (existsSync(hydraBin) && isExecutable(hydraBin)) {
-        checks.push({ name: 'hydra-cli', status: 'pass', message: '~/.hydra/bin/hydra is installed' });
+        checks.push({ name: 'hydra-cli', status: 'pass', message: `Hydra CLI is installed at ${hydraBin}` });
       } else {
         if (!existsSync(hydraBinDir)) {
           mkdirSync(hydraBinDir, { recursive: true });
         }
-        checks.push({ name: 'hydra-cli', status: 'fail', message: '~/.hydra/bin/hydra not found — open VS Code with the Hydra extension installed to auto-install' });
+        checks.push({ name: 'hydra-cli', status: 'fail', message: `Hydra CLI not found at ${hydraBin} — open VS Code with the Hydra extension installed to auto-install` });
       }
 
-      // 6. ~/.hydra/bin in PATH
+      // 7. Hydra bin in PATH
       const pathDirs = (process.env.PATH || '').split(':');
-      const binInPath = pathDirs.some(d => d === hydraBinDir || d === '~/.hydra/bin');
+      const binInPath = pathDirs.some(d => d === hydraBinDir);
       if (binInPath) {
-        checks.push({ name: 'hydra-path', status: 'pass', message: '~/.hydra/bin is in PATH' });
+        checks.push({ name: 'hydra-path', status: 'pass', message: `${hydraBinDir} is in PATH` });
       } else {
-        checks.push({ name: 'hydra-path', status: 'warn', message: '~/.hydra/bin is not in PATH — add to your shell profile:\n    export PATH="$HOME/.hydra/bin:$PATH"' });
+        checks.push({ name: 'hydra-path', status: 'warn', message: `${hydraBinDir} is not in PATH — add to your shell profile:\n    export PATH="${hydraBinDir}:$PATH"` });
       }
 
-      // 7. GitHub CLI
+      // 8. GitHub CLI
       checks.push(checkOnPath('gh')
         ? { name: 'gh', status: 'pass', message: 'GitHub CLI is installed' }
         : { name: 'gh', status: 'fail', message: 'gh not found — install from https://cli.github.com' });
 
-      // 8. GitHub CLI authenticated
+      // 9. GitHub CLI authenticated
       if (checkOnPath('gh')) {
         checks.push(ghAuthenticated()
           ? { name: 'gh-auth', status: 'pass', message: 'GitHub CLI is authenticated' }
@@ -110,7 +118,7 @@ export function registerDoctorCommand(program: Command): void {
         checks.push({ name: 'gh-auth', status: 'fail', message: 'gh is not authenticated (gh not installed)' });
       }
 
-      // 9. AI agent CLIs
+      // 10. AI agent CLIs
       const agents = ['claude', 'codex', 'gemini'];
       const foundAgents = agents.filter(a => checkOnPath(a));
       if (foundAgents.length > 0) {

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,9 +1,6 @@
 import { resolve } from 'path';
 import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
-import * as os from 'os';
-
-const SESSIONS_FILE = join(os.homedir(), '.hydra', 'sessions.json');
+import { getHydraSessionsFile } from '../core/path';
 
 export interface HydraIdentity {
   role: 'worker' | 'copilot';
@@ -42,8 +39,9 @@ export function detectIdentity(cwd?: string): HydraIdentity | null {
 
   let state: { copilots?: Record<string, RawSession>; workers?: Record<string, RawSession> };
   try {
-    if (!existsSync(SESSIONS_FILE)) return null;
-    state = JSON.parse(readFileSync(SESSIONS_FILE, 'utf-8'));
+    const sessionsFile = getHydraSessionsFile();
+    if (!existsSync(sessionsFile)) return null;
+    state = JSON.parse(readFileSync(sessionsFile, 'utf-8'));
   } catch {
     return null;
   }

--- a/src/core/cliInstaller.ts
+++ b/src/core/cliInstaller.ts
@@ -1,41 +1,136 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { getDefaultHydraHome, getHydraBinDir, getHydraConfig, writeHydraConfig } from './path';
 
-const HYDRA_DIR = path.join(os.homedir(), '.hydra');
-const BIN_DIR = path.join(HYDRA_DIR, 'bin');
-const WRAPPER_PATH = path.join(BIN_DIR, 'hydra');
-const EXT_PATH_FILE = path.join(HYDRA_DIR, 'ext-path');
-const VERSION_FILE = path.join(HYDRA_DIR, 'cli-version');
+function getWrapperPath(): string {
+  return path.join(getHydraBinDir(), 'hydra');
+}
 
-const WRAPPER_SCRIPT = `#!/bin/sh
-EXT_PATH=$(cat "$HOME/.hydra/ext-path" 2>/dev/null)
-if [ -z "$EXT_PATH" ] || [ ! -f "$EXT_PATH/out/cli/index.js" ]; then
-  echo "Error: Hydra VS Code extension not found. Open VS Code with Hydra installed." >&2
-  exit 1
-fi
-exec node "$EXT_PATH/out/cli/index.js" "$@"
+function buildWrapperScript(): string {
+  return `#!/bin/sh
+exec node - "$@" <<'NODE'
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function expandHomeDir(targetPath) {
+  if (targetPath === '~') return os.homedir();
+  if (targetPath.startsWith('~/') || targetPath.startsWith('~\\\\')) {
+    return path.join(os.homedir(), targetPath.slice(2));
+  }
+  return targetPath;
+}
+
+function toCanonicalPath(targetPath) {
+  if (typeof targetPath !== 'string' || !targetPath.trim()) {
+    return undefined;
+  }
+  const expanded = expandHomeDir(targetPath.trim());
+  return path.normalize(path.resolve(expanded));
+}
+
+function resolveConfigPathValue(value, configPath) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+  const expanded = expandHomeDir(value.trim());
+  const absolute = path.isAbsolute(expanded)
+    ? expanded
+    : path.resolve(path.dirname(configPath), expanded);
+  return path.normalize(absolute);
+}
+
+function readHydraConfigFile(configPath) {
+  try {
+    if (!fs.existsSync(configPath)) {
+      return {};
+    }
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return raw && typeof raw === 'object' ? raw : {};
+  } catch {
+    return {};
+  }
+}
+
+const defaultHydraHome = path.join(os.homedir(), '.hydra');
+const envHydraHome = toCanonicalPath(process.env.HYDRA_HOME);
+const envHydraConfigPath = toCanonicalPath(process.env.HYDRA_CONFIG_PATH);
+const bootstrapConfigPath = envHydraConfigPath
+  || path.join(envHydraHome || defaultHydraHome, 'config.json');
+
+let hydraConfig = readHydraConfigFile(bootstrapConfigPath);
+let hydraHome = envHydraHome
+  || resolveConfigPathValue(hydraConfig.hydraHome || hydraConfig.HYDRA_HOME, bootstrapConfigPath)
+  || defaultHydraHome;
+let hydraConfigPath = envHydraConfigPath
+  || resolveConfigPathValue(hydraConfig.hydraConfigPath || hydraConfig.HYDRA_CONFIG_PATH, bootstrapConfigPath)
+  || path.join(hydraHome, 'config.json');
+
+if (!envHydraConfigPath && hydraConfigPath !== bootstrapConfigPath && fs.existsSync(hydraConfigPath)) {
+  hydraConfig = readHydraConfigFile(hydraConfigPath);
+  hydraHome = envHydraHome
+    || resolveConfigPathValue(hydraConfig.hydraHome || hydraConfig.HYDRA_HOME, hydraConfigPath)
+    || hydraHome;
+  hydraConfigPath = resolveConfigPathValue(hydraConfig.hydraConfigPath || hydraConfig.HYDRA_CONFIG_PATH, hydraConfigPath)
+    || hydraConfigPath;
+}
+
+const extPath = typeof hydraConfig.cli?.extensionPath === 'string'
+  ? hydraConfig.cli.extensionPath
+  : '';
+
+if (!extPath || !fs.existsSync(path.join(extPath, 'out', 'cli', 'index.js'))) {
+  console.error('Error: Hydra VS Code extension not found. Open VS Code with Hydra installed.');
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [path.join(extPath, 'out', 'cli', 'index.js'), ...process.argv.slice(2)],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HYDRA_HOME: hydraHome,
+      HYDRA_CONFIG_PATH: hydraConfigPath,
+    },
+  },
+);
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+process.exit(1);
+NODE
 `;
+}
 
 export function installCli(extensionPath: string, version: string): { installed: boolean; updated: boolean } {
-  // Create ~/.hydra/bin/ directory
-  fs.mkdirSync(BIN_DIR, { recursive: true });
-
-  // Always write ext-path to handle extension updates
-  fs.writeFileSync(EXT_PATH_FILE, extensionPath, 'utf-8');
+  const binDir = getHydraBinDir();
+  // Create Hydra CLI directory.
+  fs.mkdirSync(binDir, { recursive: true });
 
   // Write wrapper script
-  fs.writeFileSync(WRAPPER_PATH, WRAPPER_SCRIPT, { encoding: 'utf-8', mode: 0o755 });
+  fs.writeFileSync(getWrapperPath(), buildWrapperScript(), { encoding: 'utf-8', mode: 0o755 });
 
-  // Determine install vs update by comparing cli-version
-  let previousVersion: string | undefined;
-  try {
-    previousVersion = fs.readFileSync(VERSION_FILE, 'utf-8').trim();
-  } catch {
-    // File doesn't exist — fresh install
-  }
-
-  fs.writeFileSync(VERSION_FILE, version, 'utf-8');
+  const hydraConfig = getHydraConfig();
+  const previousVersion = hydraConfig.cli?.version?.trim();
+  writeHydraConfig({
+    ...hydraConfig,
+    cli: {
+      ...hydraConfig.cli,
+      extensionPath,
+      version,
+    },
+  });
 
   if (!previousVersion) {
     return { installed: true, updated: false };
@@ -47,9 +142,16 @@ export function installCli(extensionPath: string, version: string): { installed:
   return { installed: false, updated: false };
 }
 
-export function ensurePathInShellProfile(): void {
-  const snippet = 'export PATH="$HOME/.hydra/bin:$PATH"';
-  const marker = '.hydra/bin';
+export type ShellProfileStatus = 'added' | 'already_present' | 'skipped_custom_home';
+
+export function ensurePathInShellProfile(): ShellProfileStatus {
+  const defaultBinDir = path.join(getDefaultHydraHome(), 'bin');
+  if (getHydraBinDir() !== defaultBinDir) {
+    return 'skipped_custom_home';
+  }
+
+  const snippet = getShellConfigSnippet();
+  const marker = '# Hydra CLI';
   const candidates = [
     path.join(os.homedir(), '.zshrc'),
     path.join(os.homedir(), '.bashrc'),
@@ -57,25 +159,27 @@ export function ensurePathInShellProfile(): void {
   for (const rc of candidates) {
     if (!fs.existsSync(rc)) continue;
     const content = fs.readFileSync(rc, 'utf-8');
-    if (content.includes(marker)) return;
+    if (content.includes(snippet) || content.includes(marker)) return 'already_present';
     fs.appendFileSync(rc, `\n# Hydra CLI\n${snippet}\n`);
-    return;
+    return 'added';
   }
   // No rc file found — create ~/.zshrc (macOS default)
   fs.writeFileSync(candidates[0], `# Hydra CLI\n${snippet}\n`, 'utf-8');
+  return 'added';
 }
 
 export function isCliOnPath(): boolean {
+  const binDir = getHydraBinDir();
   const envPath = process.env.PATH || '';
   return envPath.split(path.delimiter).some(p => {
     try {
-      return fs.realpathSync(p) === fs.realpathSync(BIN_DIR);
+      return fs.realpathSync(p) === fs.realpathSync(binDir);
     } catch {
-      return p === BIN_DIR || p === '$HOME/.hydra/bin' || p.endsWith('/.hydra/bin');
+      return p === binDir;
     }
   });
 }
 
 export function getShellConfigSnippet(): string {
-  return 'export PATH="$HOME/.hydra/bin:$PATH"';
+  return `export PATH="${path.join(getDefaultHydraHome(), 'bin')}:$PATH"`;
 }

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -1,5 +1,6 @@
 import { exec as execCallback } from 'child_process';
 import { promisify } from 'util';
+import { getIsolatedEnv } from './path';
 
 const execPromise = promisify(execCallback);
 
@@ -30,7 +31,7 @@ export async function exec(command: string, options?: ExecOptions): Promise<stri
   const { stdout } = await execPromise(command, {
     cwd: options?.cwd,
     env: {
-      ...process.env,
+      ...getIsolatedEnv(),
       PATH: getEnhancedPath(),
     }
   });

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { createHash } from 'crypto';
 import { exec } from './exec';
-import { toCanonicalPath } from './path';
+import { getHydraWorktreesRoot, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 import { MultiplexerBackendCore, Worktree } from './types';
 
@@ -104,7 +104,7 @@ export async function localBranchExists(repoRoot: string, branchName: string): P
 }
 
 export function getManagedWorktreesRoot(): string {
-  return path.join(os.homedir(), '.hydra', 'worktrees');
+  return getHydraWorktreesRoot();
 }
 
 /**

--- a/src/core/hydraGlobalConfig.ts
+++ b/src/core/hydraGlobalConfig.ts
@@ -1,12 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
+import { getHydraConfigPath, getHydraHome } from './path';
 
-const HYDRA_DIR = path.join(os.homedir(), '.hydra');
-
-/** Ensure ~/.hydra/ directory exists. */
+/** Ensure Hydra data/config directories exist. */
 export function ensureHydraGlobalConfig(): void {
-  if (!fs.existsSync(HYDRA_DIR)) {
-    fs.mkdirSync(HYDRA_DIR, { recursive: true });
+  const hydraHome = getHydraHome();
+  const hydraConfigDir = path.dirname(getHydraConfigPath());
+
+  if (!fs.existsSync(hydraHome)) {
+    fs.mkdirSync(hydraHome, { recursive: true });
+  }
+  if (!fs.existsSync(hydraConfigDir)) {
+    fs.mkdirSync(hydraConfigDir, { recursive: true });
   }
 }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,5 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs';
+import { shellQuote } from './shell';
 
 function expandHomeDir(targetPath: string): string {
   if (targetPath === '~') return os.homedir();
@@ -14,4 +16,167 @@ export function toCanonicalPath(targetPath?: string): string | undefined {
 
   const expanded = expandHomeDir(targetPath.trim());
   return path.normalize(path.resolve(expanded));
+}
+
+export interface HydraCliConfig {
+  extensionPath?: string;
+  version?: string;
+}
+
+export interface HydraGlobalConfig {
+  hydraHome?: string;
+  hydraConfigPath?: string;
+  HYDRA_HOME?: string;
+  HYDRA_CONFIG_PATH?: string;
+  cli?: HydraCliConfig;
+}
+
+export interface HydraResolvedPaths {
+  hydraHome: string;
+  hydraConfigPath: string;
+  hydraConfig: HydraGlobalConfig;
+  hydraBinDir: string;
+  hydraSessionsFile: string;
+  hydraArchiveFile: string;
+  hydraWorktreesRoot: string;
+}
+
+export function getDefaultHydraHome(): string {
+  return path.join(os.homedir(), '.hydra');
+}
+
+function resolveConfigPathValue(value: unknown, configPath: string): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined;
+  }
+
+  const expanded = expandHomeDir(value.trim());
+  const absolute = path.isAbsolute(expanded)
+    ? expanded
+    : path.resolve(path.dirname(configPath), expanded);
+  return path.normalize(absolute);
+}
+
+function getConfigHydraHome(config: HydraGlobalConfig): string | undefined {
+  return config.hydraHome || config.HYDRA_HOME;
+}
+
+function getConfigHydraConfigPath(config: HydraGlobalConfig): string | undefined {
+  return config.hydraConfigPath || config.HYDRA_CONFIG_PATH;
+}
+
+function readHydraConfigFile(configPath: string): HydraGlobalConfig {
+  try {
+    if (!fs.existsSync(configPath)) {
+      return {};
+    }
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    return raw && typeof raw === 'object' ? raw as HydraGlobalConfig : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getHydraPaths(): HydraResolvedPaths {
+  const defaultHydraHome = getDefaultHydraHome();
+  const envHydraHome = toCanonicalPath(process.env.HYDRA_HOME);
+  const envHydraConfigPath = toCanonicalPath(process.env.HYDRA_CONFIG_PATH);
+
+  const bootstrapConfigPath = envHydraConfigPath
+    || path.join(envHydraHome || defaultHydraHome, 'config.json');
+
+  let hydraConfig = readHydraConfigFile(bootstrapConfigPath);
+  let hydraHome = envHydraHome
+    || resolveConfigPathValue(getConfigHydraHome(hydraConfig), bootstrapConfigPath)
+    || defaultHydraHome;
+  let hydraConfigPath = envHydraConfigPath
+    || resolveConfigPathValue(getConfigHydraConfigPath(hydraConfig), bootstrapConfigPath)
+    || path.join(hydraHome, 'config.json');
+
+  if (!envHydraConfigPath && hydraConfigPath !== bootstrapConfigPath && fs.existsSync(hydraConfigPath)) {
+    hydraConfig = readHydraConfigFile(hydraConfigPath);
+    hydraHome = envHydraHome
+      || resolveConfigPathValue(getConfigHydraHome(hydraConfig), hydraConfigPath)
+      || hydraHome;
+    hydraConfigPath = envHydraConfigPath
+      || resolveConfigPathValue(getConfigHydraConfigPath(hydraConfig), hydraConfigPath)
+      || hydraConfigPath;
+  }
+
+  return {
+    hydraHome,
+    hydraConfigPath,
+    hydraConfig,
+    hydraBinDir: path.join(hydraHome, 'bin'),
+    hydraSessionsFile: path.join(hydraHome, 'sessions.json'),
+    hydraArchiveFile: path.join(hydraHome, 'archive.json'),
+    hydraWorktreesRoot: path.join(hydraHome, 'worktrees'),
+  };
+}
+
+export function getHydraHome(): string {
+  return getHydraPaths().hydraHome;
+}
+
+export function getHydraConfigPath(): string {
+  return getHydraPaths().hydraConfigPath;
+}
+
+export function getHydraConfig(): HydraGlobalConfig {
+  return getHydraPaths().hydraConfig;
+}
+
+export function writeHydraConfig(config: HydraGlobalConfig): void {
+  const { hydraConfigPath } = getHydraPaths();
+  fs.mkdirSync(path.dirname(hydraConfigPath), { recursive: true });
+  fs.writeFileSync(hydraConfigPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
+export function getHydraBinDir(): string {
+  return getHydraPaths().hydraBinDir;
+}
+
+export function getHydraSessionsFile(): string {
+  return getHydraPaths().hydraSessionsFile;
+}
+
+export function getHydraArchiveFile(): string {
+  return getHydraPaths().hydraArchiveFile;
+}
+
+export function getHydraWorktreesRoot(): string {
+  return getHydraPaths().hydraWorktreesRoot;
+}
+
+export function getIsolatedEnv(): Record<string, string | undefined> {
+  const { hydraHome, hydraConfigPath } = getHydraPaths();
+  const env: Record<string, string | undefined> = { ...process.env };
+  env.HYDRA_HOME = hydraHome;
+  env.HYDRA_CONFIG_PATH = hydraConfigPath;
+  if (process.env.HYDRA_TMUX_SOCKET) {
+    env.HYDRA_TMUX_SOCKET = process.env.HYDRA_TMUX_SOCKET;
+  }
+  return env;
+}
+
+export function getTmuxSocketArgs(): string[] {
+  const socket = process.env.HYDRA_TMUX_SOCKET;
+  if (!socket) {
+    return [];
+  }
+
+  if (socket.startsWith('/') || socket.startsWith('./') || socket.startsWith('../')) {
+    return ['-S', socket];
+  }
+
+  return ['-L', socket];
+}
+
+export function getTmuxCommand(): string {
+  const socketArgs = getTmuxSocketArgs();
+  if (socketArgs.length === 0) {
+    return 'tmux';
+  }
+
+  return `tmux ${socketArgs.map(arg => shellQuote(arg)).join(' ')}`;
 }

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -1,17 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import { randomUUID } from 'crypto';
 import { MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig } from './hydraGlobalConfig';
 import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN } from './agentConfig';
 import { exec } from './exec';
+import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile } from './path';
 import { shellQuote } from './shell';
 
-const HYDRA_DIR = path.join(os.homedir(), '.hydra');
-const SESSIONS_FILE = path.join(HYDRA_DIR, 'sessions.json');
-const ARCHIVE_FILE = path.join(HYDRA_DIR, 'archive.json');
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 15000;
 
 /**
@@ -20,8 +17,9 @@ const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 15000;
  */
 export function lookupWorkerId(sessionName: string): number | undefined {
   try {
-    if (fs.existsSync(SESSIONS_FILE)) {
-      const parsed = JSON.parse(fs.readFileSync(SESSIONS_FILE, 'utf-8'));
+    const sessionsFile = getHydraSessionsFile();
+    if (fs.existsSync(sessionsFile)) {
+      const parsed = JSON.parse(fs.readFileSync(sessionsFile, 'utf-8'));
       return parsed.workers?.[sessionName]?.workerId;
     }
   } catch {
@@ -892,9 +890,10 @@ export class SessionManager {
   }
 
   private readArchiveState(): ArchiveState {
+    const archiveFile = getHydraArchiveFile();
     try {
-      if (fs.existsSync(ARCHIVE_FILE)) {
-        const raw = fs.readFileSync(ARCHIVE_FILE, 'utf-8');
+      if (fs.existsSync(archiveFile)) {
+        const raw = fs.readFileSync(archiveFile, 'utf-8');
         const parsed = JSON.parse(raw);
         return { entries: parsed.entries || [] };
       }
@@ -905,16 +904,19 @@ export class SessionManager {
   }
 
   private writeArchiveState(archive: ArchiveState): void {
-    if (!fs.existsSync(HYDRA_DIR)) {
-      fs.mkdirSync(HYDRA_DIR, { recursive: true });
+    const archiveFile = getHydraArchiveFile();
+    const hydraHome = getHydraHome();
+    if (!fs.existsSync(hydraHome)) {
+      fs.mkdirSync(hydraHome, { recursive: true });
     }
-    fs.writeFileSync(ARCHIVE_FILE, JSON.stringify(archive, null, 2), 'utf-8');
+    fs.writeFileSync(archiveFile, JSON.stringify(archive, null, 2), 'utf-8');
   }
 
   private readSessionState(): SessionState {
+    const sessionsFile = getHydraSessionsFile();
     try {
-      if (fs.existsSync(SESSIONS_FILE)) {
-        const raw = fs.readFileSync(SESSIONS_FILE, 'utf-8');
+      if (fs.existsSync(sessionsFile)) {
+        const raw = fs.readFileSync(sessionsFile, 'utf-8');
         const parsed = JSON.parse(raw);
         const state: SessionState = {
           copilots: parsed.copilots || {},
@@ -940,10 +942,12 @@ export class SessionManager {
   }
 
   private writeSessionState(state: SessionState): void {
-    if (!fs.existsSync(HYDRA_DIR)) {
-      fs.mkdirSync(HYDRA_DIR, { recursive: true });
+    const sessionsFile = getHydraSessionsFile();
+    const hydraHome = getHydraHome();
+    if (!fs.existsSync(hydraHome)) {
+      fs.mkdirSync(hydraHome, { recursive: true });
     }
-    fs.writeFileSync(SESSIONS_FILE, JSON.stringify(state, null, 2), 'utf-8');
+    fs.writeFileSync(sessionsFile, JSON.stringify(state, null, 2), 'utf-8');
   }
 
   /**

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -1,5 +1,5 @@
 import { exec } from './exec';
-import { toCanonicalPath } from './path';
+import { getHydraConfigPath, getHydraHome, getTmuxCommand, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 import { MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo, HydraRole } from './types';
 
@@ -29,26 +29,40 @@ function getTmuxSanitizedEnvKeys(): string[] {
 
 export function buildSanitizedTmuxCommand(command: string): string {
   const envKeys = getTmuxSanitizedEnvKeys();
+  const tmuxCommand = getTmuxCommand();
   if (envKeys.length === 0) {
-    return `tmux ${command}`;
+    return `${tmuxCommand} ${command}`;
   }
   const unsetArgs = envKeys.map((key) => `-u ${shellQuote(key)}`).join(' ');
-  return `env ${unsetArgs} tmux ${command}`;
+  return `env ${unsetArgs} ${tmuxCommand} ${command}`;
 }
 
 export function buildStoredTmuxEnvScrubCommand(sessionName?: string): string {
+  const tmuxCommand = getTmuxCommand();
   const sessionTarget = sessionName ? ` -t ${shellQuote(sessionName)}` : '';
+  const varsToSet = [
+    `${tmuxCommand} set-environment -g HYDRA_HOME ${shellQuote(getHydraHome())} >/dev/null 2>&1 || true`,
+    `${tmuxCommand} set-environment -g HYDRA_CONFIG_PATH ${shellQuote(getHydraConfigPath())} >/dev/null 2>&1 || true`,
+  ];
+
+  if (process.env.HYDRA_TMUX_SOCKET) {
+    varsToSet.push(
+      `${tmuxCommand} set-environment -g HYDRA_TMUX_SOCKET ${shellQuote(process.env.HYDRA_TMUX_SOCKET)} >/dev/null 2>&1 || true`,
+    );
+  }
+
   return [
+    ...varsToSet,
     'for name in ELECTRON_RUN_AS_NODE TERM_PROGRAM TERM_PROGRAM_VERSION VSCODE_INJECTION VSCODE_SHELL_INTEGRATION; do',
-    'tmux set-environment -gu "$name" >/dev/null 2>&1 || true',
-    `tmux set-environment${sessionTarget} -u "$name" >/dev/null 2>&1 || true`,
+    `${tmuxCommand} set-environment -gu "$name" >/dev/null 2>&1 || true`,
+    `${tmuxCommand} set-environment${sessionTarget} -u "$name" >/dev/null 2>&1 || true`,
     'done',
-    'tmux show-environment -g 2>/dev/null | while IFS= read -r line; do',
+    `${tmuxCommand} show-environment -g 2>/dev/null | while IFS= read -r line; do`,
     'name=${line%%=*}',
     'case "$name" in',
     'VSCODE_*)',
-    'tmux set-environment -gu "$name" >/dev/null 2>&1 || true',
-    `tmux set-environment${sessionTarget} -u "$name" >/dev/null 2>&1 || true`,
+    `${tmuxCommand} set-environment -gu "$name" >/dev/null 2>&1 || true`,
+    `${tmuxCommand} set-environment${sessionTarget} -u "$name" >/dev/null 2>&1 || true`,
     ';;',
     'esac',
     'done'
@@ -103,7 +117,8 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async listSessions(): Promise<MultiplexerSession[]> {
     try {
-      const output = await exec("tmux list-sessions -F '#{session_name}|||#{session_windows}|||#{session_attached}'");
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} list-sessions -F '#{session_name}|||#{session_windows}|||#{session_attached}'`);
       return output.split('\n').filter(l => l.trim()).map(line => {
         const [name, windows, attached] = line.split('|||');
         return {
@@ -126,16 +141,19 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async killSession(sessionName: string): Promise<void> {
-    await exec(`tmux kill-session -t ${shellQuote(sessionName)}`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} kill-session -t ${shellQuote(sessionName)}`);
   }
 
   async renameSession(oldName: string, newName: string): Promise<void> {
-    await exec(`tmux rename-session -t ${shellQuote(oldName)} ${shellQuote(newName)}`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} rename-session -t ${shellQuote(oldName)} ${shellQuote(newName)}`);
   }
 
   async hasSession(sessionName: string): Promise<boolean> {
     try {
-      await exec(`tmux has-session -t ${shellQuote(sessionName)}`);
+      const tmuxCommand = getTmuxCommand();
+      await exec(`${tmuxCommand} has-session -t ${shellQuote(sessionName)}`);
       return true;
     } catch {
       return false;
@@ -144,7 +162,8 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async getSessionWorkdir(sessionName: string): Promise<string | undefined> {
     try {
-      const output = await exec(`tmux show-options -t ${shellQuote(sessionName)} @workdir`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} show-options -t ${shellQuote(sessionName)} @workdir`);
       const parts = output.split(' ');
       if (parts.length >= 2) {
         const rawPath = parts.slice(1).join(' ').trim();
@@ -157,12 +176,14 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async setSessionWorkdir(sessionName: string, workdir: string): Promise<void> {
-    await exec(`tmux set-option -t ${shellQuote(sessionName)} @workdir ${shellQuote(workdir)}`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} set-option -t ${shellQuote(sessionName)} @workdir ${shellQuote(workdir)}`);
   }
 
   async getSessionRole(sessionName: string): Promise<HydraRole | undefined> {
     try {
-      const output = await exec(`tmux show-options -t ${shellQuote(sessionName)} @hydra-role`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} show-options -t ${shellQuote(sessionName)} @hydra-role`);
       const parts = output.split(' ');
       if (parts.length >= 2) {
         const value = parts.slice(1).join(' ').trim() as HydraRole;
@@ -175,12 +196,14 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async setSessionRole(sessionName: string, role: HydraRole): Promise<void> {
-    await exec(`tmux set-option -t ${shellQuote(sessionName)} @hydra-role ${shellQuote(role)}`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} set-option -t ${shellQuote(sessionName)} @hydra-role ${shellQuote(role)}`);
   }
 
   async getSessionAgent(sessionName: string): Promise<string | undefined> {
     try {
-      const output = await exec(`tmux show-options -t ${shellQuote(sessionName)} @hydra-agent`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} show-options -t ${shellQuote(sessionName)} @hydra-agent`);
       const parts = output.split(' ');
       if (parts.length >= 2) {
         const value = parts.slice(1).join(' ').trim();
@@ -193,29 +216,34 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async setSessionAgent(sessionName: string, agent: string): Promise<void> {
-    await exec(`tmux set-option -t ${shellQuote(sessionName)} @hydra-agent ${shellQuote(agent)}`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} set-option -t ${shellQuote(sessionName)} @hydra-agent ${shellQuote(agent)}`);
   }
 
   async sendKeys(sessionName: string, keys: string): Promise<void> {
-    await exec(`tmux send-keys -t ${shellQuote(sessionName)} ${shellQuote(keys)} Enter`);
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} send-keys -t ${shellQuote(sessionName)} ${shellQuote(keys)} Enter`);
   }
 
   async capturePane(sessionName: string, lines?: number): Promise<string> {
+    const tmuxCommand = getTmuxCommand();
     const startArg = lines ? `-S -${lines}` : '';
-    return exec(`tmux capture-pane -t ${shellQuote(sessionName)} -p ${startArg}`.trim());
+    return exec(`${tmuxCommand} capture-pane -t ${shellQuote(sessionName)} -p ${startArg}`.trim());
   }
 
   async sendMessage(sessionName: string, message: string): Promise<void> {
+    const tmuxCommand = getTmuxCommand();
     // Send message text literally (without Enter) to avoid it being absorbed in bracketed paste
-    await exec(`tmux send-keys -l -t ${shellQuote(sessionName)} ${shellQuote(message)}`);
+    await exec(`${tmuxCommand} send-keys -l -t ${shellQuote(sessionName)} ${shellQuote(message)}`);
     await new Promise(resolve => setTimeout(resolve, 100));
     // Send Enter separately to submit
-    await exec(`tmux send-keys -t ${shellQuote(sessionName)} Enter`);
+    await exec(`${tmuxCommand} send-keys -t ${shellQuote(sessionName)} Enter`);
   }
 
   async getSessionInfo(sessionName: string): Promise<SessionStatusInfo> {
     try {
-      const output = await exec(`tmux display-message -p -t ${shellQuote(sessionName)} '#{session_attached}|||#{session_activity}'`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} display-message -p -t ${shellQuote(sessionName)} '#{session_attached}|||#{session_activity}'`);
       const [attachedStr, activityStr] = output.split('|||');
       return {
         attached: attachedStr === '1',
@@ -228,7 +256,8 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async getSessionPaneCount(sessionName: string): Promise<number> {
     try {
-      const output = await exec(`tmux list-panes -t ${shellQuote(sessionName)}`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} list-panes -t ${shellQuote(sessionName)}`);
       return output.split('\n').filter(l => l.trim()).length || 1;
     } catch {
       return 1;
@@ -237,7 +266,8 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async getSessionPanePids(sessionName: string): Promise<string[]> {
     try {
-      const output = await exec(`tmux list-panes -t ${shellQuote(sessionName)} -F '#{pane_pid}'`);
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} list-panes -t ${shellQuote(sessionName)} -F '#{pane_pid}'`);
       return output.split('\n').filter(l => l.trim());
     } catch {
       return [];
@@ -245,13 +275,15 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   }
 
   async splitPane(sessionName: string, cwd?: string): Promise<void> {
+    const tmuxCommand = getTmuxCommand();
     const cwdArg = cwd ? `-c ${shellQuote(cwd)}` : '';
-    await exec(`tmux split-window -v -t ${shellQuote(sessionName)} ${cwdArg}`);
+    await exec(`${tmuxCommand} split-window -v -t ${shellQuote(sessionName)} ${cwdArg}`);
   }
 
   async newWindow(sessionName: string, cwd?: string): Promise<void> {
+    const tmuxCommand = getTmuxCommand();
     const cwdArg = cwd ? `-c ${shellQuote(cwd)}` : '';
-    await exec(`tmux new-window -t ${shellQuote(sessionName)} ${cwdArg}`);
+    await exec(`${tmuxCommand} new-window -t ${shellQuote(sessionName)} ${cwdArg}`);
   }
 
   buildSessionName(repoName: string, slug: string): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,10 +149,12 @@ function silentInstallCli(context: vscode.ExtensionContext): void {
     const version = (context.extension.packageJSON as { version: string }).version;
     const result = installCli(context.extensionPath, version);
     if (result.installed) {
-      ensurePathInShellProfile();
-      vscode.window.showInformationMessage(
-        'Hydra CLI installed. PATH configured automatically — restart your shell or open a new terminal to use `hydra`.'
-      );
+      const shellProfileStatus = ensurePathInShellProfile();
+      if (shellProfileStatus !== 'skipped_custom_home') {
+        vscode.window.showInformationMessage(
+          'Hydra CLI installed. PATH configured automatically — restart your shell or open a new terminal to use `hydra`.'
+        );
+      }
     }
   } catch (err) {
     // CLI install is best-effort — don't block activation

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { exec } from '../utils/exec';
-import { getRepoRoot, getRepoName, getBaseBranch } from '../utils/git';
+import { getRepoRoot, getBaseBranch } from '../utils/git';
 import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multiplexer';
 import { toCanonicalPath } from '../utils/path';
-import { SessionManager, WorkerInfo, CopilotInfo } from '../core/sessionManager';
+import { SessionManager, WorkerInfo } from '../core/sessionManager';
 import { Worktree } from '../core/types';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';

--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { exec } from './exec';
 import { TmuxBackendCore, buildStoredTmuxEnvScrubCommand } from '../core/tmux';
+import { getIsolatedEnv, getTmuxCommand } from '../core/path';
 import { MultiplexerBackend, HydraRole } from './multiplexer';
 import { getHydraEditorLocation, buildHydraTerminalName, getHydraTerminalIcon, getHydraTerminalColor, HYDRA_PREFIX_WORKER } from './hydraEditorGroup';
 import { lookupWorkerId } from '../core/sessionManager';
@@ -40,7 +41,8 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
     const existing = findTerminalBySession(sessionName);
 
     if (existing) {
-      void exec(`tmux set-window-option -t "${sessionName}":. window-size latest`).catch(() => {});
+      const tmuxCommand = getTmuxCommand();
+      void exec(`${tmuxCommand} set-window-option -t "${sessionName}":. window-size latest`).catch(() => {});
       const options = existing.creationOptions as vscode.TerminalOptions;
       // For editor locations, reuse if both are editor-area targets
       const existingIsEditor = options?.location !== vscode.TerminalLocation.Panel;
@@ -58,12 +60,13 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
     }
 
     const escapedName = sessionName.replace(/'/g, "'\\''");
+    const tmuxCommand = getTmuxCommand();
     const attachCommand = [
       buildStoredTmuxEnvScrubCommand(sessionName),
-      "tmux set-option -gq set-clipboard on >/dev/null 2>&1 || true",
-      "tmux set-option -agq terminal-features ',xterm-256color:clipboard' >/dev/null 2>&1 || true",
-      "tmux set-option -agq terminal-overrides ',*:clipboard' >/dev/null 2>&1 || true",
-      "tmux set-option -gwq allow-passthrough on >/dev/null 2>&1 || true",
+      `${tmuxCommand} set-option -gq set-clipboard on >/dev/null 2>&1 || true`,
+      `${tmuxCommand} set-option -agq terminal-features ',xterm-256color:clipboard' >/dev/null 2>&1 || true`,
+      `${tmuxCommand} set-option -agq terminal-overrides ',*:clipboard' >/dev/null 2>&1 || true`,
+      `${tmuxCommand} set-window-option -gwq allow-passthrough on >/dev/null 2>&1 || true`,
       "rows=''; cols=''",
       "for _ in 1 2 3 4 5; do",
       "size=$(stty size 2>/dev/null || true)",
@@ -73,11 +76,11 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
       "if [ -n \"$rows\" ] && [ \"$rows\" -ge 30 ] && [ \"$cols\" -ge 100 ]; then break; fi",
       "sleep 0.04",
       "done",
-      "if [ -n \"$rows\" ] && [ -n \"$cols\" ]; then tmux set-option -t '" + escapedName + "' default-size \"${cols}x${rows}\" >/dev/null 2>&1 || true; fi",
-      "if [ -n \"$rows\" ] && [ -n \"$cols\" ]; then tmux resize-window -t '" + escapedName + "':. -x \"$cols\" -y \"$rows\" >/dev/null 2>&1 || true; fi",
-      "tmux set-window-option -t '" + escapedName + "':. window-size latest >/dev/null 2>&1 || true",
+      "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " set-option -t '" + escapedName + "' default-size \"${cols}x${rows}\" >/dev/null 2>&1 || true; fi",
+      "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " resize-window -t '" + escapedName + "':. -x \"$cols\" -y \"$rows\" >/dev/null 2>&1 || true; fi",
+      `${tmuxCommand} set-window-option -t '${escapedName}':. window-size latest >/dev/null 2>&1 || true`,
       "sleep 0.08",
-      `exec tmux attach -t '${escapedName}'`
+      `exec ${tmuxCommand} attach -t '${escapedName}'`
     ].join('\n');
 
     const terminal = vscode.window.createTerminal({
@@ -91,6 +94,7 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
         'TERM_PROGRAM_VERSION': null,
         'VSCODE_SHELL_INTEGRATION': null,
         'VSCODE_INJECTION': null,
+        ...getIsolatedEnv(),
       },
       location: resolvedLocation,
       iconPath: getHydraTerminalIcon(),


### PR DESCRIPTION
## Summary
- centralize Hydra home/config path resolution with `HYDRA_HOME` and `HYDRA_CONFIG_PATH` support
- propagate isolated Hydra env state to CLI, tmux, shell sessions, and child processes
- add an isolated E2E runner for temp Hydra homes, private tmux sockets, and trust-free Dev Host launches
- update CLI install behavior so isolated/custom homes do not mutate the user's shell profile

## Verification
- `npm run compile`
- `npm run lint`
- `git diff --check`
- isolated runner smoke checks for exported `HYDRA_HOME`, `HYDRA_CONFIG_PATH`, `HYDRA_TMUX_SOCKET`, and private VS Code `--user-data-dir`
- manual isolated Dev Host validation for empty sidebar state, isolated copilot creation, and no Codex re-sign flow
- isolated nested CLI validation that sessions created under the isolated root do not appear in the main Hydra environment

## Notes
- reviewed the branch diff before opening this PR and fixed one issue found during review: shell profile PATH writes must stay on the default global Hydra home and be skipped for isolated/custom homes
