### PR TITLE
[codex] Exclude local state from VSIX packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,5 +18,8 @@ CLAUDE.md
 README.ai-ready.md
 eslint.config.js
 .hydra-task*
+.hydra/**
 .claude/**
+.codex/**
+.gemini/**
 skills/**


### PR DESCRIPTION
## What changed

Exclude local Hydra and agent state directories from VSIX packaging by adding these patterns to `.vscodeignore`:

- `.hydra/**`
- `.codex/**`
- `.gemini/**`

## Why

Local Hydra worktrees under `.hydra/` were being included in the extension package. During `vsce package`, secret scanning walked those packaged entries and failed with `EISDIR: illegal operation on a directory, read`.

Excluding these local-only directories keeps the package contents deterministic and avoids bundling machine-specific state.

## Impact

- `vsce package` no longer attempts to package local Hydra worktrees
- local Codex and Gemini symlink directories are also excluded
- the VSIX contains only extension assets and intended runtime files

## Validation

- `npm run compile`
- `npx @vscode/vsce package --out hydra-0.1.31.vsix`
