### PR TITLE
[codex] integrate e2e scenario runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,10 @@
         "title": "Hydra: Attach/Create Session"
       },
       {
+        "command": "hydra.createWorker",
+        "title": "Hydra: Create Worker"
+      },
+      {
         "command": "tmux.removeTask",
         "title": "Hydra: Remove"
       },

--- a/scripts/e2e-isolated-runner.js
+++ b/scripts/e2e-isolated-runner.js
@@ -153,6 +153,7 @@ function createIsolatedEnvironment(requestedRoot) {
   const shimBinDir = path.join(root, 'bin');
   const tmuxDir = path.join(hydraHome, 'tmux');
   const tmpDir = path.join(root, 'tmp');
+  const zdotdir = path.join(root, 'zdotdir');
   const vscodeUserDataDir = path.join(root, 'vscode-user-data');
   const vscodeUserDir = path.join(vscodeUserDataDir, 'User');
   const vscodeSettingsPath = path.join(vscodeUserDir, 'settings.json');
@@ -170,6 +171,7 @@ function createIsolatedEnvironment(requestedRoot) {
   ensureDir(shimBinDir);
   ensureDir(tmuxDir);
   ensureDir(tmpDir);
+  ensureDir(zdotdir);
   ensureDir(vscodeUserDir);
   ensureSymlink(path.join(homeDir, '.hydra'), hydraHome);
   ensureJsonFile(hydraConfigPath);
@@ -268,12 +270,42 @@ function createIsolatedEnvironment(requestedRoot) {
     ].join('\n'),
   );
 
+  const shellExports = [
+    `export HYDRA_HOME=${shellQuote(hydraHome)}`,
+    `export HYDRA_CONFIG_PATH=${shellQuote(hydraConfigPath)}`,
+    `export HYDRA_TMUX_SOCKET=${shellQuote(tmuxSocket)}`,
+    `export HYDRA_E2E_ROOT=${shellQuote(root)}`,
+    `export TMPDIR=${shellQuote(tmpDir)}`,
+    `export TMP=${shellQuote(tmpDir)}`,
+    `export TEMP=${shellQuote(tmpDir)}`,
+    `export PATH=${shellQuote([hydraBinDir, shimBinDir, process.env.PATH || ''].filter(Boolean).join(':'))}`,
+    'unset TMUX',
+    'unset TMUX_PANE',
+    '',
+  ].join('\n');
+
+  const zshInit = [
+    '# Hydra isolated shell init',
+    '[ -f "$HOME/.zshrc" ] && ZDOTDIR="$HOME" . "$HOME/.zshrc"',
+    shellExports,
+  ].join('\n');
+
+  const bashInit = [
+    '# Hydra isolated shell init',
+    '[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"',
+    shellExports,
+  ].join('\n');
+
+  fs.writeFileSync(path.join(zdotdir, '.zshrc'), zshInit, 'utf8');
+  fs.writeFileSync(path.join(zdotdir, '.bashrc'), bashInit, 'utf8');
+
   const env = {
     ...process.env,
     HYDRA_HOME: hydraHome,
     HYDRA_CONFIG_PATH: hydraConfigPath,
     HYDRA_TMUX_SOCKET: tmuxSocket,
     HYDRA_E2E_ROOT: root,
+    ZDOTDIR: zdotdir,
     PATH: [hydraBinDir, shimBinDir, process.env.PATH || ''].filter(Boolean).join(':'),
     TMPDIR: tmpDir,
     TMP: tmpDir,
@@ -290,6 +322,7 @@ function createIsolatedEnvironment(requestedRoot) {
       `export HYDRA_CONFIG_PATH=${shellQuote(hydraConfigPath)}`,
       `export HYDRA_TMUX_SOCKET=${shellQuote(tmuxSocket)}`,
       `export HYDRA_E2E_ROOT=${shellQuote(root)}`,
+      `export ZDOTDIR=${shellQuote(zdotdir)}`,
       `export TMPDIR=${shellQuote(tmpDir)}`,
       `export TMP=${shellQuote(tmpDir)}`,
       `export TEMP=${shellQuote(tmpDir)}`,
@@ -306,6 +339,7 @@ function createIsolatedEnvironment(requestedRoot) {
     homeDir,
     hydraHome,
     hydraConfigPath,
+    zdotdir,
     tmuxSocket,
     vscodeUserDataDir,
     activateScript,

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -11,7 +11,8 @@ export function registerTestCommand(program: Command): void {
     .command('test')
     .description('Run Hydra E2E scenario tests inside an isolated environment')
     .option('--filter <pattern>', 'Run only tests matching this substring')
-    .action(async (opts: { filter?: string }) => {
+    .option('--agent <type>', 'Force a specific agent CLI (claude, codex, gemini)')
+    .action(async (opts: { filter?: string; agent?: string }) => {
       const globalOpts = program.opts() as OutputOpts;
 
       try {
@@ -20,7 +21,10 @@ export function registerTestCommand(program: Command): void {
           console.log('\u2500'.repeat(60));
         }
 
-        const report: TestReport = await runE2ETests({ filter: opts.filter });
+        const report: TestReport = await runE2ETests({
+          filter: opts.filter,
+          agent: opts.agent,
+        });
 
         if (globalOpts.json) {
           console.log(JSON.stringify(report));

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import { runE2ETests, type TestReport } from '../../e2e/runner';
+import { outputError, type OutputOpts } from '../output';
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+
+export function registerTestCommand(program: Command): void {
+  program
+    .command('test')
+    .description('Run Hydra E2E scenario tests inside an isolated environment')
+    .option('--filter <pattern>', 'Run only tests matching this substring')
+    .action(async (opts: { filter?: string }) => {
+      const globalOpts = program.opts() as OutputOpts;
+
+      try {
+        if (!globalOpts.quiet && !globalOpts.json) {
+          console.log('\nHydra E2E Test Suite\n');
+          console.log('\u2500'.repeat(60));
+        }
+
+        const report: TestReport = await runE2ETests({ filter: opts.filter });
+
+        if (globalOpts.json) {
+          console.log(JSON.stringify(report));
+        } else if (!globalOpts.quiet) {
+          for (const result of report.results) {
+            const duration = (result.durationMs / 1000).toFixed(1);
+            if (result.passed) {
+              console.log(`  ${GREEN}[PASS]${RESET} ${result.name} (${duration}s)`);
+            } else {
+              console.log(`  ${RED}[FAIL]${RESET} ${result.name}: ${result.error}`);
+            }
+          }
+
+          if (report.total === 0) {
+            console.log('  No tests matched the current filter.');
+          }
+
+          console.log('');
+          console.log('\u2500'.repeat(60));
+          const totalDuration = (report.durationMs / 1000).toFixed(1);
+          console.log(`  Results: ${report.passed}/${report.total} passed, ${report.failed} failed (${totalDuration}s)`);
+          console.log('');
+        }
+
+        process.exitCode = report.failed > 0 ? 1 : 0;
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { registerCopilotCommands } from './commands/copilot';
 import { registerArchiveCommands } from './commands/archive';
 import { registerDoctorCommand } from './commands/doctor';
 import { registerWhoamiCommand } from './commands/whoami';
+import { registerTestCommand } from './commands/test';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
 
@@ -32,5 +33,6 @@ registerCopilotCommands(program);
 registerArchiveCommands(program);
 registerDoctorCommand(program);
 registerWhoamiCommand(program);
+registerTestCommand(program);
 
 program.parse();

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+import { SessionManager } from '../core/sessionManager';
+import { TmuxBackendCore } from '../core/tmux';
+import { validateBranchName, localBranchExists, getRepoRoot } from '../utils/git';
+import { pickAgentType } from '../utils/agentConfig';
+import { getActiveBackend } from '../utils/multiplexer';
+
+function getBaseBranchOverride(): string | undefined {
+  const hydraOverride = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch');
+  if (hydraOverride?.trim()) {
+    return hydraOverride.trim();
+  }
+
+  const legacyOverride = vscode.workspace.getConfiguration('tmuxWorktree').get<string>('baseBranch');
+  return legacyOverride?.trim() || undefined;
+}
+
+export async function newTask(): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await backend.isInstalled()) {
+    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+    return;
+  }
+
+  let repoRoot: string;
+  try {
+    repoRoot = getRepoRoot();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+    return;
+  }
+
+  const branchInput = await vscode.window.showInputBox({
+    prompt: 'Enter branch name (e.g. feat/auth, fix/session-cleanup)',
+    placeHolder: 'feat/my-task',
+    validateInput: validateBranchName,
+  });
+  if (!branchInput) {
+    return;
+  }
+
+  const branchName = branchInput.trim();
+  const validationError = validateBranchName(branchName);
+  if (validationError) {
+    vscode.window.showErrorMessage(validationError);
+    return;
+  }
+
+  const agentType = await pickAgentType();
+  if (!agentType) {
+    return;
+  }
+
+  try {
+    const branchExisted = await localBranchExists(repoRoot, branchName);
+    const sessionManager = new SessionManager(new TmuxBackendCore());
+    const { workerInfo, postCreatePromise } = await sessionManager.createWorker({
+      repoRoot,
+      branchName,
+      agentType,
+      baseBranchOverride: getBaseBranchOverride(),
+    });
+
+    backend.attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+    void postCreatePromise.catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showWarningMessage(
+        `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,
+      );
+    });
+
+    const action = branchExisted ? 'Resumed' : 'Created';
+    vscode.window.showInformationMessage(`${action} worker: ${workerInfo.sessionName}`);
+    void vscode.commands.executeCommand('tmux.refresh');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+  }
+}

--- a/src/e2e/runner.ts
+++ b/src/e2e/runner.ts
@@ -23,13 +23,19 @@ export interface TestReport {
   durationMs: number;
 }
 
-type TestFn = () => Promise<void>;
+interface RunE2ETestOptions {
+  filter?: string;
+  agent?: string;
+}
+
+type TestFn = (opts: RunE2ETestOptions) => Promise<void>;
 
 interface IsolatedEnvironmentContext {
   root: string;
   homeDir: string;
   hydraHome: string;
   hydraConfigPath: string;
+  zdotdir: string;
   tmuxSocket: string;
   vscodeUserDataDir: string;
   activateScript: string;
@@ -83,6 +89,7 @@ const MANAGED_ENV_KEYS = [
   'TMPDIR',
   'TMP',
   'TEMP',
+  'ZDOTDIR',
   'TMUX',
   'TMUX_PANE',
 ] as const;
@@ -125,7 +132,16 @@ async function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function detectAgent(): Promise<string> {
+async function detectAgent(preferredAgent?: string): Promise<string> {
+  if (preferredAgent) {
+    try {
+      await exec(`which ${preferredAgent}`);
+      return preferredAgent;
+    } catch {
+      throw new Error(`Requested agent "${preferredAgent}" is not installed or not on PATH`);
+    }
+  }
+
   for (const agent of ['claude', 'codex', 'gemini']) {
     try {
       await exec(`which ${agent}`);
@@ -171,6 +187,7 @@ function captureManagedEnv(): Record<ManagedEnvKey, string | undefined> {
     TMPDIR: process.env.TMPDIR,
     TMP: process.env.TMP,
     TEMP: process.env.TEMP,
+    ZDOTDIR: process.env.ZDOTDIR,
     TMUX: process.env.TMUX,
     TMUX_PANE: process.env.TMUX_PANE,
   };
@@ -201,6 +218,7 @@ function applyIsolatedEnvironment(context: IsolatedEnvironmentContext): ActiveIs
   process.env.TMPDIR = tmpDir;
   process.env.TMP = tmpDir;
   process.env.TEMP = tmpDir;
+  process.env.ZDOTDIR = context.zdotdir;
   delete process.env.TMUX;
   delete process.env.TMUX_PANE;
 
@@ -398,13 +416,13 @@ function buildDemoPrompt(repoRoot: string, branchName: string, agentType: string
   ].join('\n');
 }
 
-const test_copilot_worker_conversation: TestFn = async () => {
+const test_copilot_worker_conversation: TestFn = async (opts) => {
   const environment = getActiveEnvironment();
   const backend = new TmuxBackendCore();
   const sessionManager = new SessionManager(backend);
   const branchName = `${TEST_PREFIX}demo-${generateId()}`;
   const copilotName = `${TEST_PREFIX}copilot-${generateId()}`;
-  const agentType = await detectAgent();
+  const agentType = await detectAgent(opts.agent);
 
   launchExtensionDevHost(environment.repoRoot);
   await sleep(3000);
@@ -458,7 +476,7 @@ const ALL_TESTS: Array<{ name: string; fn: TestFn }> = [
   { name: 'test_copilot_worker_conversation', fn: test_copilot_worker_conversation },
 ];
 
-export async function runE2ETests(opts?: { filter?: string }): Promise<TestReport> {
+export async function runE2ETests(opts?: RunE2ETestOptions): Promise<TestReport> {
   const startTime = Date.now();
   const results: TestResult[] = [];
 
@@ -485,7 +503,7 @@ export async function runE2ETests(opts?: { filter?: string }): Promise<TestRepor
       const testStart = Date.now();
 
       try {
-        await withTimeout(test.fn(), SCENARIO_TIMEOUT_MS + 90_000, test.name);
+        await withTimeout(test.fn(opts || {}), SCENARIO_TIMEOUT_MS + 90_000, test.name);
         results.push({
           name: test.name,
           passed: true,

--- a/src/e2e/runner.ts
+++ b/src/e2e/runner.ts
@@ -50,7 +50,7 @@ interface ActiveIsolatedEnvironment {
 interface ActiveTestEnvironment {
   isolated: ActiveIsolatedEnvironment;
   repoRoot: string;
-  repoName: string;
+  repositoryFullName: string;
 }
 
 interface SessionFileWorkerEntry {
@@ -77,6 +77,7 @@ interface ArchiveState {
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const ISOLATED_RUNNER_PATH = path.join(REPO_ROOT, 'scripts', 'e2e-isolated-runner.js');
+const DEFAULT_E2E_REPOSITORY_NAME = 'hydra-e2e-shared';
 const TEST_PREFIX = 'test-e2e-';
 const SCENARIO_TIMEOUT_MS = 5 * 60 * 1000;
 const POLL_INTERVAL_MS = 5000;
@@ -175,6 +176,53 @@ async function checkPrerequisites(): Promise<void> {
   } catch {
     throw new Error('Prerequisite failed: gh is not authenticated. Run: gh auth login');
   }
+}
+
+function getConfiguredE2ERepository(): string {
+  return process.env.HYDRA_E2E_REPOSITORY?.trim() || DEFAULT_E2E_REPOSITORY_NAME;
+}
+
+async function getE2ERepositoryFullName(): Promise<string> {
+  const configuredRepository = getConfiguredE2ERepository();
+  if (configuredRepository.includes('/')) {
+    return configuredRepository;
+  }
+
+  const login = await exec('gh api user --jq .login');
+  return `${login}/${configuredRepository}`;
+}
+
+async function githubRepositoryExists(repositoryFullName: string): Promise<boolean> {
+  try {
+    await exec(`gh repo view ${shellQuote(repositoryFullName)} --json nameWithOwner >/dev/null`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function prepareE2ERepository(cloneRoot: string): Promise<{ repositoryFullName: string; repoRoot: string }> {
+  const repositoryFullName = await getE2ERepositoryFullName();
+  const repoDirName = repositoryFullName.split('/').pop() || DEFAULT_E2E_REPOSITORY_NAME;
+  const repoRoot = path.join(cloneRoot, repoDirName);
+  const exists = await githubRepositoryExists(repositoryFullName);
+
+  if (exists) {
+    await exec(
+      `gh repo clone ${shellQuote(repositoryFullName)} ${shellQuote(repoDirName)}`,
+      { cwd: cloneRoot },
+    );
+  } else {
+    await exec(
+      `gh repo create ${shellQuote(repositoryFullName)} --private --add-readme --clone`,
+      { cwd: cloneRoot },
+    );
+  }
+
+  await exec('git config user.email "test@hydra.dev"', { cwd: repoRoot });
+  await exec('git config user.name "Hydra E2E"', { cwd: repoRoot });
+
+  return { repositoryFullName, repoRoot };
 }
 
 function captureManagedEnv(): Record<ManagedEnvKey, string | undefined> {
@@ -285,27 +333,20 @@ async function setupTestEnvironment(): Promise<ActiveTestEnvironment> {
   await checkPrerequisites();
 
   const isolated = bootstrapIsolatedEnvironment();
-  const repoName = `hydra-e2e-${generateId()}`;
   const tempRoot = path.join(isolated.context.root, 'tmp');
-  const repoRoot = path.join(tempRoot, repoName);
 
   try {
-    await exec(`gh repo create ${repoName} --private --add-readme --clone`, {
-      cwd: tempRoot,
-    });
-    await exec('git config user.email "test@hydra.dev"', { cwd: repoRoot });
-    await exec('git config user.name "Hydra E2E"', { cwd: repoRoot });
+    const { repositoryFullName, repoRoot } = await prepareE2ERepository(tempRoot);
+    return {
+      isolated,
+      repoRoot,
+      repositoryFullName,
+    };
   } catch (error) {
     restoreManagedEnv(isolated.previousEnv);
     cleanupIsolatedEnvironment(isolated.context.root);
     throw error;
   }
-
-  return {
-    isolated,
-    repoRoot,
-    repoName,
-  };
 }
 
 function launchExtensionDevHost(workspacePath: string): void {
@@ -330,12 +371,6 @@ async function teardownTestEnvironment(): Promise<void> {
       await exec('tmux kill-server');
     } catch {
       // The isolated tmux server may already be gone.
-    }
-
-    try {
-      await exec(`gh repo delete ${environment.repoName} --yes`);
-    } catch {
-      // Best-effort cleanup for remote repositories.
     }
   } finally {
     restoreManagedEnv(environment.isolated.previousEnv);

--- a/src/e2e/runner.ts
+++ b/src/e2e/runner.ts
@@ -1,0 +1,517 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn, spawnSync } from 'child_process';
+import { exec as execCore } from '../core/exec';
+import { shellQuote } from '../core/shell';
+import { TmuxBackendCore } from '../core/tmux';
+import { SessionManager } from '../core/sessionManager';
+import { getHydraArchiveFile, getHydraSessionsFile } from '../core/path';
+
+export interface TestResult {
+  name: string;
+  passed: boolean;
+  durationMs: number;
+  error?: string;
+}
+
+export interface TestReport {
+  results: TestResult[];
+  passed: number;
+  failed: number;
+  total: number;
+  durationMs: number;
+}
+
+type TestFn = () => Promise<void>;
+
+interface IsolatedEnvironmentContext {
+  root: string;
+  homeDir: string;
+  hydraHome: string;
+  hydraConfigPath: string;
+  tmuxSocket: string;
+  vscodeUserDataDir: string;
+  activateScript: string;
+  sampleInvocation: string;
+}
+
+interface ActiveIsolatedEnvironment {
+  context: IsolatedEnvironmentContext;
+  previousEnv: Record<ManagedEnvKey, string | undefined>;
+}
+
+interface ActiveTestEnvironment {
+  isolated: ActiveIsolatedEnvironment;
+  repoRoot: string;
+  repoName: string;
+}
+
+interface SessionFileWorkerEntry {
+  branch?: string;
+}
+
+interface SessionFileState {
+  workers?: Record<string, SessionFileWorkerEntry>;
+}
+
+interface ArchiveWorkerData {
+  branch?: string;
+}
+
+interface ArchiveEntry {
+  type?: string;
+  sessionName?: string;
+  data?: ArchiveWorkerData;
+}
+
+interface ArchiveState {
+  entries: ArchiveEntry[];
+}
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ISOLATED_RUNNER_PATH = path.join(REPO_ROOT, 'scripts', 'e2e-isolated-runner.js');
+const TEST_PREFIX = 'test-e2e-';
+const SCENARIO_TIMEOUT_MS = 5 * 60 * 1000;
+const POLL_INTERVAL_MS = 5000;
+const MANAGED_ENV_KEYS = [
+  'HYDRA_HOME',
+  'HYDRA_CONFIG_PATH',
+  'HYDRA_TMUX_SOCKET',
+  'HYDRA_E2E_ROOT',
+  'PATH',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'TMUX',
+  'TMUX_PANE',
+] as const;
+
+type ManagedEnvKey = typeof MANAGED_ENV_KEYS[number];
+
+let activeTestEnvironment: ActiveTestEnvironment | null = null;
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 8);
+}
+
+async function exec(command: string, opts?: { cwd?: string }): Promise<string> {
+  return execCore(command, opts);
+}
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout after ${Math.round(ms / 1000)}s: ${label}`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function detectAgent(): Promise<string> {
+  for (const agent of ['claude', 'codex', 'gemini']) {
+    try {
+      await exec(`which ${agent}`);
+      return agent;
+    } catch {
+      // Try the next agent.
+    }
+  }
+
+  throw new Error('No agent CLI found. Install one of: claude, codex, gemini');
+}
+
+async function checkPrerequisites(): Promise<void> {
+  const missing: string[] = [];
+  for (const command of ['tmux', 'git', 'gh', 'code']) {
+    try {
+      await exec(`which ${command}`);
+    } catch {
+      missing.push(command);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Prerequisite failed: missing commands: ${missing.join(', ')}`);
+  }
+
+  await detectAgent();
+
+  try {
+    await exec('gh auth status');
+  } catch {
+    throw new Error('Prerequisite failed: gh is not authenticated. Run: gh auth login');
+  }
+}
+
+function captureManagedEnv(): Record<ManagedEnvKey, string | undefined> {
+  return {
+    HYDRA_HOME: process.env.HYDRA_HOME,
+    HYDRA_CONFIG_PATH: process.env.HYDRA_CONFIG_PATH,
+    HYDRA_TMUX_SOCKET: process.env.HYDRA_TMUX_SOCKET,
+    HYDRA_E2E_ROOT: process.env.HYDRA_E2E_ROOT,
+    PATH: process.env.PATH,
+    TMPDIR: process.env.TMPDIR,
+    TMP: process.env.TMP,
+    TEMP: process.env.TEMP,
+    TMUX: process.env.TMUX,
+    TMUX_PANE: process.env.TMUX_PANE,
+  };
+}
+
+function restoreManagedEnv(previousEnv: Record<ManagedEnvKey, string | undefined>): void {
+  for (const key of MANAGED_ENV_KEYS) {
+    const previousValue = previousEnv[key];
+    if (previousValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previousValue;
+    }
+  }
+}
+
+function applyIsolatedEnvironment(context: IsolatedEnvironmentContext): ActiveIsolatedEnvironment {
+  const previousEnv = captureManagedEnv();
+  const hydraBinDir = path.join(context.hydraHome, 'bin');
+  const shimBinDir = path.join(context.root, 'bin');
+  const tmpDir = path.join(context.root, 'tmp');
+
+  process.env.HYDRA_HOME = context.hydraHome;
+  process.env.HYDRA_CONFIG_PATH = context.hydraConfigPath;
+  process.env.HYDRA_TMUX_SOCKET = context.tmuxSocket;
+  process.env.HYDRA_E2E_ROOT = context.root;
+  process.env.PATH = [hydraBinDir, shimBinDir, previousEnv.PATH || ''].filter(Boolean).join(':');
+  process.env.TMPDIR = tmpDir;
+  process.env.TMP = tmpDir;
+  process.env.TEMP = tmpDir;
+  delete process.env.TMUX;
+  delete process.env.TMUX_PANE;
+
+  return { context, previousEnv };
+}
+
+function bootstrapIsolatedEnvironment(): ActiveIsolatedEnvironment {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-e2e-runner-'));
+  const result = spawnSync(process.execPath, [
+    ISOLATED_RUNNER_PATH,
+    '--keep',
+    '--root',
+    root,
+  ], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    const message = stderr || stdout || `isolated runner exited with code ${result.status}`;
+    throw new Error(`Failed to prepare isolated test environment: ${message}`);
+  }
+
+  const contextPath = path.join(root, 'context.json');
+  if (!fs.existsSync(contextPath)) {
+    throw new Error(`Isolated runner did not create ${contextPath}`);
+  }
+
+  const context = JSON.parse(fs.readFileSync(contextPath, 'utf-8')) as IsolatedEnvironmentContext;
+  return applyIsolatedEnvironment(context);
+}
+
+function cleanupIsolatedEnvironment(root: string): void {
+  const result = spawnSync(process.execPath, [
+    ISOLATED_RUNNER_PATH,
+    '--cleanup',
+    '--root',
+    root,
+  ], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+
+  if (result.error || result.status !== 0) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function getActiveEnvironment(): ActiveTestEnvironment {
+  if (!activeTestEnvironment) {
+    throw new Error('E2E test environment is not initialized');
+  }
+
+  return activeTestEnvironment;
+}
+
+async function setupTestEnvironment(): Promise<ActiveTestEnvironment> {
+  await checkPrerequisites();
+
+  const isolated = bootstrapIsolatedEnvironment();
+  const repoName = `hydra-e2e-${generateId()}`;
+  const tempRoot = path.join(isolated.context.root, 'tmp');
+  const repoRoot = path.join(tempRoot, repoName);
+
+  try {
+    await exec(`gh repo create ${repoName} --private --add-readme --clone`, {
+      cwd: tempRoot,
+    });
+    await exec('git config user.email "test@hydra.dev"', { cwd: repoRoot });
+    await exec('git config user.name "Hydra E2E"', { cwd: repoRoot });
+  } catch (error) {
+    restoreManagedEnv(isolated.previousEnv);
+    cleanupIsolatedEnvironment(isolated.context.root);
+    throw error;
+  }
+
+  return {
+    isolated,
+    repoRoot,
+    repoName,
+  };
+}
+
+function launchExtensionDevHost(workspacePath: string): void {
+  spawn('code', [
+    `--extensionDevelopmentPath=${REPO_ROOT}`,
+    workspacePath,
+  ], {
+    detached: true,
+    env: process.env,
+    stdio: 'ignore',
+  }).unref();
+}
+
+async function teardownTestEnvironment(): Promise<void> {
+  const environment = activeTestEnvironment;
+  if (!environment) {
+    return;
+  }
+
+  try {
+    try {
+      await exec('tmux kill-server');
+    } catch {
+      // The isolated tmux server may already be gone.
+    }
+
+    try {
+      await exec(`gh repo delete ${environment.repoName} --yes`);
+    } catch {
+      // Best-effort cleanup for remote repositories.
+    }
+  } finally {
+    restoreManagedEnv(environment.isolated.previousEnv);
+    cleanupIsolatedEnvironment(environment.isolated.context.root);
+    activeTestEnvironment = null;
+  }
+}
+
+function readSessions(): SessionFileState {
+  const file = getHydraSessionsFile();
+  if (!fs.existsSync(file)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as SessionFileState;
+}
+
+function readArchive(): ArchiveState {
+  const file = getHydraArchiveFile();
+  if (!fs.existsSync(file)) {
+    return { entries: [] };
+  }
+
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as ArchiveState;
+}
+
+async function pollUntil<T>(
+  condition: () => T | false | null | undefined | Promise<T | false | null | undefined>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = await condition();
+    if (result) {
+      return result;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timeout waiting for: ${label}`);
+}
+
+function buildDemoPrompt(repoRoot: string, branchName: string, agentType: string): string {
+  const quotedRepoRoot = shellQuote(repoRoot);
+  const quotedBranchName = shellQuote(branchName);
+  const quotedTask = shellQuote(
+    'Write a Python script called calc.py that implements a calculator function. ' +
+    'But FIRST, ask me what operations to support. Wait for my answer before writing any code.',
+  );
+
+  return [
+    'I want you to demo the full Hydra copilot-worker workflow. Follow these steps:',
+    '',
+    '1. Create a worker to write a small Python script:',
+    `   hydra worker create --repo ${quotedRepoRoot} --branch ${quotedBranchName} --agent ${agentType} --task ${quotedTask}`,
+    '',
+    '2. The worker will ask you a clarification question about what operations to support.',
+    '   Check its progress with: hydra worker logs <session>',
+    "   Then answer it with: hydra worker send <session> 'Support addition and multiplication only. The function should be called calculate(a, op, b) and return the result.'",
+    '',
+    '3. Wait for the worker to finish implementing the code.',
+    '   Check progress with: hydra worker logs <session>',
+    '',
+    '4. Once the worker is done, review its work:',
+    '   - Check the file exists: ls <workdir>/calc.py',
+    '   - Review the code: cat <workdir>/calc.py',
+    '   - Verify it implements calculate(a, op, b) with + and * support',
+    '',
+    '5. If the code looks correct, approve and clean up:',
+    '   hydra worker delete <session>',
+    '',
+    '6. Print a summary of what happened.',
+    '',
+    "Important: Use the session name and workdir from the 'hydra worker create' output.",
+    'Wait at least 15-20 seconds between creating the worker and checking logs for the first time.',
+  ].join('\n');
+}
+
+const test_copilot_worker_conversation: TestFn = async () => {
+  const environment = getActiveEnvironment();
+  const backend = new TmuxBackendCore();
+  const sessionManager = new SessionManager(backend);
+  const branchName = `${TEST_PREFIX}demo-${generateId()}`;
+  const copilotName = `${TEST_PREFIX}copilot-${generateId()}`;
+  const agentType = await detectAgent();
+
+  launchExtensionDevHost(environment.repoRoot);
+  await sleep(3000);
+
+  const copilotInfo = await sessionManager.createCopilotAndFinalize({
+    workdir: environment.repoRoot,
+    agentType,
+    name: copilotName,
+    sessionName: copilotName,
+  });
+
+  const prompt = buildDemoPrompt(environment.repoRoot, branchName, agentType);
+  await backend.sendMessage(copilotInfo.sessionName, prompt);
+
+  const workerSessionName = await pollUntil(() => {
+    const sessions = readSessions();
+    for (const [sessionName, worker] of Object.entries(sessions.workers || {})) {
+      if (worker.branch === branchName) {
+        return sessionName;
+      }
+    }
+    return undefined;
+  }, SCENARIO_TIMEOUT_MS, 'worker to be created by copilot');
+
+  await pollUntil(() => {
+    return readArchive().entries.find(entry => (
+      entry.type === 'worker'
+      && entry.sessionName === workerSessionName
+      && entry.data?.branch === branchName
+    ));
+  }, SCENARIO_TIMEOUT_MS, 'worker to be archived after review and cleanup');
+
+  await sessionManager.deleteCopilot(copilotInfo.sessionName);
+
+  const liveSessions = await backend.listSessions();
+  const orphanedSessions = liveSessions.filter(session => session.name.includes(TEST_PREFIX));
+  assert(
+    orphanedSessions.length === 0,
+    `Orphan test sessions remain: ${orphanedSessions.map(session => session.name).join(', ')}`,
+  );
+
+  const archivedWorker = readArchive().entries.find(entry => (
+    entry.type === 'worker'
+    && entry.sessionName === workerSessionName
+    && entry.data?.branch === branchName
+  ));
+  assert(!!archivedWorker, 'Worker should be present in archive.json');
+};
+
+const ALL_TESTS: Array<{ name: string; fn: TestFn }> = [
+  { name: 'test_copilot_worker_conversation', fn: test_copilot_worker_conversation },
+];
+
+export async function runE2ETests(opts?: { filter?: string }): Promise<TestReport> {
+  const startTime = Date.now();
+  const results: TestResult[] = [];
+
+  let tests = ALL_TESTS;
+  if (opts?.filter) {
+    const filter = opts.filter.toLowerCase();
+    tests = tests.filter(test => test.name.toLowerCase().includes(filter));
+  }
+
+  if (tests.length === 0) {
+    return {
+      results,
+      passed: 0,
+      failed: 0,
+      total: 0,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  activeTestEnvironment = await setupTestEnvironment();
+
+  try {
+    for (const test of tests) {
+      const testStart = Date.now();
+
+      try {
+        await withTimeout(test.fn(), SCENARIO_TIMEOUT_MS + 90_000, test.name);
+        results.push({
+          name: test.name,
+          passed: true,
+          durationMs: Date.now() - testStart,
+        });
+      } catch (error) {
+        results.push({
+          name: test.name,
+          passed: false,
+          durationMs: Date.now() - testStart,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  } finally {
+    await teardownTestEnvironment();
+  }
+
+  const passed = results.filter(result => result.passed).length;
+  const failed = results.length - passed;
+
+  return {
+    results,
+    passed,
+    failed,
+    total: results.length,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
 import { attachCreate } from './commands/attachCreate';
+import { newTask } from './commands/newTask';
 import { removeTask } from './commands/removeTask';
 import { autoAttachOnStartup } from './commands/autoAttach';
 import {
@@ -33,6 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
     copilotView,
     workerView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
+    vscode.commands.registerCommand('hydra.createWorker', newTask),
     vscode.commands.registerCommand('tmux.removeTask', (item) => removeTask(item)),
     vscode.commands.registerCommand('tmux.refresh', () => { copilotProvider.refresh(); workerProvider.refresh(); }),
     vscode.commands.registerCommand('tmux.attach', attach),


### PR DESCRIPTION
## What changed

This PR ports the E2E scenario runner work onto the current branch state after PR #101.

- add a new TypeScript E2E runner at `src/e2e/runner.ts`
- expose `hydra test` from the CLI via `src/cli/commands/test.ts`
- refactor the runner to bootstrap through `scripts/e2e-isolated-runner.js` instead of maintaining its own isolated setup logic
- add a SessionManager-backed `newTask` command so VS Code worker creation follows the same path as the CLI
- register the new worker-create command in the extension and manifest
- keep path handling on the official `src/core/path.ts` APIs for `sessions.json` and `archive.json`

## Why

Worker #21 carried the scenario-test framework on top of an older branch shape. This integrates the useful parts without reintroducing the older `core/paths` layer or duplicating environment/bootstrap logic that now lives in the isolated runner script.

It also restores a UI entry point for worker creation that routes through `SessionManager`, keeping UI and CLI lifecycle behavior aligned.

## Impact

- contributors can run `hydra test` for the end-to-end copilot/worker scenario
- the E2E runner now uses the same isolated Hydra/tmux infrastructure already added in PR #101
- command-palette worker creation now shares the same create/resume behavior as the CLI path

## Validation

- `npm run compile`
- `npm run lint`
- `node out/cli/index.js test --filter does-not-match --json`

## Notes

I did not change `removeTask` because the current branch already uses the refactored SessionManager-aligned removal flow and is newer than the worker #21 version.
