### PR TITLE
chore: release v0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.32] - 2026-05-06
+
+### Fixed
+- Exclude local state files from VSIX packaging (#107)
+- Fail closed on worker delete tmux errors instead of silently continuing (#106)
+
 ## [0.1.31] - 2026-05-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary
- Bump version to 0.1.32
- Changelog for 2 fixes merged after v0.1.31

### Fixed
- Exclude local state files from VSIX packaging (#107)
- Fail closed on worker delete tmux errors instead of silently continuing (#106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)