### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.2.0] - 2026-05-06
+
+### Added
+- Windows platform support for core helpers (#112)
+- Windows CLI installer, doctor, and clipboard support (#113)
+- Windows terminal and shell integration via psmux (#114)
+- Windows CI smoke test job
+- Copilot lifecycle CLI and hardened tmux sync (#95)
+- Codex and Gemini skills symlinks (#97)
+- Isolated e2e scenario runner and plumbing (#101, #103)
+
+### Fixed
+- Fix Codex copilot launch when tmux PATH cannot find codex (#109)
+- Fix unresolved merge markers in session manager (#109)
+- Exclude local state files from VSIX packaging (#107)
+- Fail closed on worker delete tmux errors (#106)
+- Reuse shared GitHub repo in e2e runner (#103)
+- Support codex e2e runner isolation (#102)
+- Serialize session state updates to avoid worker ID races (#102)
+- Keep codex sessions in bypass mode (#100)
+
+### Changed
+- Limit `hydra whoami` to worker worktrees only (#99)
+- Clarify isolated test modes in docs (#100)
+
 ## [0.1.32] - 2026-05-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.1.32",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.1.32",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.1.32",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Release v0.2.0

Minor version bump — adds full **Windows support** via PowerShell + psmux.

---

### Changelog (since v0.1.30 — `9f07221`)

#### Features
- **Windows terminal and shell integration via psmux** (refs #111) (#114)
- **Windows CLI installer, doctor, and clipboard support** (refs #111) (#113)
- **Windows platform support for core helpers** (#112)
- Add copilot lifecycle CLI and harden tmux sync (#95)
- Integrate e2e scenario runner (#103)
- Add isolated hydra e2e plumbing (#101)

#### Fixes
- Fix Codex copilot launch when tmux PATH cannot find codex (#109)
- Fix unresolved merge markers in session manager (#109)
- Exclude local state from VSIX packaging (#107)
- Fail closed on worker delete tmux errors (#106)
- Reuse shared github repo in e2e runner (#103)
- Support codex e2e runner isolation (#102)
- Serialize session state updates (#102)
- Keep codex sessions in bypass mode (#100)

#### Refactor
- Limit whoami to worker worktrees (#99)

#### Chore
- Add codex and gemini skills symlinks (#97)
- Release v0.1.31 (#105)
- Release v0.1.32 (#110)

#### Docs
- Clarify isolated test modes (#100)

---

### Highlights
- 🪟 **Windows support**: Full Windows platform support via PowerShell and psmux, including CLI installer, doctor diagnostics, clipboard integration, and terminal/shell integration (issues #111, PRs #112, #113, #114)
- 🧪 **Windows CI**: Smoke test job added for Windows
- 🤖 **Copilot lifecycle**: CLI for copilot management with hardened tmux sync
- 🧩 **E2E framework**: Isolated end-to-end scenario runner infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)