### PR TITLE
feat: add Windows terminal and shell integration via psmux

### DIFF
--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -173,10 +173,11 @@ export function getTmuxSocketArgs(): string[] {
 }
 
 export function getTmuxCommand(): string {
+  const binary = process.platform === 'win32' ? 'psmux' : 'tmux';
   const socketArgs = getTmuxSocketArgs();
   if (socketArgs.length === 0) {
-    return 'tmux';
+    return binary;
   }
 
-  return `tmux ${socketArgs.map(arg => shellQuote(arg)).join(' ')}`;
+  return `${binary} ${socketArgs.map(arg => shellQuote(arg)).join(' ')}`;
 }

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,3 +1,7 @@
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
+
+export function pwshQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -1,6 +1,6 @@
 import { exec } from './exec';
 import { getHydraConfigPath, getHydraHome, getTmuxCommand, toCanonicalPath } from './path';
-import { shellQuote } from './shell';
+import { shellQuote, pwshQuote } from './shell';
 import { MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo, HydraRole } from './types';
 
 interface ExecFailure extends Error {
@@ -37,7 +37,41 @@ export function buildSanitizedTmuxCommand(command: string): string {
   return `env ${unsetArgs} ${tmuxCommand} ${command}`;
 }
 
+function buildStoredTmuxEnvScrubCommandPowerShell(sessionName?: string): string {
+  const tmuxCommand = getTmuxCommand();
+  const sessionTarget = sessionName ? ` -t ${pwshQuote(sessionName)}` : '';
+  const varsToSet = [
+    `${tmuxCommand} set-environment -g HYDRA_HOME ${pwshQuote(getHydraHome())} *>$null`,
+    `${tmuxCommand} set-environment -g HYDRA_CONFIG_PATH ${pwshQuote(getHydraConfigPath())} *>$null`,
+  ];
+
+  if (process.env.HYDRA_TMUX_SOCKET) {
+    varsToSet.push(
+      `${tmuxCommand} set-environment -g HYDRA_TMUX_SOCKET ${pwshQuote(process.env.HYDRA_TMUX_SOCKET)} *>$null`,
+    );
+  }
+
+  return [
+    ...varsToSet,
+    `foreach ($name in @('ELECTRON_RUN_AS_NODE', 'TERM_PROGRAM', 'TERM_PROGRAM_VERSION', 'VSCODE_INJECTION', 'VSCODE_SHELL_INTEGRATION')) {`,
+    `  ${tmuxCommand} set-environment -gu $name *>$null`,
+    `  ${tmuxCommand} set-environment${sessionTarget} -u $name *>$null`,
+    '}',
+    `(${tmuxCommand} show-environment -g 2>$null) | ForEach-Object {`,
+    `  $name = $_.Split('=')[0]`,
+    `  if ($name -like 'VSCODE_*') {`,
+    `    ${tmuxCommand} set-environment -gu $name *>$null`,
+    `    ${tmuxCommand} set-environment${sessionTarget} -u $name *>$null`,
+    '  }',
+    '}',
+  ].join('\n');
+}
+
 export function buildStoredTmuxEnvScrubCommand(sessionName?: string): string {
+  if (process.platform === 'win32') {
+    return buildStoredTmuxEnvScrubCommandPowerShell(sessionName);
+  }
+
   const tmuxCommand = getTmuxCommand();
   const sessionTarget = sessionName ? ` -t ${shellQuote(sessionName)}` : '';
   const varsToSet = [
@@ -111,11 +145,14 @@ export class TmuxUnavailableError extends Error {
 export class TmuxBackendCore implements MultiplexerBackendCore {
   readonly type = 'tmux' as const;
   readonly displayName = 'tmux';
-  readonly installHint = 'Install: `brew install tmux`';
+  readonly installHint = process.platform === 'win32'
+    ? 'Install: `winget install psmux`'
+    : 'Install: `brew install tmux`';
 
   async isInstalled(): Promise<boolean> {
     try {
-      await exec('which tmux');
+      const cmd = process.platform === 'win32' ? 'where psmux' : 'which tmux';
+      await exec(cmd);
       return true;
     } catch {
       return false;

--- a/src/utils/tmuxBackend.ts
+++ b/src/utils/tmuxBackend.ts
@@ -59,34 +59,56 @@ export class TmuxBackend extends TmuxBackendCore implements MultiplexerBackend {
       existing.dispose();
     }
 
-    const escapedName = sessionName.replace(/'/g, "'\\''");
     const tmuxCommand = getTmuxCommand();
-    const attachCommand = [
-      buildStoredTmuxEnvScrubCommand(sessionName),
-      `${tmuxCommand} set-option -gq set-clipboard on >/dev/null 2>&1 || true`,
-      `${tmuxCommand} set-option -agq terminal-features ',xterm-256color:clipboard' >/dev/null 2>&1 || true`,
-      `${tmuxCommand} set-option -agq terminal-overrides ',*:clipboard' >/dev/null 2>&1 || true`,
-      `${tmuxCommand} set-window-option -gwq allow-passthrough on >/dev/null 2>&1 || true`,
-      "rows=''; cols=''",
-      "for _ in 1 2 3 4 5; do",
-      "size=$(stty size 2>/dev/null || true)",
-      "candidate_rows=${size%% *}",
-      "candidate_cols=${size##* }",
-      "if [ -n \"$candidate_rows\" ] && [ -n \"$candidate_cols\" ] && [ \"$candidate_rows\" -gt 0 ] && [ \"$candidate_cols\" -gt 0 ]; then rows=\"$candidate_rows\"; cols=\"$candidate_cols\"; fi",
-      "if [ -n \"$rows\" ] && [ \"$rows\" -ge 30 ] && [ \"$cols\" -ge 100 ]; then break; fi",
-      "sleep 0.04",
-      "done",
-      "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " set-option -t '" + escapedName + "' default-size \"${cols}x${rows}\" >/dev/null 2>&1 || true; fi",
-      "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " resize-window -t '" + escapedName + "':. -x \"$cols\" -y \"$rows\" >/dev/null 2>&1 || true; fi",
-      `${tmuxCommand} set-window-option -t '${escapedName}':. window-size latest >/dev/null 2>&1 || true`,
-      "sleep 0.08",
-      `exec ${tmuxCommand} attach -t '${escapedName}'`
-    ].join('\n');
+    let shellPath: string;
+    let shellArgs: string[];
+
+    if (process.platform === 'win32') {
+      // Windows: PowerShell with simplified attach (VS Code handles terminal sizing)
+      const escapedName = sessionName.replace(/'/g, "''");
+      const attachCommand = [
+        buildStoredTmuxEnvScrubCommand(sessionName),
+        `${tmuxCommand} set-option -gq set-clipboard on *>$null`,
+        `${tmuxCommand} set-option -agq terminal-features ',xterm-256color:clipboard' *>$null`,
+        `${tmuxCommand} set-option -agq terminal-overrides ',*:clipboard' *>$null`,
+        `${tmuxCommand} set-window-option -gwq allow-passthrough on *>$null`,
+        `${tmuxCommand} set-window-option -t '${escapedName}':. window-size latest *>$null`,
+        `${tmuxCommand} attach -t '${escapedName}'`,
+      ].join('\n');
+      shellPath = 'powershell.exe';
+      shellArgs = ['-NoProfile', '-Command', attachCommand];
+    } else {
+      // Unix: /bin/sh with stty sizing for proper initial terminal dimensions
+      const escapedName = sessionName.replace(/'/g, "'\\''");
+      const attachCommand = [
+        buildStoredTmuxEnvScrubCommand(sessionName),
+        `${tmuxCommand} set-option -gq set-clipboard on >/dev/null 2>&1 || true`,
+        `${tmuxCommand} set-option -agq terminal-features ',xterm-256color:clipboard' >/dev/null 2>&1 || true`,
+        `${tmuxCommand} set-option -agq terminal-overrides ',*:clipboard' >/dev/null 2>&1 || true`,
+        `${tmuxCommand} set-window-option -gwq allow-passthrough on >/dev/null 2>&1 || true`,
+        "rows=''; cols=''",
+        "for _ in 1 2 3 4 5; do",
+        "size=$(stty size 2>/dev/null || true)",
+        "candidate_rows=${size%% *}",
+        "candidate_cols=${size##* }",
+        "if [ -n \"$candidate_rows\" ] && [ -n \"$candidate_cols\" ] && [ \"$candidate_rows\" -gt 0 ] && [ \"$candidate_cols\" -gt 0 ]; then rows=\"$candidate_rows\"; cols=\"$candidate_cols\"; fi",
+        "if [ -n \"$rows\" ] && [ \"$rows\" -ge 30 ] && [ \"$cols\" -ge 100 ]; then break; fi",
+        "sleep 0.04",
+        "done",
+        "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " set-option -t '" + escapedName + "' default-size \"${cols}x${rows}\" >/dev/null 2>&1 || true; fi",
+        "if [ -n \"$rows\" ] && [ \"$rows\" -ge 1 ] && [ \"$cols\" -ge 1 ]; then " + tmuxCommand + " resize-window -t '" + escapedName + "':. -x \"$cols\" -y \"$rows\" >/dev/null 2>&1 || true; fi",
+        `${tmuxCommand} set-window-option -t '${escapedName}':. window-size latest >/dev/null 2>&1 || true`,
+        "sleep 0.08",
+        `exec ${tmuxCommand} attach -t '${escapedName}'`
+      ].join('\n');
+      shellPath = '/bin/sh';
+      shellArgs = ['-c', attachCommand];
+    }
 
     const terminal = vscode.window.createTerminal({
       name: terminalName,
-      shellPath: '/bin/sh',
-      shellArgs: ['-c', attachCommand],
+      shellPath,
+      shellArgs,
       cwd: cwd,
       env: {
         'TERM': 'xterm-256color',


### PR DESCRIPTION
## Summary
- Adds Windows (win32) support for the tmux backend by using `psmux` as the multiplexer binary
- Generates PowerShell-compatible scripts for environment scrubbing and session attach
- Simplifies the Windows attach flow by skipping `stty` sizing (VS Code handles terminal dimensions)
- Adds `pwshQuote()` utility for PowerShell single-quote escaping

## Changes
| File | Change |
|---|---|
| `src/core/shell.ts` | Add `pwshQuote()` — PowerShell single-quote escaping (doubles `'` instead of bash `'\''`) |
| `src/core/path.ts` | `getTmuxCommand()` returns `psmux` binary on `win32` |
| `src/core/tmux.ts` | `buildStoredTmuxEnvScrubCommand()` generates PowerShell (`foreach`, `ForEach-Object`, `*>$null`) on `win32`; `installHint` says `winget install psmux`; `isInstalled()` uses `where psmux` |
| `src/utils/tmuxBackend.ts` | `attachSession()` on `win32`: uses `powershell.exe` shell, skips stty sizing loop, uses `*>$null` error suppression |

## Test plan
- [ ] Verify `npm run compile` and `npm run lint` pass (confirmed locally)
- [ ] On Windows with psmux installed: create a session and verify terminal attaches correctly
- [ ] On macOS/Linux: verify existing tmux attach behavior is unchanged (no regression)
- [ ] Verify `isInstalled()` correctly detects psmux on Windows / tmux on Unix

Refs #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)