### PR TITLE
[codex] Modernize the isolated quickstart demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Imagine you're porting 40 features from an old codebase. Doing it alone is a wee
 
 ---
 
+## First Five Minutes
+
+Want a safe, self-contained tour before pointing Hydra at a real repository?
+
+```bash
+./quickstart/run.sh
+```
+
+The quickstart boots a temporary isolated Hydra home, scaffolds a local demo repository inside that sandbox, and launches 3 parallel workers against it. No GitHub repo setup required. See [quickstart/README.md](quickstart/README.md) for the full flow.
+
+---
+
 ## Quick Start (60 Seconds)
 
 1. **Install:** Search for **"Hydra Code"** in the VS Code Marketplace.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Want a safe, self-contained tour before pointing Hydra at a real repository?
 ./quickstart/run.sh
 ```
 
-The quickstart boots a temporary isolated Hydra home, scaffolds a local demo repository inside that sandbox, and launches 3 parallel workers against it. No GitHub repo setup required. See [quickstart/README.md](quickstart/README.md) for the full flow.
+The quickstart boots a temporary isolated Hydra home, starts a copilot inside that sandbox, and lets the copilot scaffold a local demo repository plus 3 parallel workers. No GitHub repo setup required. See [quickstart/README.md](quickstart/README.md) for the full flow.
 
 ---
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,6 +1,6 @@
 # Hydra Quickstart Demo
 
-One command. No repo risk. Hydra spins up a temporary sandbox, scaffolds a local demo project, and launches 3 parallel workers so you can see the full workflow in your first few minutes.
+One command. No repo risk. Hydra spins up a temporary sandbox, starts a copilot, and lets that copilot scaffold a local demo project plus 3 parallel workers.
 
 ## Run It
 
@@ -20,14 +20,14 @@ Optional: force a specific agent or reuse a sandbox root.
 The script:
 
 1. Boots `scripts/e2e-isolated-runner.js` and creates an isolated Hydra home under your OS temp directory.
-2. Scaffolds a local TypeScript calculator repo plus a local bare `origin` inside that sandbox.
-3. Installs demo dependencies and pushes `main` to the local remote.
-4. Spawns 3 parallel Hydra workers:
+2. Starts one copilot inside the sandbox.
+3. Hands that copilot a local-only quickstart task.
+4. The copilot creates a local TypeScript calculator repo plus a local bare `origin`.
+5. The copilot spawns 3 parallel Hydra workers:
    - `feat/core` implements the calculator core
    - `feat/cli` builds a Commander-based CLI
    - `feat/tests` writes Vitest coverage
-5. Polls until each worker has pushed its branch inside the sandbox.
-6. Prints the exact paths and follow-up commands to inspect the result.
+6. Prints the exact commands to inspect the copilot and worker sessions.
 
 ## What Gets Created
 
@@ -35,26 +35,28 @@ The run is isolated from your real Hydra home and your current repository.
 
 - `.../home` is the temporary HOME for the sandbox.
 - `.../hydra-home` holds the isolated Hydra state, tmux socket, and worktrees.
-- `.../playground/hydra-demo` is the demo repo you can inspect.
-- `.../playground/hydra-demo-origin.git` is the local bare remote used by the demo.
+- `.../playground` is the copilot work area.
+- `.../playground/hydra-demo` is the demo repo the copilot creates.
+- `.../playground/hydra-demo-origin.git` is the local bare remote the copilot creates.
 
 The sandbox root path is printed when the run starts and again in the final summary.
 
 ## Follow-Up Commands
 
-After the demo finishes, source the generated activation script so `hydra` points at the sandbox:
+After launch, source the generated activation script so `hydra` points at the sandbox:
 
 ```bash
 source /tmp/hydra-.../activate.sh
 hydra list --json
-git -C /tmp/hydra-.../playground/hydra-demo log --oneline --graph --all
+hydra copilot logs hydra-quickstart --lines 80
 ```
 
-To open the demo repo in VS Code with the isolated user-data directory:
+Once the copilot finishes scaffolding the demo repo, inspect it with:
 
 ```bash
 source /tmp/hydra-.../activate.sh
-code --extensionDevelopmentPath=. /tmp/hydra-.../playground/hydra-demo
+git -C /tmp/hydra-.../playground/hydra-demo log --oneline --graph --all
+code --extensionDevelopmentPath=. /tmp/hydra-.../playground
 ```
 
 ## Requirements
@@ -68,7 +70,7 @@ If the Hydra CLI build output is missing, the script runs `npm run compile` auto
 
 ## Cleanup
 
-The quickstart preserves the sandbox by default so you can inspect the worktrees and logs.
+The quickstart preserves the sandbox by default so you can inspect the copilot, worktrees, and logs.
 
 When you are done:
 
@@ -86,6 +88,7 @@ Delete workers one at a time if you want the sidebar state to stay responsive.
 | Issue | Fix |
 |-------|-----|
 | No agent is detected | Re-run with `--agent <name>` or install one of `codex`, `claude`, `gemini` |
+| The copilot seems idle | `source <sandbox>/activate.sh` then run `hydra copilot logs hydra-quickstart --lines 80` |
 | A worker stalls | `source <sandbox>/activate.sh` then run `hydra worker logs <session> --lines 80` |
 | You want a clean rerun in the same sandbox | Re-run with the same `--root`; the script resets the isolated Hydra state first |
 | The CLI build is missing | Run `npm install && npm run compile`, then re-run the quickstart |

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,0 +1,91 @@
+# Hydra Quickstart Demo
+
+One command. No repo risk. Hydra spins up a temporary sandbox, scaffolds a local demo project, and launches 3 parallel workers so you can see the full workflow in your first few minutes.
+
+## Run It
+
+```bash
+./quickstart/run.sh
+```
+
+Optional: force a specific agent or reuse a sandbox root.
+
+```bash
+./quickstart/run.sh --agent codex
+./quickstart/run.sh --root /tmp/hydra-quickstart-demo
+```
+
+## What It Does
+
+The script:
+
+1. Boots `scripts/e2e-isolated-runner.js` and creates an isolated Hydra home under your OS temp directory.
+2. Scaffolds a local TypeScript calculator repo plus a local bare `origin` inside that sandbox.
+3. Installs demo dependencies and pushes `main` to the local remote.
+4. Spawns 3 parallel Hydra workers:
+   - `feat/core` implements the calculator core
+   - `feat/cli` builds a Commander-based CLI
+   - `feat/tests` writes Vitest coverage
+5. Polls until each worker has pushed its branch inside the sandbox.
+6. Prints the exact paths and follow-up commands to inspect the result.
+
+## What Gets Created
+
+The run is isolated from your real Hydra home and your current repository.
+
+- `.../home` is the temporary HOME for the sandbox.
+- `.../hydra-home` holds the isolated Hydra state, tmux socket, and worktrees.
+- `.../playground/hydra-demo` is the demo repo you can inspect.
+- `.../playground/hydra-demo-origin.git` is the local bare remote used by the demo.
+
+The sandbox root path is printed when the run starts and again in the final summary.
+
+## Follow-Up Commands
+
+After the demo finishes, source the generated activation script so `hydra` points at the sandbox:
+
+```bash
+source /tmp/hydra-.../activate.sh
+hydra list --json
+git -C /tmp/hydra-.../playground/hydra-demo log --oneline --graph --all
+```
+
+To open the demo repo in VS Code with the isolated user-data directory:
+
+```bash
+source /tmp/hydra-.../activate.sh
+code --extensionDevelopmentPath=. /tmp/hydra-.../playground/hydra-demo
+```
+
+## Requirements
+
+- `git`
+- `tmux`
+- `node` and `npm`
+- At least one supported agent CLI on `PATH`: `codex`, `claude`, or `gemini`
+
+If the Hydra CLI build output is missing, the script runs `npm run compile` automatically before entering the sandbox.
+
+## Cleanup
+
+The quickstart preserves the sandbox by default so you can inspect the worktrees and logs.
+
+When you are done:
+
+```bash
+source /tmp/hydra-.../activate.sh
+hydra list --json
+hydra worker delete <session>
+rm -rf /tmp/hydra-...
+```
+
+Delete workers one at a time if you want the sidebar state to stay responsive.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| No agent is detected | Re-run with `--agent <name>` or install one of `codex`, `claude`, `gemini` |
+| A worker stalls | `source <sandbox>/activate.sh` then run `hydra worker logs <session> --lines 80` |
+| You want a clean rerun in the same sandbox | Re-run with the same `--root`; the script resets the isolated Hydra state first |
+| The CLI build is missing | Run `npm install && npm run compile`, then re-run the quickstart |

--- a/quickstart/copilot-prompt.md
+++ b/quickstart/copilot-prompt.md
@@ -1,0 +1,89 @@
+You are the copilot for Hydra's isolated quickstart demo.
+
+Operate from the current working directory. Do not ask follow-up questions unless blocked by a real error. Keep the run self-contained and local-only: do not use GitHub, `gh`, or any network repo hosting.
+
+Goal:
+
+1. Create a bare local remote at `./hydra-demo-origin.git`.
+2. Create a working repository at `./hydra-demo`.
+3. Scaffold a tiny TypeScript calculator project in `./hydra-demo`.
+4. Commit and push `main` to the local bare remote.
+5. Spawn 3 Hydra workers with agent `__AGENT__` against `./hydra-demo`.
+6. Monitor them, review obvious problems, and nudge them if needed.
+7. Finish by printing a concise status summary in this copilot session.
+
+Repository scaffold requirements:
+
+- `package.json` with `commander`, `typescript`, and `vitest`
+- `tsconfig.json` with a minimal strict NodeNext TypeScript setup
+- `src/calculator.ts` exporting:
+  - `type CalcOperation = 'add' | 'subtract' | 'multiply' | 'divide'`
+  - `add`, `subtract`, `multiply`, `divide`
+  - `calculate(op, a, b)`
+- `src/index.ts` re-exporting from `./calculator.js`
+- `.gitignore` for `dist` and `node_modules`
+- `README.md` explaining that this repo is the quickstart sandbox demo
+
+Important constraints:
+
+- Keep everything inside the current directory tree.
+- Use the local bare repo as `origin`.
+- Do not touch the parent Hydra repository.
+- Use `hydra worker create --repo ./hydra-demo --branch <name> --agent __AGENT__ ...`.
+- Use one branch per worker.
+- Monitor with `hydra worker logs`.
+- Review with `git -C <workdir> diff`.
+- If a worker makes a bad choice, correct it with `hydra worker send`.
+- Do not clean up the workers automatically; leave them available for inspection.
+
+Worker plan:
+
+1. `feat/core`
+Task:
+Implement the calculator core in `src/calculator.ts`.
+Requirements:
+- implement `add`, `subtract`, `multiply`, `divide`
+- `divide` must throw an `Error` on division by zero
+- implement `calculate(op, a, b)` as the dispatcher
+- keep the branch focused on the calculator core
+- run `npm run build`
+- commit with `feat: implement calculator core`
+- push with `git push -u origin feat/core`
+
+2. `feat/cli`
+Task:
+Create `src/cli.ts` using `commander`.
+Requirements:
+- add a `#!/usr/bin/env node` shebang
+- expose `calc <operation> <a> <b>`
+- import from `./calculator.js`
+- support `add`, `subtract`, `multiply`, `divide`
+- print the result to stdout
+- print errors to stderr and exit 1
+- run `npm run build`
+- commit with `feat: add calculator cli`
+- push with `git push -u origin feat/cli`
+
+3. `feat/tests`
+Task:
+Create `src/calculator.test.ts` with Vitest coverage.
+Requirements:
+- test `add`, `subtract`, `multiply`, `divide`
+- test division by zero
+- test the `calculate` dispatcher
+- include negative numbers, zero, and decimals
+- include at least 12 assertions total
+- commit with `test: add calculator coverage`
+- push with `git push -u origin feat/tests`
+
+Execution notes:
+
+- After scaffolding the repo, run `npm install --no-fund --no-audit`.
+- Commit the scaffold on `main` before creating workers.
+- Let the workers do the implementation work. Do not manually do their tasks in the copilot unless recovery is necessary.
+- Wait until all 3 worker branches are pushed to the local `origin`.
+- End with:
+  - the repo path
+  - the worker session names
+  - which branches were pushed
+  - any branch that still needs attention

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -6,24 +6,21 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 RUNNER_SCRIPT="${REPO_ROOT}/scripts/e2e-isolated-runner.js"
 CLI_ENTRY="${REPO_ROOT}/out/cli/index.js"
+PROMPT_TEMPLATE="${SCRIPT_DIR}/copilot-prompt.md"
 
-POLL_INTERVAL=20
-MAX_WAIT=360
 REQUESTED_AGENT=""
 REQUESTED_ROOT=""
 INNER_MODE=0
 
-RED=$'\033[0;31m'
-GREEN=$'\033[0;32m'
-YELLOW=$'\033[1;33m'
 BLUE=$'\033[0;34m'
+GREEN=$'\033[0;32m'
+RED=$'\033[0;31m'
 BOLD=$'\033[1m'
 DIM=$'\033[2m'
 RESET=$'\033[0m'
 
 info() { printf '%s▶%s %s\n' "${BLUE}" "${RESET}" "$*"; }
 ok() { printf '%s✔%s %s\n' "${GREEN}" "${RESET}" "$*"; }
-warn() { printf '%s⚠%s %s\n' "${YELLOW}" "${RESET}" "$*"; }
 die() { printf '%s✘%s %s\n' "${RED}" "${RESET}" "$*" >&2; exit 1; }
 
 print_usage() {
@@ -34,12 +31,10 @@ Usage:
   ./quickstart/run.sh [options]
 
 Options:
-  --agent <name>            Force a specific agent: codex, claude, or gemini.
-  --root <path>             Reuse a specific isolated sandbox root.
-  --poll-interval <secs>    Worker polling interval in seconds. Default: 20.
-  --max-wait <secs>         Max time to wait for all branches. Default: 360.
-  --inner                   Internal flag used by the isolated runner.
-  -h, --help                Show this help.
+  --agent <name>   Force a specific agent: codex, claude, or gemini.
+  --root <path>    Reuse a specific isolated sandbox root.
+  --inner          Internal flag used by the isolated runner.
+  -h, --help       Show this help.
 EOF
 }
 
@@ -63,16 +58,6 @@ while [[ $# -gt 0 ]]; do
       REQUESTED_ROOT="$2"
       shift 2
       ;;
-    --poll-interval)
-      require_value "$1" "${2-}"
-      POLL_INTERVAL="$2"
-      shift 2
-      ;;
-    --max-wait)
-      require_value "$1" "${2-}"
-      MAX_WAIT="$2"
-      shift 2
-      ;;
     --inner)
       INNER_MODE=1
       shift
@@ -86,23 +71,6 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-
-case "${POLL_INTERVAL}" in
-  ''|*[!0-9]*)
-    die "--poll-interval must be a positive integer"
-    ;;
-esac
-case "${MAX_WAIT}" in
-  ''|*[!0-9]*)
-    die "--max-wait must be a positive integer"
-    ;;
-esac
-if (( POLL_INTERVAL <= 0 )); then
-  die "--poll-interval must be greater than 0"
-fi
-if (( MAX_WAIT <= 0 )); then
-  die "--max-wait must be greater than 0"
-fi
 
 ensure_cli_build() {
   if [[ -f "${CLI_ENTRY}" ]]; then
@@ -120,11 +88,7 @@ if (( INNER_MODE == 0 )) && [[ -z "${HYDRA_E2E_ROOT:-}" ]]; then
   ensure_cli_build
 
   runner_args=(--keep)
-  inner_args=(
-    --inner
-    --poll-interval "${POLL_INTERVAL}"
-    --max-wait "${MAX_WAIT}"
-  )
+  inner_args=(--inner)
   if [[ -n "${REQUESTED_ROOT}" ]]; then
     runner_args+=(--root "${REQUESTED_ROOT}")
   fi
@@ -133,8 +97,7 @@ if (( INNER_MODE == 0 )) && [[ -z "${HYDRA_E2E_ROOT:-}" ]]; then
   fi
 
   exec node "${RUNNER_SCRIPT}" "${runner_args[@]}" -- \
-    bash "${SCRIPT_DIR}/run.sh" \
-      "${inner_args[@]}"
+    bash "${SCRIPT_DIR}/run.sh" "${inner_args[@]}"
 fi
 
 command_exists() {
@@ -143,9 +106,7 @@ command_exists() {
 
 pick_agent() {
   if [[ -n "${REQUESTED_AGENT}" ]]; then
-    if ! command_exists "${REQUESTED_AGENT}"; then
-      die "Requested agent '${REQUESTED_AGENT}' is not on PATH"
-    fi
+    command_exists "${REQUESTED_AGENT}" || die "Requested agent '${REQUESTED_AGENT}' is not on PATH"
     printf '%s' "${REQUESTED_AGENT}"
     return
   fi
@@ -174,14 +135,10 @@ json_field() {
   ' "${field}"
 }
 
-count_running_workers() {
-  hydra list --json | node -e '
-    const fs = require("fs");
-    const data = JSON.parse(fs.readFileSync(0, "utf8"));
-    const workers = Array.isArray(data.workers) ? data.workers : [];
-    const running = workers.filter(worker => worker && worker.status === "running").length;
-    process.stdout.write(String(running));
-  '
+render_prompt() {
+  local agent="$1"
+  local prompt_path="$2"
+  sed "s/__AGENT__/${agent}/g" "${PROMPT_TEMPLATE}" > "${prompt_path}"
 }
 
 reset_isolated_state() {
@@ -196,362 +153,49 @@ reset_isolated_state() {
   fi
 }
 
-write_demo_files() {
-  cat > package.json <<'EOF'
-{
-  "name": "hydra-demo",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Hydra quickstart sandbox project",
-  "type": "module",
-  "scripts": {
-    "build": "tsc",
-    "test": "vitest run",
-    "start": "node dist/cli.js"
-  },
-  "dependencies": {
-    "commander": "^14.0.3"
-  },
-  "devDependencies": {
-    "typescript": "^5.4.0",
-    "vitest": "^2.0.0"
-  }
-}
-EOF
-
-  cat > tsconfig.json <<'EOF'
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "outDir": "dist",
-    "rootDir": "src",
-    "strict": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
-  },
-  "include": ["src/**/*"]
-}
-EOF
-
-  cat > .gitignore <<'EOF'
-dist
-node_modules
-EOF
-
-  mkdir -p src
-
-  cat > src/calculator.ts <<'EOF'
-export type CalcOperation = 'add' | 'subtract' | 'multiply' | 'divide';
-
-function todo(name: string): never {
-  throw new Error(`${name} is not implemented yet.`);
-}
-
-export function add(a: number, b: number): number {
-  return todo(`add(${a}, ${b})`);
-}
-
-export function subtract(a: number, b: number): number {
-  return todo(`subtract(${a}, ${b})`);
-}
-
-export function multiply(a: number, b: number): number {
-  return todo(`multiply(${a}, ${b})`);
-}
-
-export function divide(a: number, b: number): number {
-  return todo(`divide(${a}, ${b})`);
-}
-
-export function calculate(op: CalcOperation, a: number, b: number): number {
-  switch (op) {
-    case 'add':
-      return add(a, b);
-    case 'subtract':
-      return subtract(a, b);
-    case 'multiply':
-      return multiply(a, b);
-    case 'divide':
-      return divide(a, b);
-  }
-}
-EOF
-
-  cat > src/index.ts <<'EOF'
-export * from './calculator.js';
-EOF
-
-  cat > README.md <<'EOF'
-# Hydra Demo Workspace
-
-This repository was scaffolded by `quickstart/run.sh` inside an isolated Hydra sandbox.
-
-Branches created by the demo:
-
-- `feat/core` implements the calculator contract
-- `feat/cli` builds a small CLI on top of that contract
-- `feat/tests` adds Vitest coverage for the contract
-EOF
-}
-
-make_task_core() {
-  cat <<'EOF'
-You own `src/calculator.ts` and `src/index.ts`.
-
-Implement the calculator contract that is already scaffolded in `src/calculator.ts`:
-- `add(a, b)`
-- `subtract(a, b)`
-- `multiply(a, b)`
-- `divide(a, b)` with an `Error` on division by zero
-- `calculate(op, a, b)` as the dispatcher
-
-Constraints:
-- Keep the branch focused on the calculator core.
-- Do not edit the CLI or test files.
-- Keep relative TypeScript imports compatible with `module: "NodeNext"` by using `.js` extensions in TS imports when needed.
-
-Before finishing:
-1. Run `npm run build`.
-2. Commit with message `feat: implement calculator core`.
-3. Push with `git push -u origin feat/core`.
-EOF
-}
-
-make_task_cli() {
-  cat <<'EOF'
-You own `src/cli.ts` only.
-
-Build a CLI using `commander` with the shape `calc <operation> <a> <b>`.
-Requirements:
-- Use a `#!/usr/bin/env node` shebang.
-- Import `calculate` and `CalcOperation` from `./calculator.js`.
-- Accept `add`, `subtract`, `multiply`, and `divide`.
-- Print the numeric result to stdout.
-- Print errors to stderr and exit with code 1.
-
-Constraints:
-- Do not modify calculator logic or test files.
-- Assume the calculator contract in `src/calculator.ts` is the source of truth.
-
-Before finishing:
-1. Run `npm run build`.
-2. Commit with message `feat: add calculator cli`.
-3. Push with `git push -u origin feat/cli`.
-EOF
-}
-
-make_task_tests() {
-  cat <<'EOF'
-You own `src/calculator.test.ts` only.
-
-Write a Vitest suite for the calculator contract in `src/calculator.ts`.
-Coverage requirements:
-- add, subtract, multiply, divide
-- division by zero
-- the `calculate` dispatcher
-- negative numbers, zero, and decimals
-- at least 12 assertions total
-
-Constraints:
-- Do not edit the calculator implementation or the CLI.
-- This branch is allowed to target the contract even if the placeholder implementation on `main` still fails the new tests.
-
-Before finishing:
-1. Commit with message `test: add calculator coverage`.
-2. Push with `git push -u origin feat/tests`.
-EOF
-}
-
-spawn_worker() {
-  local branch="$1"
-  local task="$2"
-  local result
-  result="$(hydra worker create --repo "${WORK_DIR}" --branch "${branch}" --agent "${AGENT}" --task "${task}" --json)"
-  local session workdir
-  session="$(printf '%s' "${result}" | json_field session)"
-  workdir="$(printf '%s' "${result}" | json_field workdir)"
-  printf '%s\t%s' "${session}" "${workdir}"
-}
-
-remote_branch_exists() {
-  git --git-dir="${ORIGIN_DIR}" show-ref --verify --quiet "refs/heads/$1"
-}
-
-local_commits_ahead() {
-  git -C "${WORK_DIR}" rev-list --count "main..$1" 2>/dev/null || printf '0'
-}
-
-branch_state_label() {
-  local branch="$1"
-  local expected_file="$2"
-  local workdir="$3"
-
-  if remote_branch_exists "${branch}" && [[ -f "${workdir}/${expected_file}" ]]; then
-    printf 'pushed'
-    return
-  fi
-
-  if [[ -f "${workdir}/${expected_file}" ]]; then
-    printf 'edited'
-    return
-  fi
-
-  local commits
-  commits="$(local_commits_ahead "${branch}")"
-  if [[ "${commits}" != "0" ]]; then
-    printf 'committed'
-    return
-  fi
-
-  printf 'running'
-}
-
-printf '\n%sHydra Quickstart Demo%s\n' "${BOLD}" "${RESET}"
-printf '%sIsolated sandbox, local repo, 3 parallel workers.%s\n\n' "${DIM}" "${RESET}"
-
-for required_cmd in git node npm hydra tmux; do
-  if ! command_exists "${required_cmd}"; then
-    die "Required command '${required_cmd}' is not on PATH"
-  fi
+for required_cmd in hydra node tmux; do
+  command_exists "${required_cmd}" || die "Required command '${required_cmd}' is not on PATH"
 done
+
+[[ -f "${PROMPT_TEMPLATE}" ]] || die "Missing prompt template: ${PROMPT_TEMPLATE}"
 
 AGENT="$(pick_agent)"
 SANDBOX_ROOT="${HYDRA_E2E_ROOT:-}"
-if [[ -z "${SANDBOX_ROOT}" ]]; then
-  SANDBOX_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hydra-quickstart-XXXXXX")"
-fi
-
 ACTIVATE_SCRIPT="${SANDBOX_ROOT}/activate.sh"
 PLAYGROUND_DIR="${SANDBOX_ROOT}/playground"
-ORIGIN_DIR="${PLAYGROUND_DIR}/hydra-demo-origin.git"
-WORK_DIR="${PLAYGROUND_DIR}/hydra-demo"
-INSTALL_LOG="${PLAYGROUND_DIR}/npm-install.log"
+PROMPT_FILE="${PLAYGROUND_DIR}/quickstart-copilot-task.md"
+SESSION_NAME="hydra-quickstart"
+
+printf '\n%sHydra Quickstart Demo%s\n' "${BOLD}" "${RESET}"
+printf '%sMinimal bootstrap. Hydra does the rest.%s\n\n' "${DIM}" "${RESET}"
 
 info "Using agent: ${AGENT}"
 info "Sandbox root: ${SANDBOX_ROOT}"
 
 reset_isolated_state
-
-if [[ -e "${PLAYGROUND_DIR}" ]]; then
-  warn "Resetting existing quickstart playground at ${PLAYGROUND_DIR}"
-  rm -rf "${PLAYGROUND_DIR}"
-fi
+rm -rf "${PLAYGROUND_DIR}"
 mkdir -p "${PLAYGROUND_DIR}"
 
-info "Creating local demo repository..."
-git init --bare "${ORIGIN_DIR}" >/dev/null
-git init -b main "${WORK_DIR}" >/dev/null
-cd "${WORK_DIR}"
-git config user.name "Hydra Quickstart"
-git config user.email "quickstart@hydra.local"
-git remote add origin "${ORIGIN_DIR}"
-write_demo_files
-ok "Workspace scaffolded at ${WORK_DIR}"
+render_prompt "${AGENT}" "${PROMPT_FILE}"
 
-info "Installing demo dependencies..."
-if npm install --no-fund --no-audit >"${INSTALL_LOG}" 2>&1; then
-  ok "Dependencies installed"
-else
-  die "npm install failed. See ${INSTALL_LOG}"
-fi
+info "Creating quickstart copilot..."
+COPILOT_JSON="$(hydra copilot create --workdir "${PLAYGROUND_DIR}" --agent "${AGENT}" --session "${SESSION_NAME}" --json)"
+COPILOT_SESSION="$(printf '%s' "${COPILOT_JSON}" | json_field session)"
 
-git add -A
-git commit -m "chore: scaffold quickstart demo" >/dev/null
-git push -u origin main >/dev/null
-ok "Local origin seeded"
-
-TASK_CORE="$(make_task_core)"
-TASK_CLI="$(make_task_cli)"
-TASK_TESTS="$(make_task_tests)"
-
-declare -A SESSION_BY_BRANCH
-declare -A WORKDIR_BY_BRANCH
-declare -A FILE_BY_BRANCH=(
-  ["feat/core"]="src/calculator.ts"
-  ["feat/cli"]="src/cli.ts"
-  ["feat/tests"]="src/calculator.test.ts"
-)
-
-info "Spawning 3 parallel workers..."
-
-IFS=$'\t' read -r core_session core_workdir <<<"$(spawn_worker "feat/core" "${TASK_CORE}")"
-SESSION_BY_BRANCH["feat/core"]="${core_session}"
-WORKDIR_BY_BRANCH["feat/core"]="${core_workdir}"
-printf '  %s●%s %sfeat/core%s  -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${core_session}"
-
-IFS=$'\t' read -r cli_session cli_workdir <<<"$(spawn_worker "feat/cli" "${TASK_CLI}")"
-SESSION_BY_BRANCH["feat/cli"]="${cli_session}"
-WORKDIR_BY_BRANCH["feat/cli"]="${cli_workdir}"
-printf '  %s●%s %sfeat/cli%s   -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${cli_session}"
-
-IFS=$'\t' read -r tests_session tests_workdir <<<"$(spawn_worker "feat/tests" "${TASK_TESTS}")"
-SESSION_BY_BRANCH["feat/tests"]="${tests_session}"
-WORKDIR_BY_BRANCH["feat/tests"]="${tests_workdir}"
-printf '  %s●%s %sfeat/tests%s -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${tests_session}"
-
-ok "All workers launched"
-
-info "Monitoring worker branches for up to ${MAX_WAIT}s..."
-printf '%sUse the activation script below if you want to inspect the sandbox in another shell.%s\n\n' "${DIM}" "${RESET}"
-
-elapsed=0
-completed=0
-branches=("feat/core" "feat/cli" "feat/tests")
-
-while (( elapsed < MAX_WAIT )); do
-  completed=0
-  status_parts=()
-
-  for branch in "${branches[@]}"; do
-    status="$(branch_state_label "${branch}" "${FILE_BY_BRANCH[$branch]}" "${WORKDIR_BY_BRANCH[$branch]}")"
-    status_parts+=("${branch}=${status}")
-    if [[ "${status}" == "pushed" ]]; then
-      completed=$((completed + 1))
-    fi
-  done
-
-  running_workers="$(count_running_workers)"
-  printf '  %s[%3ss]%s branches: %s/3 | active workers: %s | %s\n' \
-    "${DIM}" "${elapsed}" "${RESET}" "${completed}" "${running_workers}" "${status_parts[*]}"
-
-  if (( completed == 3 )); then
-    break
-  fi
-
-  sleep "${POLL_INTERVAL}"
-  elapsed=$((elapsed + POLL_INTERVAL))
-done
+info "Sending orchestration task to ${COPILOT_SESSION}..."
+hydra copilot send "${COPILOT_SESSION}" "$(cat "${PROMPT_FILE}")" >/dev/null
+ok "Quickstart launched"
 
 printf '\n'
-if (( completed == 3 )); then
-  printf '%s%sHydra Quickstart Complete%s\n' "${GREEN}" "${BOLD}" "${RESET}"
-else
-  printf '%s%sHydra Quickstart Timed Out%s\n' "${YELLOW}" "${BOLD}" "${RESET}"
-fi
-
-printf '  sandbox:   %s\n' "${SANDBOX_ROOT}"
-printf '  activate:  source %q\n' "${ACTIVATE_SCRIPT}"
-printf '  workspace: %s\n' "${WORK_DIR}"
-printf '  origin:    %s\n' "${ORIGIN_DIR}"
-printf '  agent:     %s\n' "${AGENT}"
+printf '  copilot:    %s\n' "${COPILOT_SESSION}"
+printf '  sandbox:    %s\n' "${SANDBOX_ROOT}"
+printf '  activate:   source %q\n' "${ACTIVATE_SCRIPT}"
+printf '  workspace:  %s\n' "${PLAYGROUND_DIR}"
 printf '\n'
 
-info "Worker summary"
-for branch in "${branches[@]}"; do
-  printf '  %-10s | %-8s | %s\n' \
-    "${branch}" \
-    "$(branch_state_label "${branch}" "${FILE_BY_BRANCH[$branch]}" "${WORKDIR_BY_BRANCH[$branch]}")" \
-    "${SESSION_BY_BRANCH[$branch]}"
-done
-
-printf '\n'
 info "Next commands"
 printf '  source %q\n' "${ACTIVATE_SCRIPT}"
 printf '  hydra list --json\n'
-printf '  git -C %q log --oneline --graph --all --decorate\n' "${WORK_DIR}"
-printf '  hydra worker logs %q --lines 80\n' "${SESSION_BY_BRANCH[feat/core]}"
-printf '  code --extensionDevelopmentPath=%q %q\n' "${REPO_ROOT}" "${WORK_DIR}"
+printf '  hydra copilot logs %q --lines 80\n' "${COPILOT_SESSION}"
+printf '  code --extensionDevelopmentPath=%q %q\n' "${REPO_ROOT}" "${PLAYGROUND_DIR}"
 printf '\n'

--- a/quickstart/run.sh
+++ b/quickstart/run.sh
@@ -1,0 +1,557 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+RUNNER_SCRIPT="${REPO_ROOT}/scripts/e2e-isolated-runner.js"
+CLI_ENTRY="${REPO_ROOT}/out/cli/index.js"
+
+POLL_INTERVAL=20
+MAX_WAIT=360
+REQUESTED_AGENT=""
+REQUESTED_ROOT=""
+INNER_MODE=0
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+RESET=$'\033[0m'
+
+info() { printf '%s▶%s %s\n' "${BLUE}" "${RESET}" "$*"; }
+ok() { printf '%s✔%s %s\n' "${GREEN}" "${RESET}" "$*"; }
+warn() { printf '%s⚠%s %s\n' "${YELLOW}" "${RESET}" "$*"; }
+die() { printf '%s✘%s %s\n' "${RED}" "${RESET}" "$*" >&2; exit 1; }
+
+print_usage() {
+  cat <<'EOF'
+Hydra Quickstart Demo
+
+Usage:
+  ./quickstart/run.sh [options]
+
+Options:
+  --agent <name>            Force a specific agent: codex, claude, or gemini.
+  --root <path>             Reuse a specific isolated sandbox root.
+  --poll-interval <secs>    Worker polling interval in seconds. Default: 20.
+  --max-wait <secs>         Max time to wait for all branches. Default: 360.
+  --inner                   Internal flag used by the isolated runner.
+  -h, --help                Show this help.
+EOF
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2-}"
+  if [[ -z "${value}" ]]; then
+    die "${flag} requires a value"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      require_value "$1" "${2-}"
+      REQUESTED_AGENT="$2"
+      shift 2
+      ;;
+    --root)
+      require_value "$1" "${2-}"
+      REQUESTED_ROOT="$2"
+      shift 2
+      ;;
+    --poll-interval)
+      require_value "$1" "${2-}"
+      POLL_INTERVAL="$2"
+      shift 2
+      ;;
+    --max-wait)
+      require_value "$1" "${2-}"
+      MAX_WAIT="$2"
+      shift 2
+      ;;
+    --inner)
+      INNER_MODE=1
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+case "${POLL_INTERVAL}" in
+  ''|*[!0-9]*)
+    die "--poll-interval must be a positive integer"
+    ;;
+esac
+case "${MAX_WAIT}" in
+  ''|*[!0-9]*)
+    die "--max-wait must be a positive integer"
+    ;;
+esac
+if (( POLL_INTERVAL <= 0 )); then
+  die "--poll-interval must be greater than 0"
+fi
+if (( MAX_WAIT <= 0 )); then
+  die "--max-wait must be greater than 0"
+fi
+
+ensure_cli_build() {
+  if [[ -f "${CLI_ENTRY}" ]]; then
+    return
+  fi
+
+  info "Hydra CLI build output is missing. Running npm run compile..."
+  (
+    cd "${REPO_ROOT}"
+    npm run compile
+  )
+}
+
+if (( INNER_MODE == 0 )) && [[ -z "${HYDRA_E2E_ROOT:-}" ]]; then
+  ensure_cli_build
+
+  runner_args=(--keep)
+  inner_args=(
+    --inner
+    --poll-interval "${POLL_INTERVAL}"
+    --max-wait "${MAX_WAIT}"
+  )
+  if [[ -n "${REQUESTED_ROOT}" ]]; then
+    runner_args+=(--root "${REQUESTED_ROOT}")
+  fi
+  if [[ -n "${REQUESTED_AGENT}" ]]; then
+    inner_args+=(--agent "${REQUESTED_AGENT}")
+  fi
+
+  exec node "${RUNNER_SCRIPT}" "${runner_args[@]}" -- \
+    bash "${SCRIPT_DIR}/run.sh" \
+      "${inner_args[@]}"
+fi
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+pick_agent() {
+  if [[ -n "${REQUESTED_AGENT}" ]]; then
+    if ! command_exists "${REQUESTED_AGENT}"; then
+      die "Requested agent '${REQUESTED_AGENT}' is not on PATH"
+    fi
+    printf '%s' "${REQUESTED_AGENT}"
+    return
+  fi
+
+  local candidate
+  for candidate in codex claude gemini; do
+    if command_exists "${candidate}"; then
+      printf '%s' "${candidate}"
+      return
+    fi
+  done
+
+  die "No supported agent CLI found on PATH. Install codex, claude, or gemini."
+}
+
+json_field() {
+  local field="$1"
+  node -e '
+    const fs = require("fs");
+    const data = JSON.parse(fs.readFileSync(0, "utf8"));
+    const value = data[process.argv[1]];
+    if (value === undefined || value === null) {
+      process.exit(1);
+    }
+    process.stdout.write(String(value));
+  ' "${field}"
+}
+
+count_running_workers() {
+  hydra list --json | node -e '
+    const fs = require("fs");
+    const data = JSON.parse(fs.readFileSync(0, "utf8"));
+    const workers = Array.isArray(data.workers) ? data.workers : [];
+    const running = workers.filter(worker => worker && worker.status === "running").length;
+    process.stdout.write(String(running));
+  '
+}
+
+reset_isolated_state() {
+  if [[ -n "${HYDRA_TMUX_SOCKET:-}" ]] && command_exists tmux; then
+    tmux kill-server >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "${HYDRA_HOME:-}" ]]; then
+    rm -f "${HYDRA_HOME}/sessions.json" "${HYDRA_HOME}/archive.json"
+    rm -rf "${HYDRA_HOME}/worktrees" "${HYDRA_HOME}/tmux"
+    mkdir -p "${HYDRA_HOME}/bin" "${HYDRA_HOME}/tmux"
+  fi
+}
+
+write_demo_files() {
+  cat > package.json <<'EOF'
+{
+  "name": "hydra-demo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Hydra quickstart sandbox project",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "commander": "^14.0.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}
+EOF
+
+  cat > tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}
+EOF
+
+  cat > .gitignore <<'EOF'
+dist
+node_modules
+EOF
+
+  mkdir -p src
+
+  cat > src/calculator.ts <<'EOF'
+export type CalcOperation = 'add' | 'subtract' | 'multiply' | 'divide';
+
+function todo(name: string): never {
+  throw new Error(`${name} is not implemented yet.`);
+}
+
+export function add(a: number, b: number): number {
+  return todo(`add(${a}, ${b})`);
+}
+
+export function subtract(a: number, b: number): number {
+  return todo(`subtract(${a}, ${b})`);
+}
+
+export function multiply(a: number, b: number): number {
+  return todo(`multiply(${a}, ${b})`);
+}
+
+export function divide(a: number, b: number): number {
+  return todo(`divide(${a}, ${b})`);
+}
+
+export function calculate(op: CalcOperation, a: number, b: number): number {
+  switch (op) {
+    case 'add':
+      return add(a, b);
+    case 'subtract':
+      return subtract(a, b);
+    case 'multiply':
+      return multiply(a, b);
+    case 'divide':
+      return divide(a, b);
+  }
+}
+EOF
+
+  cat > src/index.ts <<'EOF'
+export * from './calculator.js';
+EOF
+
+  cat > README.md <<'EOF'
+# Hydra Demo Workspace
+
+This repository was scaffolded by `quickstart/run.sh` inside an isolated Hydra sandbox.
+
+Branches created by the demo:
+
+- `feat/core` implements the calculator contract
+- `feat/cli` builds a small CLI on top of that contract
+- `feat/tests` adds Vitest coverage for the contract
+EOF
+}
+
+make_task_core() {
+  cat <<'EOF'
+You own `src/calculator.ts` and `src/index.ts`.
+
+Implement the calculator contract that is already scaffolded in `src/calculator.ts`:
+- `add(a, b)`
+- `subtract(a, b)`
+- `multiply(a, b)`
+- `divide(a, b)` with an `Error` on division by zero
+- `calculate(op, a, b)` as the dispatcher
+
+Constraints:
+- Keep the branch focused on the calculator core.
+- Do not edit the CLI or test files.
+- Keep relative TypeScript imports compatible with `module: "NodeNext"` by using `.js` extensions in TS imports when needed.
+
+Before finishing:
+1. Run `npm run build`.
+2. Commit with message `feat: implement calculator core`.
+3. Push with `git push -u origin feat/core`.
+EOF
+}
+
+make_task_cli() {
+  cat <<'EOF'
+You own `src/cli.ts` only.
+
+Build a CLI using `commander` with the shape `calc <operation> <a> <b>`.
+Requirements:
+- Use a `#!/usr/bin/env node` shebang.
+- Import `calculate` and `CalcOperation` from `./calculator.js`.
+- Accept `add`, `subtract`, `multiply`, and `divide`.
+- Print the numeric result to stdout.
+- Print errors to stderr and exit with code 1.
+
+Constraints:
+- Do not modify calculator logic or test files.
+- Assume the calculator contract in `src/calculator.ts` is the source of truth.
+
+Before finishing:
+1. Run `npm run build`.
+2. Commit with message `feat: add calculator cli`.
+3. Push with `git push -u origin feat/cli`.
+EOF
+}
+
+make_task_tests() {
+  cat <<'EOF'
+You own `src/calculator.test.ts` only.
+
+Write a Vitest suite for the calculator contract in `src/calculator.ts`.
+Coverage requirements:
+- add, subtract, multiply, divide
+- division by zero
+- the `calculate` dispatcher
+- negative numbers, zero, and decimals
+- at least 12 assertions total
+
+Constraints:
+- Do not edit the calculator implementation or the CLI.
+- This branch is allowed to target the contract even if the placeholder implementation on `main` still fails the new tests.
+
+Before finishing:
+1. Commit with message `test: add calculator coverage`.
+2. Push with `git push -u origin feat/tests`.
+EOF
+}
+
+spawn_worker() {
+  local branch="$1"
+  local task="$2"
+  local result
+  result="$(hydra worker create --repo "${WORK_DIR}" --branch "${branch}" --agent "${AGENT}" --task "${task}" --json)"
+  local session workdir
+  session="$(printf '%s' "${result}" | json_field session)"
+  workdir="$(printf '%s' "${result}" | json_field workdir)"
+  printf '%s\t%s' "${session}" "${workdir}"
+}
+
+remote_branch_exists() {
+  git --git-dir="${ORIGIN_DIR}" show-ref --verify --quiet "refs/heads/$1"
+}
+
+local_commits_ahead() {
+  git -C "${WORK_DIR}" rev-list --count "main..$1" 2>/dev/null || printf '0'
+}
+
+branch_state_label() {
+  local branch="$1"
+  local expected_file="$2"
+  local workdir="$3"
+
+  if remote_branch_exists "${branch}" && [[ -f "${workdir}/${expected_file}" ]]; then
+    printf 'pushed'
+    return
+  fi
+
+  if [[ -f "${workdir}/${expected_file}" ]]; then
+    printf 'edited'
+    return
+  fi
+
+  local commits
+  commits="$(local_commits_ahead "${branch}")"
+  if [[ "${commits}" != "0" ]]; then
+    printf 'committed'
+    return
+  fi
+
+  printf 'running'
+}
+
+printf '\n%sHydra Quickstart Demo%s\n' "${BOLD}" "${RESET}"
+printf '%sIsolated sandbox, local repo, 3 parallel workers.%s\n\n' "${DIM}" "${RESET}"
+
+for required_cmd in git node npm hydra tmux; do
+  if ! command_exists "${required_cmd}"; then
+    die "Required command '${required_cmd}' is not on PATH"
+  fi
+done
+
+AGENT="$(pick_agent)"
+SANDBOX_ROOT="${HYDRA_E2E_ROOT:-}"
+if [[ -z "${SANDBOX_ROOT}" ]]; then
+  SANDBOX_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/hydra-quickstart-XXXXXX")"
+fi
+
+ACTIVATE_SCRIPT="${SANDBOX_ROOT}/activate.sh"
+PLAYGROUND_DIR="${SANDBOX_ROOT}/playground"
+ORIGIN_DIR="${PLAYGROUND_DIR}/hydra-demo-origin.git"
+WORK_DIR="${PLAYGROUND_DIR}/hydra-demo"
+INSTALL_LOG="${PLAYGROUND_DIR}/npm-install.log"
+
+info "Using agent: ${AGENT}"
+info "Sandbox root: ${SANDBOX_ROOT}"
+
+reset_isolated_state
+
+if [[ -e "${PLAYGROUND_DIR}" ]]; then
+  warn "Resetting existing quickstart playground at ${PLAYGROUND_DIR}"
+  rm -rf "${PLAYGROUND_DIR}"
+fi
+mkdir -p "${PLAYGROUND_DIR}"
+
+info "Creating local demo repository..."
+git init --bare "${ORIGIN_DIR}" >/dev/null
+git init -b main "${WORK_DIR}" >/dev/null
+cd "${WORK_DIR}"
+git config user.name "Hydra Quickstart"
+git config user.email "quickstart@hydra.local"
+git remote add origin "${ORIGIN_DIR}"
+write_demo_files
+ok "Workspace scaffolded at ${WORK_DIR}"
+
+info "Installing demo dependencies..."
+if npm install --no-fund --no-audit >"${INSTALL_LOG}" 2>&1; then
+  ok "Dependencies installed"
+else
+  die "npm install failed. See ${INSTALL_LOG}"
+fi
+
+git add -A
+git commit -m "chore: scaffold quickstart demo" >/dev/null
+git push -u origin main >/dev/null
+ok "Local origin seeded"
+
+TASK_CORE="$(make_task_core)"
+TASK_CLI="$(make_task_cli)"
+TASK_TESTS="$(make_task_tests)"
+
+declare -A SESSION_BY_BRANCH
+declare -A WORKDIR_BY_BRANCH
+declare -A FILE_BY_BRANCH=(
+  ["feat/core"]="src/calculator.ts"
+  ["feat/cli"]="src/cli.ts"
+  ["feat/tests"]="src/calculator.test.ts"
+)
+
+info "Spawning 3 parallel workers..."
+
+IFS=$'\t' read -r core_session core_workdir <<<"$(spawn_worker "feat/core" "${TASK_CORE}")"
+SESSION_BY_BRANCH["feat/core"]="${core_session}"
+WORKDIR_BY_BRANCH["feat/core"]="${core_workdir}"
+printf '  %s●%s %sfeat/core%s  -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${core_session}"
+
+IFS=$'\t' read -r cli_session cli_workdir <<<"$(spawn_worker "feat/cli" "${TASK_CLI}")"
+SESSION_BY_BRANCH["feat/cli"]="${cli_session}"
+WORKDIR_BY_BRANCH["feat/cli"]="${cli_workdir}"
+printf '  %s●%s %sfeat/cli%s   -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${cli_session}"
+
+IFS=$'\t' read -r tests_session tests_workdir <<<"$(spawn_worker "feat/tests" "${TASK_TESTS}")"
+SESSION_BY_BRANCH["feat/tests"]="${tests_session}"
+WORKDIR_BY_BRANCH["feat/tests"]="${tests_workdir}"
+printf '  %s●%s %sfeat/tests%s -> %s\n' "${GREEN}" "${RESET}" "${BOLD}" "${RESET}" "${tests_session}"
+
+ok "All workers launched"
+
+info "Monitoring worker branches for up to ${MAX_WAIT}s..."
+printf '%sUse the activation script below if you want to inspect the sandbox in another shell.%s\n\n' "${DIM}" "${RESET}"
+
+elapsed=0
+completed=0
+branches=("feat/core" "feat/cli" "feat/tests")
+
+while (( elapsed < MAX_WAIT )); do
+  completed=0
+  status_parts=()
+
+  for branch in "${branches[@]}"; do
+    status="$(branch_state_label "${branch}" "${FILE_BY_BRANCH[$branch]}" "${WORKDIR_BY_BRANCH[$branch]}")"
+    status_parts+=("${branch}=${status}")
+    if [[ "${status}" == "pushed" ]]; then
+      completed=$((completed + 1))
+    fi
+  done
+
+  running_workers="$(count_running_workers)"
+  printf '  %s[%3ss]%s branches: %s/3 | active workers: %s | %s\n' \
+    "${DIM}" "${elapsed}" "${RESET}" "${completed}" "${running_workers}" "${status_parts[*]}"
+
+  if (( completed == 3 )); then
+    break
+  fi
+
+  sleep "${POLL_INTERVAL}"
+  elapsed=$((elapsed + POLL_INTERVAL))
+done
+
+printf '\n'
+if (( completed == 3 )); then
+  printf '%s%sHydra Quickstart Complete%s\n' "${GREEN}" "${BOLD}" "${RESET}"
+else
+  printf '%s%sHydra Quickstart Timed Out%s\n' "${YELLOW}" "${BOLD}" "${RESET}"
+fi
+
+printf '  sandbox:   %s\n' "${SANDBOX_ROOT}"
+printf '  activate:  source %q\n' "${ACTIVATE_SCRIPT}"
+printf '  workspace: %s\n' "${WORK_DIR}"
+printf '  origin:    %s\n' "${ORIGIN_DIR}"
+printf '  agent:     %s\n' "${AGENT}"
+printf '\n'
+
+info "Worker summary"
+for branch in "${branches[@]}"; do
+  printf '  %-10s | %-8s | %s\n' \
+    "${branch}" \
+    "$(branch_state_label "${branch}" "${FILE_BY_BRANCH[$branch]}" "${WORKDIR_BY_BRANCH[$branch]}")" \
+    "${SESSION_BY_BRANCH[$branch]}"
+done
+
+printf '\n'
+info "Next commands"
+printf '  source %q\n' "${ACTIVATE_SCRIPT}"
+printf '  hydra list --json\n'
+printf '  git -C %q log --oneline --graph --all --decorate\n' "${WORK_DIR}"
+printf '  hydra worker logs %q --lines 80\n' "${SESSION_BY_BRANCH[feat/core]}"
+printf '  code --extensionDevelopmentPath=%q %q\n' "${REPO_ROOT}" "${WORK_DIR}"
+printf '\n'


### PR DESCRIPTION
## Summary

This PR ports the quickstart demo into the repo and rewires it around the isolated E2E sandbox flow.

## What changed

- add `quickstart/README.md` for the new self-contained "First Five Minutes" walkthrough
- add `quickstart/run.sh` that boots through `scripts/e2e-isolated-runner.js`
- scaffold the demo repo inside a temporary sandbox with a local bare `origin`
- launch and monitor 3 local Hydra workers without requiring GitHub repo setup
- update the main `README.md` to point to the isolated quickstart flow
- keep the worker #28 UI command changes out of this PR

## Why

The previous quickstart flow depended on live GitHub repo creation and PR polling, which made it heavier and less isolated than the new E2E infrastructure supports. This change makes the onboarding demo safe to run in a temporary sandbox while still showing Hydra's parallel worker workflow.

## Impact

Users get a self-contained quickstart that is easier to try in the first five minutes and does not touch their real Hydra home or require GitHub setup.

## Validation

- `bash -n quickstart/run.sh`
- `./quickstart/run.sh --help`
- `npm run compile`
- `npm run lint`
