### PR TITLE
fix: prompt to install psmux on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] - 2026-05-06
+
+### Fixed
+- Prompt Windows users to install psmux from VS Code when Hydra cannot find the session backend
+
 ## [0.2.1] - 2026-05-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -5,6 +5,7 @@ import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem } from '../providers
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
 import { SessionManager } from '../core/sessionManager';
 import { TmuxBackendCore } from '../core/tmux';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
@@ -91,8 +92,7 @@ async function handleCommandExecution(): Promise<void> {
 
 export async function attachCreate(item?: TmuxItem | string): Promise<void> {
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -12,6 +12,7 @@ import {
 import { getActiveBackend, HydraRole } from '../utils/multiplexer';
 import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
 import { exec } from '../utils/exec';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
 
 function getWorktreePath(item: TmuxItem): string | undefined {
   if (item instanceof CopilotItem) return item.worktreePath;
@@ -50,8 +51,7 @@ export async function attach(item: TmuxItem): Promise<void> {
     return;
   }
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 
@@ -73,8 +73,7 @@ export async function attachInEditor(item: TmuxItem): Promise<void> {
     return;
   }
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 
@@ -117,8 +116,7 @@ export async function newPane(item: TmuxItem): Promise<void> {
   }
   const backend = getActiveBackend();
   try {
-    if (!await backend.isInstalled()) {
-      vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+    if (!await ensureBackendInstalled(backend)) {
       return;
     }
 
@@ -138,8 +136,7 @@ export async function newWindow(item: TmuxItem): Promise<void> {
   }
   const backend = getActiveBackend();
   try {
-    if (!await backend.isInstalled()) {
-      vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+    if (!await ensureBackendInstalled(backend)) {
       return;
     }
 

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -4,6 +4,7 @@ import { getActiveBackend, MultiplexerBackend } from '../utils/multiplexer';
 import { getAgentCommand, pickAgentType, AgentType } from '../utils/agentConfig';
 import { TmuxBackendCore } from '../core/tmux';
 import { SessionManager } from '../core/sessionManager';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
 
 const ONBOARDING_PROMPT = `You are a Hydra copilot — an AI orchestrator that manages parallel AI workers to complete complex tasks.
 
@@ -40,8 +41,7 @@ function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string)
 
 export async function createCopilotWithAgent(agentType: AgentType): Promise<void> {
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 
@@ -76,8 +76,7 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
 
 export async function createCopilot(): Promise<void> {
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 

--- a/src/commands/createWorktreeFromBranch.ts
+++ b/src/commands/createWorktreeFromBranch.ts
@@ -14,6 +14,7 @@ import {
 import { exec } from '../utils/exec';
 import { getActiveBackend } from '../utils/multiplexer';
 import { WorktreeItem } from '../providers/tmuxSessionProvider';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
 
 function formatFileStatusCounts(nameStatusOutput: string): string {
   const lines = nameStatusOutput.trim().split('\n').filter(l => l.length > 0);
@@ -53,8 +54,7 @@ export async function createWorktreeFromBranch(item: WorktreeItem | undefined): 
   }
 
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 

--- a/src/commands/ensureBackendInstalled.ts
+++ b/src/commands/ensureBackendInstalled.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { MultiplexerBackend } from '../utils/multiplexer';
+
+const INSTALL_PSMUX_ACTION = 'Install psmux';
+const COPY_COMMAND_ACTION = 'Copy command';
+
+const PSMUX_INSTALL_COMMAND = 'winget install psmux --accept-source-agreements --accept-package-agreements';
+
+function showPsmuxInstallTerminal(): void {
+  const terminal = vscode.window.createTerminal({ name: 'Hydra Setup: psmux' });
+  terminal.show();
+  terminal.sendText(PSMUX_INSTALL_COMMAND);
+
+  void vscode.window.showInformationMessage(
+    'psmux installation started in the terminal. When it finishes, restart VS Code or run the Hydra command again.',
+  );
+}
+
+async function promptForPsmuxInstall(): Promise<void> {
+  const choice = await vscode.window.showErrorMessage(
+    'Hydra needs psmux on Windows to keep copilot and worker sessions persistent.',
+    INSTALL_PSMUX_ACTION,
+    COPY_COMMAND_ACTION,
+  );
+
+  if (choice === INSTALL_PSMUX_ACTION) {
+    showPsmuxInstallTerminal();
+    return;
+  }
+
+  if (choice === COPY_COMMAND_ACTION) {
+    await vscode.env.clipboard.writeText(PSMUX_INSTALL_COMMAND);
+    void vscode.window.showInformationMessage('Copied psmux install command to clipboard.');
+  }
+}
+
+export async function ensureBackendInstalled(backend: MultiplexerBackend): Promise<boolean> {
+  if (await backend.isInstalled()) {
+    return true;
+  }
+
+  if (process.platform === 'win32') {
+    await promptForPsmuxInstall();
+    return false;
+  }
+
+  vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  return false;
+}

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -4,6 +4,7 @@ import { TmuxBackendCore } from '../core/tmux';
 import { validateBranchName, localBranchExists, getRepoRoot } from '../utils/git';
 import { pickAgentType } from '../utils/agentConfig';
 import { getActiveBackend } from '../utils/multiplexer';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
 
 function getBaseBranchOverride(): string | undefined {
   const hydraOverride = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch');
@@ -17,8 +18,7 @@ function getBaseBranchOverride(): string | undefined {
 
 export async function newTask(): Promise<void> {
   const backend = getActiveBackend();
-  if (!await backend.isInstalled()) {
-    vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  if (!await ensureBackendInstalled(backend)) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Prompt Windows users to install psmux when Hydra cannot find the tmux backend
- Open a visible VS Code terminal with the winget install command instead of failing with a raw hint
- Bump extension version to v0.2.2 and update the changelog

## Testing
- npm run compile
- npm run lint

## Release
Merging this PR changes package.json to 0.2.2. The auto-tag-release workflow should create v0.2.2, which triggers the publish workflow for VS Marketplace and Open VSX.