### PR TITLE
fix: detect agent CLIs on Windows

### DIFF
--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -1,9 +1,11 @@
-import { exec as execCallback } from 'child_process';
+import { exec as execCallback, execFile as execFileCallback } from 'child_process';
 import path from 'node:path';
+import os from 'node:os';
 import { promisify } from 'util';
 import { getIsolatedEnv } from './path';
 
 const execPromise = promisify(execCallback);
+const execFilePromise = promisify(execFileCallback);
 
 export interface ExecOptions {
   cwd?: string;
@@ -11,12 +13,20 @@ export interface ExecOptions {
 
 // VS Code is a GUI app and doesn't inherit shell PATH.
 // Add common binary locations (Homebrew, etc.) to PATH.
+function getCurrentPath(): string {
+  return process.env.PATH || process.env.Path || '';
+}
+
 function getEnhancedPath(): string {
-  const currentPath = process.env.PATH || '';
+  const currentPath = getCurrentPath();
   const additionalPaths = process.platform === 'win32'
     ? [
+        path.join(os.homedir(), 'AppData', 'Roaming', 'npm'),
+        path.join(os.homedir(), 'AppData', 'Local', 'pnpm'),
+        path.join(os.homedir(), 'scoop', 'shims'),
         'C:\\Program Files\\nodejs',
         'C:\\Program Files\\Git\\cmd',
+        'C:\\ProgramData\\chocolatey\\bin',
       ]
     : [
         '/Applications/Codex.app/Contents/Resources',
@@ -26,21 +36,64 @@ function getEnhancedPath(): string {
         '/usr/local/sbin',
       ];
 
-  const pathSet = new Set(currentPath.split(path.delimiter));
-  const newPaths = additionalPaths.filter(p => !pathSet.has(p));
+  const pathSet = new Set(currentPath.split(path.delimiter).map(p => (
+    process.platform === 'win32' ? p.toLowerCase() : p
+  )));
+  const newPaths = additionalPaths.filter(p => {
+    const key = process.platform === 'win32' ? p.toLowerCase() : p;
+    return !pathSet.has(key);
+  });
 
   return newPaths.length > 0
     ? `${newPaths.join(path.delimiter)}${path.delimiter}${currentPath}`
     : currentPath;
 }
 
+function getExecEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {
+    ...getIsolatedEnv(),
+    PATH: getEnhancedPath(),
+  };
+
+  if (process.platform === 'win32') {
+    delete env.Path;
+  }
+
+  return env;
+}
+
 export async function exec(command: string, options?: ExecOptions): Promise<string> {
   const { stdout } = await execPromise(command, {
     cwd: options?.cwd,
-    env: {
-      ...getIsolatedEnv(),
-      PATH: getEnhancedPath(),
-    }
+    env: getExecEnv(),
   });
   return stdout.trim();
+}
+
+function posixShellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export async function resolveCommandPath(command: string): Promise<string | null> {
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  try {
+    const lookup = process.platform === 'win32'
+      ? await execFilePromise('where.exe', [trimmed], { env: getExecEnv() })
+      : await execFilePromise('/bin/sh', ['-lc', `command -v ${posixShellQuote(trimmed)}`], { env: getExecEnv() });
+
+    const lines = lookup.stdout.toString().split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean);
+    if (process.platform === 'win32') {
+      const pathExts = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+        .split(';')
+        .map(ext => ext.toLowerCase());
+      return lines.find(line => pathExts.includes(path.extname(line).toLowerCase())) || lines[0] || null;
+    }
+    return lines[0] || null;
+  } catch {
+    return null;
+  }
 }

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -5,7 +5,7 @@ import { MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig } from './hydraGlobalConfig';
 import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN } from './agentConfig';
-import { exec } from './exec';
+import { exec, resolveCommandPath } from './exec';
 import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile } from './path';
 import { shellQuote } from './shell';
 
@@ -1332,12 +1332,12 @@ export class SessionManager {
     if (!trimmed) return agentCommand;
 
     const [binary, ...rest] = trimmed.split(/\s+/);
-    if (!binary || binary.includes('/')) return trimmed;
+    if (!binary || binary.includes('/') || binary.includes('\\')) return trimmed;
 
     try {
-      const resolved = await exec(`command -v ${shellQuote(binary)}`);
+      const resolved = await resolveCommandPath(binary);
       if (!resolved) return trimmed;
-      return [shellQuote(resolved.split('\n')[0]), ...rest].join(' ');
+      return [shellQuote(resolved), ...rest].join(' ');
     } catch {
       return trimmed;
     }

--- a/src/utils/agentConfig.ts
+++ b/src/utils/agentConfig.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { AgentType } from '../core/types';
 import { AGENT_LABELS } from '../core/agentConfig';
-import { exec } from '../core/exec';
+import { resolveCommandPath } from '../core/exec';
 
 export type { AgentType } from '../core/types';
 export { AGENT_LABELS, DEFAULT_AGENT_COMMANDS, buildAgentLaunchCommand } from '../core/agentConfig';
@@ -11,12 +11,7 @@ export async function detectAvailableAgents(): Promise<AgentType[]> {
   const results = await Promise.all(agents.map(async (agent) => {
     const cmd = getAgentCommand(agent);
     const binary = cmd.split(/\s+/)[0];
-    try {
-      await exec(`which ${binary}`);
-      return agent;
-    } catch {
-      return null;
-    }
+    return await resolveCommandPath(binary) ? agent : null;
   }));
   return results.filter((a): a is AgentType => a !== null);
 }


### PR DESCRIPTION
## Summary
- Replace Unix-only agent detection with cross-platform command resolution
- Add common Windows user-level CLI install paths to the extension execution PATH
- Reuse the same resolver when launching agent commands

## Verification
- npm run compile
- npm run lint