### PR TITLE
feat: Windows support for CLI installer, doctor, and clipboard

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, constants, accessSync } from 'fs';
-import { join } from 'path';
+import { join, delimiter } from 'path';
 import { getHydraBinDir, getHydraConfigPath, getHydraHome } from '../../core/path';
 import { type OutputOpts } from '../output';
 
@@ -18,7 +18,8 @@ const RESET = '\x1b[0m';
 
 function checkOnPath(cmd: string): boolean {
   try {
-    execSync(`which ${cmd}`, { stdio: 'pipe' });
+    const lookupCmd = process.platform === 'win32' ? 'where' : 'which';
+    execSync(`${lookupCmd} ${cmd}`, { stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -53,17 +54,19 @@ export function registerDoctorCommand(program: Command): void {
       const hydraDir = getHydraHome();
       const hydraConfigPath = getHydraConfigPath();
       const hydraBinDir = getHydraBinDir();
-      const hydraBin = join(hydraBinDir, 'hydra');
+      const hydraBin = join(hydraBinDir, process.platform === 'win32' ? 'hydra.cmd' : 'hydra');
 
       // 1. git
       checks.push(checkOnPath('git')
         ? { name: 'git', status: 'pass', message: 'git is installed' }
         : { name: 'git', status: 'fail', message: 'git not found — install from https://git-scm.com' });
 
-      // 2. tmux
-      checks.push(checkOnPath('tmux')
-        ? { name: 'tmux', status: 'pass', message: 'tmux is installed' }
-        : { name: 'tmux', status: 'fail', message: 'tmux not found — install with: brew install tmux' });
+      // 2. tmux (not available on Windows)
+      if (process.platform !== 'win32') {
+        checks.push(checkOnPath('tmux')
+          ? { name: 'tmux', status: 'pass', message: 'tmux is installed' }
+          : { name: 'tmux', status: 'fail', message: 'tmux not found — install with: brew install tmux' });
+      }
 
       // 3. VS Code CLI
       checks.push(checkOnPath('code')
@@ -96,12 +99,15 @@ export function registerDoctorCommand(program: Command): void {
       }
 
       // 7. Hydra bin in PATH
-      const pathDirs = (process.env.PATH || '').split(':');
+      const pathDirs = (process.env.PATH || '').split(delimiter);
       const binInPath = pathDirs.some(d => d === hydraBinDir);
       if (binInPath) {
         checks.push({ name: 'hydra-path', status: 'pass', message: `${hydraBinDir} is in PATH` });
       } else {
-        checks.push({ name: 'hydra-path', status: 'warn', message: `${hydraBinDir} is not in PATH — add to your shell profile:\n    export PATH="${hydraBinDir}:$PATH"` });
+        const pathHint = process.platform === 'win32'
+          ? `$env:PATH = "${hydraBinDir};$env:PATH"`
+          : `export PATH="${hydraBinDir}:$PATH"`;
+        checks.push({ name: 'hydra-path', status: 'warn', message: `${hydraBinDir} is not in PATH — add to your shell profile:\n    ${pathHint}` });
       }
 
       // 8. GitHub CLI

--- a/src/commands/pasteImage.ts
+++ b/src/commands/pasteImage.ts
@@ -98,9 +98,12 @@ async function saveClipboardImage(): Promise<string | null> {
   if (platform === 'linux') {
     return saveClipboardImageLinux();
   }
+  if (platform === 'win32') {
+    return saveClipboardImageWindows();
+  }
 
   vscode.window.showInformationMessage(
-    'Clipboard image paste is currently supported on macOS and Linux only.'
+    'Clipboard image paste is currently supported on macOS, Linux, and Windows only.'
   );
   return null;
 }
@@ -489,6 +492,58 @@ async function saveClipboardImageLinux(): Promise<string | null> {
   }
 
   return null;
+}
+
+/**
+ * Windows: Use PowerShell to read clipboard image via System.Windows.Forms.
+ * Saves the clipboard image as a PNG file.
+ */
+async function saveClipboardImageWindows(): Promise<string | null> {
+  const tmpDir = path.join(os.tmpdir(), 'vscode-tmux-paste');
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  }
+  const tmpFile = path.join(
+    tmpDir,
+    `clipboard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.png`
+  );
+
+  return new Promise((resolve) => {
+    const psScript = `
+Add-Type -AssemblyName System.Windows.Forms
+$img = [System.Windows.Forms.Clipboard]::GetImage()
+if ($img) {
+  $img.Save('${tmpFile.replace(/'/g, "''")}', [System.Drawing.Imaging.ImageFormat]::Png)
+  Write-Output 'OK'
+} else {
+  Write-Output 'NO_IMAGE'
+}
+`;
+    const proc = spawn('powershell', ['-NoProfile', '-Command', psScript]);
+    let stdout = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.on('close', (code: number | null) => {
+      if (code === 0 && stdout.trim() === 'OK') {
+        tempFiles.push(tmpFile);
+        resolve(tmpFile);
+      } else {
+        try {
+          fs.unlinkSync(tmpFile);
+        } catch {
+          // Ignore cleanup failure
+        }
+        resolve(null);
+      }
+    });
+
+    proc.on('error', () => {
+      resolve(null);
+    });
+  });
 }
 
 /**

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -149,5 +149,9 @@ export function buildAgentLaunchCommand(
 }
 
 function shellQuoteForDisplay(s: string): string {
+  if (process.platform === 'win32') {
+    // PowerShell double-quote escaping: escape backticks and double-quotes
+    return `"${s.replace(/[`"$]/g, '`$&')}"`;
+  }
   return `'${s.replace(/'/g, "'\\''")}'`;
 }

--- a/src/core/cliInstaller.ts
+++ b/src/core/cliInstaller.ts
@@ -4,10 +4,37 @@ import * as os from 'os';
 import { getDefaultHydraHome, getHydraBinDir, getHydraConfig, writeHydraConfig } from './path';
 
 function getWrapperPath(): string {
+  if (process.platform === 'win32') {
+    return path.join(getHydraBinDir(), 'hydra.cmd');
+  }
   return path.join(getHydraBinDir(), 'hydra');
 }
 
+function buildWrapperScriptWindows(): string {
+  return `@echo off
+setlocal EnableDelayedExpansion
+
+set "HYDRA_DEFAULT_HOME=%USERPROFILE%\\.hydra"
+if defined HYDRA_HOME (
+  set "HYDRA_HOME_DIR=%HYDRA_HOME%"
+) else (
+  set "HYDRA_HOME_DIR=%HYDRA_DEFAULT_HOME%"
+)
+
+if defined HYDRA_CONFIG_PATH (
+  set "CONFIG_PATH=%HYDRA_CONFIG_PATH%"
+) else (
+  set "CONFIG_PATH=%HYDRA_HOME_DIR%\\config.json"
+)
+
+node -e "const fs=require('fs'),path=require('path'),os=require('os');function expandHomeDir(p){if(p==='~')return os.homedir();if(p.startsWith('~/')||p.startsWith('~\\\\'))return path.join(os.homedir(),p.slice(2));return p}function resolveConfigPathValue(v,c){if(typeof v!=='string'||!v.trim())return undefined;const e=expandHomeDir(v.trim());const a=path.isAbsolute(e)?e:path.resolve(path.dirname(c),e);return path.normalize(a)}const configPath=process.env.HYDRA_CONFIG_PATH||path.join(process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),'config.json');let cfg={};try{if(fs.existsSync(configPath))cfg=JSON.parse(fs.readFileSync(configPath,'utf8'))||{}}catch{}const extPath=typeof(cfg.cli||{}).extensionPath==='string'?cfg.cli.extensionPath:'';if(!extPath||!fs.existsSync(path.join(extPath,'out','cli','index.js'))){console.error('Error: Hydra VS Code extension not found. Open VS Code with Hydra installed.');process.exit(1)}const {spawnSync}=require('child_process');const r=spawnSync(process.execPath,[path.join(extPath,'out','cli','index.js'),...process.argv.slice(2)],{stdio:'inherit',env:{...process.env,HYDRA_HOME:process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),HYDRA_CONFIG_PATH:configPath}});if(r.error){console.error(r.error.message);process.exit(1)}process.exit(typeof r.status==='number'?r.status:1)" %*
+`;
+}
+
 function buildWrapperScript(): string {
+  if (process.platform === 'win32') {
+    return buildWrapperScriptWindows();
+  }
   return `#!/bin/sh
 exec node - "$@" <<'NODE'
 const { spawnSync } = require('child_process');
@@ -118,7 +145,7 @@ export function installCli(extensionPath: string, version: string): { installed:
   // Create Hydra CLI directory.
   fs.mkdirSync(binDir, { recursive: true });
 
-  // Write wrapper script
+  // Write wrapper script (mode is ignored on Windows)
   fs.writeFileSync(getWrapperPath(), buildWrapperScript(), { encoding: 'utf-8', mode: 0o755 });
 
   const hydraConfig = getHydraConfig();
@@ -152,6 +179,30 @@ export function ensurePathInShellProfile(): ShellProfileStatus {
 
   const snippet = getShellConfigSnippet();
   const marker = '# Hydra CLI';
+
+  if (process.platform === 'win32') {
+    // On Windows, look for PowerShell profile paths
+    const candidates = [
+      path.join(os.homedir(), 'Documents', 'PowerShell', 'Microsoft.PowerShell_profile.ps1'),
+      path.join(os.homedir(), 'Documents', 'WindowsPowerShell', 'Microsoft.PowerShell_profile.ps1'),
+    ];
+    for (const rc of candidates) {
+      const rcDir = path.dirname(rc);
+      if (!fs.existsSync(rcDir)) continue;
+      if (fs.existsSync(rc)) {
+        const content = fs.readFileSync(rc, 'utf-8');
+        if (content.includes(snippet) || content.includes(marker)) return 'already_present';
+        fs.appendFileSync(rc, `\n# Hydra CLI\n${snippet}\n`);
+        return 'added';
+      }
+    }
+    // Create the first profile directory and file
+    const profileDir = path.dirname(candidates[0]);
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(candidates[0], `# Hydra CLI\n${snippet}\n`, 'utf-8');
+    return 'added';
+  }
+
   const candidates = [
     path.join(os.homedir(), '.zshrc'),
     path.join(os.homedir(), '.bashrc'),
@@ -181,5 +232,9 @@ export function isCliOnPath(): boolean {
 }
 
 export function getShellConfigSnippet(): string {
-  return `export PATH="${path.join(getDefaultHydraHome(), 'bin')}:$PATH"`;
+  const binDir = path.join(getDefaultHydraHome(), 'bin');
+  if (process.platform === 'win32') {
+    return `$env:PATH = "${binDir};$env:PATH"`;
+  }
+  return `export PATH="${binDir}:$PATH"`;
 }


### PR DESCRIPTION
## Summary

Adds Windows (`win32`) platform support across three areas, refs #111:

- **CLI Installer** (`src/core/cliInstaller.ts`): Generates a `.cmd` batch wrapper on Windows instead of a shell script. Detects PowerShell profile paths (`Documents/PowerShell/` and `Documents/WindowsPowerShell/`) for PATH setup. Uses `$env:PATH` syntax for the shell config snippet.
- **Doctor Command** (`src/cli/commands/doctor.ts`): Uses `where` instead of `which` on Windows. Splits PATH with `path.delimiter` instead of hardcoded `:`. Shows PowerShell syntax in PATH hint messages. Skips tmux check on Windows (not available).
- **Clipboard** (`src/commands/pasteImage.ts`): Adds `saveClipboardImageWindows()` using PowerShell's `System.Windows.Forms.Clipboard` to save clipboard images as PNG.
- **Agent Config** (`src/core/agentConfig.ts`): Uses PowerShell double-quote escaping on Windows instead of bash single-quote escaping.

## Test plan

- [ ] Verify `npm run compile` passes
- [ ] Verify `npm run lint` passes
- [ ] Test CLI install on Windows: confirm `hydra.cmd` is created in `~/.hydra/bin/`
- [ ] Test `hydra doctor` on Windows: confirm `where` is used, PATH split works, tmux check skipped
- [ ] Test clipboard image paste on Windows: confirm PowerShell clipboard access works
- [ ] Verify no regressions on macOS/Linux (all changes are gated behind `process.platform === 'win32'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)