### PR TITLE
[codex] fail closed on worker delete tmux errors

### DIFF
--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -421,9 +421,7 @@ export class SessionManager {
   }
 
   async deleteWorker(sessionName: string): Promise<void> {
-    try {
-      await this.backend.killSession(sessionName);
-    } catch { /* Already dead */ }
+    await this.killSessionOrConfirmAbsent(sessionName);
 
     const worker = this.readSessionState().workers[sessionName];
 
@@ -930,6 +928,26 @@ export class SessionManager {
         },
       );
     });
+  }
+
+  private async killSessionOrConfirmAbsent(sessionName: string): Promise<void> {
+    try {
+      await this.backend.killSession(sessionName);
+      return;
+    } catch (error) {
+      let hasLiveSession: boolean;
+      try {
+        hasLiveSession = await this.backend.hasSession(sessionName);
+      } catch {
+        throw error;
+      }
+
+      if (!hasLiveSession) {
+        return;
+      }
+
+      throw error;
+    }
   }
 
   private archiveEntry(

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -94,6 +94,13 @@ function isTmuxNoServerError(error: unknown): boolean {
     || (text.includes('error connecting to') && text.includes('no such file or directory'));
 }
 
+function isTmuxMissingSessionError(error: unknown): boolean {
+  const text = getExecFailureText(error).toLowerCase();
+  return text.includes(`can't find session`)
+    || text.includes('no such session')
+    || text.includes('session not found');
+}
+
 export class TmuxUnavailableError extends Error {
   constructor(message: string) {
     super(message);
@@ -155,8 +162,11 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
       const tmuxCommand = getTmuxCommand();
       await exec(`${tmuxCommand} has-session -t ${shellQuote(sessionName)}`);
       return true;
-    } catch {
-      return false;
+    } catch (error) {
+      if (isTmuxNoServerError(error) || isTmuxMissingSessionError(error)) {
+        return false;
+      }
+      throw new TmuxUnavailableError(`Unable to inspect tmux session "${sessionName}": ${getExecFailureText(error)}`);
     }
   }
 

--- a/src/smoke/workerDeleteFailClosedSmoke.ts
+++ b/src/smoke/workerDeleteFailClosedSmoke.ts
@@ -1,0 +1,362 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  HydraRole,
+  MultiplexerBackendCore,
+  MultiplexerSession,
+  SessionStatusInfo,
+} from '../core/types';
+
+type ExecFailure = Error & {
+  stderr?: string;
+  stdout?: string;
+};
+
+type WorkerRecord = {
+  sessionName: string;
+  displayName: string;
+  workerId: number;
+  repo: string;
+  repoRoot: string;
+  branch: string;
+  slug: string;
+  status: 'running' | 'stopped';
+  attached: boolean;
+  agent: string;
+  workdir: string;
+  tmuxSession: string;
+  createdAt: string;
+  lastSeenAt: string;
+  sessionId: string | null;
+  copilotSessionName: string | null;
+};
+
+class DeleteWorkerBackend implements MultiplexerBackendCore {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'fake-tmux';
+  readonly installHint = 'not needed';
+
+  private readonly sessions = new Set<string>();
+
+  killError: Error | null = null;
+  hasSessionError: Error | null = null;
+
+  constructor(sessionNames: string[] = []) {
+    for (const sessionName of sessionNames) {
+      this.sessions.add(sessionName);
+    }
+  }
+
+  async isInstalled(): Promise<boolean> {
+    return true;
+  }
+
+  async listSessions(): Promise<MultiplexerSession[]> {
+    return [];
+  }
+
+  async createSession(): Promise<void> {
+    this.unexpected();
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    if (this.killError) {
+      throw this.killError;
+    }
+    this.sessions.delete(sessionName);
+  }
+
+  async renameSession(): Promise<void> {
+    this.unexpected();
+  }
+
+  async hasSession(sessionName: string): Promise<boolean> {
+    if (this.hasSessionError) {
+      throw this.hasSessionError;
+    }
+    return this.sessions.has(sessionName);
+  }
+
+  async getSessionWorkdir(): Promise<string | undefined> {
+    this.unexpected();
+  }
+
+  async setSessionWorkdir(): Promise<void> {
+    this.unexpected();
+  }
+
+  async getSessionRole(): Promise<HydraRole | undefined> {
+    this.unexpected();
+  }
+
+  async setSessionRole(): Promise<void> {
+    this.unexpected();
+  }
+
+  async getSessionAgent(): Promise<string | undefined> {
+    this.unexpected();
+  }
+
+  async setSessionAgent(): Promise<void> {
+    this.unexpected();
+  }
+
+  async sendKeys(): Promise<void> {
+    this.unexpected();
+  }
+
+  async capturePane(): Promise<string> {
+    this.unexpected();
+  }
+
+  async sendMessage(): Promise<void> {
+    this.unexpected();
+  }
+
+  async getSessionInfo(): Promise<SessionStatusInfo> {
+    this.unexpected();
+  }
+
+  async getSessionPaneCount(): Promise<number> {
+    this.unexpected();
+  }
+
+  async getSessionPanePids(): Promise<string[]> {
+    this.unexpected();
+  }
+
+  async splitPane(): Promise<void> {
+    this.unexpected();
+  }
+
+  async newWindow(): Promise<void> {
+    this.unexpected();
+  }
+
+  buildSessionName(repoName: string, slug: string): string {
+    return `${repoName}_${slug}`;
+  }
+
+  sanitizeSessionName(name: string): string {
+    return name;
+  }
+
+  private unexpected(): never {
+    throw new Error('Unexpected backend call in worker delete smoke test');
+  }
+}
+
+function makeExecError(message: string, stderr?: string, stdout?: string): ExecFailure {
+  const error = new Error(message) as ExecFailure;
+  error.stderr = stderr;
+  error.stdout = stdout;
+  return error;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+function readJson<T>(filePath: string, fallback: T): T {
+  if (!fs.existsSync(filePath)) {
+    return fallback;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+}
+
+function patchModule(
+  target: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): () => void {
+  const originals = new Map<string, unknown>();
+  for (const [key, value] of Object.entries(overrides)) {
+    originals.set(key, target[key]);
+    target[key] = value;
+  }
+
+  return () => {
+    for (const [key, value] of originals.entries()) {
+      target[key] = value;
+    }
+  };
+}
+
+function buildWorker(sessionName: string, repoRoot: string, workdir: string): WorkerRecord {
+  const now = new Date().toISOString();
+  return {
+    sessionName,
+    displayName: sessionName,
+    workerId: 1,
+    repo: 'repo',
+    repoRoot,
+    branch: 'fix/delete-worker',
+    slug: 'fix-delete-worker',
+    status: 'running',
+    attached: false,
+    agent: 'codex',
+    workdir,
+    tmuxSession: sessionName,
+    createdAt: now,
+    lastSeenAt: now,
+    sessionId: '55555555-5555-4555-8555-555555555555',
+    copilotSessionName: null,
+  };
+}
+
+function writeWorkerState(sessionsFile: string, worker: WorkerRecord): void {
+  writeJson(sessionsFile, {
+    copilots: {},
+    workers: {
+      [worker.sessionName]: worker,
+    },
+    nextWorkerId: worker.workerId + 1,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+async function main(): Promise<void> {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-'));
+  process.env.HOME = tempHome;
+
+  const hydraDir = path.join(tempHome, '.hydra');
+  const sessionsFile = path.join(hydraDir, 'sessions.json');
+  const archiveFile = path.join(hydraDir, 'archive.json');
+
+  const coreExec = await import('../core/exec') as unknown as Record<string, unknown>;
+  const coreGit = await import('../core/git') as unknown as Record<string, unknown>;
+  const { SessionManager } = await import('../core/sessionManager');
+  const { TmuxBackendCore, TmuxUnavailableError } = await import('../core/tmux');
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-repo-'));
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-worktree-'));
+    const worker = buildWorker('worker-delete-fail-closed', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeJson(archiveFile, { entries: [] });
+
+    const backend = new DeleteWorkerBackend([worker.sessionName]);
+    backend.killError = makeExecError('kill-session failed', 'permission denied');
+
+    let removeWorktreeCalls = 0;
+    const branchDeleteCommands: string[] = [];
+    const restoreCoreGit = patchModule(coreGit, {
+      removeWorktree: async () => {
+        removeWorktreeCalls += 1;
+      },
+    });
+    const restoreExec = patchModule(coreExec, {
+      exec: async (command: string) => {
+        branchDeleteCommands.push(command);
+        return '';
+      },
+    });
+
+    try {
+      const sm = new SessionManager(backend);
+      await assert.rejects(
+        sm.deleteWorker(worker.sessionName),
+        /kill-session failed/,
+      );
+    } finally {
+      restoreExec();
+      restoreCoreGit();
+    }
+
+    const archive = readJson<{ entries: Array<Record<string, unknown>> }>(archiveFile, { entries: [] });
+    const state = readJson<{ workers: Record<string, unknown> }>(sessionsFile, { workers: {} });
+    assert.equal(archive.entries.length, 0);
+    assert.ok(state.workers[worker.sessionName], 'sessions.json entry should remain after kill failure');
+    assert.equal(removeWorktreeCalls, 0);
+    assert.equal(branchDeleteCommands.length, 0);
+    assert.ok(fs.existsSync(workdir), 'worktree should remain after kill failure');
+  }
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-repo-'));
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-worktree-'));
+    const worker = buildWorker('worker-delete-already-gone', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeJson(archiveFile, { entries: [] });
+
+    const backend = new DeleteWorkerBackend();
+    backend.killError = makeExecError('kill-session failed', `can't find session: ${worker.sessionName}`);
+
+    let removeWorktreeCalls = 0;
+    const branchDeleteCommands: string[] = [];
+    const restoreCoreGit = patchModule(coreGit, {
+      removeWorktree: async () => {
+        removeWorktreeCalls += 1;
+      },
+    });
+    const restoreExec = patchModule(coreExec, {
+      exec: async (command: string) => {
+        branchDeleteCommands.push(command);
+        return '';
+      },
+    });
+
+    try {
+      const sm = new SessionManager(backend);
+      await sm.deleteWorker(worker.sessionName);
+    } finally {
+      restoreExec();
+      restoreCoreGit();
+    }
+
+    const archive = readJson<{ entries: Array<{ sessionName: string }> }>(archiveFile, { entries: [] });
+    const state = readJson<{ workers: Record<string, unknown> }>(sessionsFile, { workers: {} });
+    assert.equal(archive.entries.length, 1);
+    assert.equal(archive.entries[0]?.sessionName, worker.sessionName);
+    assert.equal(state.workers[worker.sessionName], undefined);
+    assert.equal(removeWorktreeCalls, 1);
+    assert.equal(branchDeleteCommands.length, 1);
+    assert.match(branchDeleteCommands[0] || '', /git branch -D/);
+  }
+
+  {
+    const restoreExec = patchModule(coreExec, {
+      exec: async () => {
+        throw makeExecError('missing session', `can't find session: worker-missing`);
+      },
+    });
+
+    try {
+      const backend = new TmuxBackendCore();
+      assert.equal(await backend.hasSession('worker-missing'), false);
+    } finally {
+      restoreExec();
+    }
+  }
+
+  {
+    const restoreExec = patchModule(coreExec, {
+      exec: async () => {
+        throw makeExecError('tmux unavailable', 'permission denied');
+      },
+    });
+
+    try {
+      const backend = new TmuxBackendCore();
+      await assert.rejects(
+        backend.hasSession('worker-error'),
+        (error: unknown) => {
+          assert.ok(error instanceof TmuxUnavailableError);
+          assert.match((error as Error).message, /Unable to inspect tmux session "worker-error"/);
+          return true;
+        },
+      );
+    } finally {
+      restoreExec();
+    }
+  }
+
+  console.log('workerDeleteFailClosedSmoke: ok');
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
Fix the worker delete path so it fails closed when tmux session termination errors are not confirmed as an already-missing session.

## What Changed
- gate worker archive and cleanup behind successful `killSession()` or an explicit follow-up `hasSession()` absence check
- preserve `sessions.json`, the worktree, and the branch when tmux kill fails and the session may still exist
- tighten tmux `hasSession()` so only missing-session and no-server cases map to `false`, while other tmux failures surface as `TmuxUnavailableError`
- add a focused smoke regression for the fail-closed worker delete path and tmux error classification

## Root Cause
`deleteWorker()` swallowed every `killSession()` failure and proceeded with archive, metadata deletion, worktree removal, and branch deletion even when tmux had failed for an unrelated reason.

## User Impact
Worker deletion now stops loudly on real tmux errors instead of partially deleting Hydra state or removing the worktree underneath a still-live session.

## Validation
- `npm run compile`
- `npm run lint`
- `node out/smoke/workerDeleteFailClosedSmoke.js`
- `npm run smoke:codex-bypass`
- `npm run e2e:isolated -- --root '/var/folders/kq/lm9lyx1919sb72b8d9dgxz0c0000gn/T/hydra-e2e-FNtIYQ' -- hydra list --json`
- launched isolated Extension Development Host via `npm run e2e:isolated -- --keep -- code --extensionDevelopmentPath='/Users/jinjingzhou/.hydra/worktrees/hydra-ad84c436/fix-delete-worker-fail-loud' /tmp/hydra-test-1778037335`
