### PR TITLE
docs(release): switch versioning to 0.<minor>.<yyyyddmmhhmm>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026050600] - 2026-05-06
+
+### Changed
+- Adopt date-based versioning: `0.<minor>.<yyyymmddNN>` (UTC date + in-day counter); minor bumps only on schema/breaking changes
+
 ## [0.2.2] - 2026-05-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.2.2",
+  "version": "0.3.2026050600",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.2.2",
+      "version": "0.3.2026050600",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.2.2",
+  "version": "0.3.2026050600",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/skills/release-hydra/SKILL.md
+++ b/skills/release-hydra/SKILL.md
@@ -14,36 +14,12 @@ Release a new version of the Hydra VS Code extension by creating a release PR.
 
 ## Steps
 
-1. **Determine the current version and next version**
+1. **Determine the next version**
 
-   ```bash
-   node -p "require('./package.json').version"
-   ```
+   Format: `0.<minor>.<yyyymmddNN>` (UTC date + 2-digit in-day counter).
 
-   Hydra uses the format `0.<minor>.<yyyymmddNN>`:
-   - The **second digit** is the major small-release version. Bump it only when the user requests a "major small release" or when there is a schema/breaking change.
-   - The **patch** is `<yyyymmdd><NN>` — today's UTC date followed by a 2-digit in-day counter. `NN` starts at `00` for the first release of the day and increments for each subsequent release that same day.
-
-   Compute the next patch:
-
-   ```bash
-   TODAY=$(date -u +%Y%m%d)
-   CURRENT=$(node -p "require('./package.json').version")
-   CURRENT_MINOR=$(echo "$CURRENT" | cut -d. -f2)
-   CURRENT_PATCH=$(echo "$CURRENT" | cut -d. -f3)
-   # If today's date matches the current patch's date prefix AND the minor is unchanged,
-   # increment the counter; otherwise reset to 00.
-   if [ "${CURRENT_PATCH:0:8}" = "$TODAY" ] && [ "$CURRENT_MINOR" = "<target-minor>" ]; then
-     NN=$(printf "%02d" $((10#${CURRENT_PATCH:8:2} + 1)))
-   else
-     NN="00"
-   fi
-   echo "0.<target-minor>.${TODAY}${NN}"
-   ```
-
-   Default behavior: keep the current minor, set patch as above. If the user asks for a "major small release" bump (or this release contains a schema/breaking change), increment the minor and reset `NN` to `00`.
-
-   Note: the `0.2.x` line was the last to use a sequential patch counter. The first release on the date scheme jumped to `0.3.<yyyymmdd>00`.
+   - Patch: today's `yyyymmdd` + `NN` — `00` for the first release of the day, else increment from the current patch's `NN`.
+   - Minor: bump only on schema/breaking changes (resets `NN` to `00`). The `0.3.x` line is the first on this scheme.
 
 2. **Collect commits since last release**
 

--- a/skills/release-hydra/SKILL.md
+++ b/skills/release-hydra/SKILL.md
@@ -20,7 +20,17 @@ Release a new version of the Hydra VS Code extension by creating a release PR.
    node -p "require('./package.json').version"
    ```
 
-   Bump the patch number (e.g., 0.1.27 → 0.1.28) unless the user specifies a different bump type (minor/major).
+   Hydra uses the format `0.<minor>.<yyyyddmmhhmm>`:
+   - The **second digit** is the major small-release version. Bump it only when the user requests a "major small release" or when there is a schema/breaking change.
+   - The **patch** is a UTC timestamp `yyyyddmmhhmm` (year, day, month, hour, minute) generated at release time:
+
+     ```bash
+     date -u +%Y%d%m%H%M
+     ```
+
+   Default behavior: keep the current minor, set patch to the current `yyyyddmmhhmm`. If the user asks for a "major small release" bump (or this release contains a schema/breaking change), increment the minor and use the same timestamp for patch.
+
+   Note: the `0.2.x` line was the last to use a sequential patch counter. The first release on the timestamp scheme jumped to `0.3.<yyyyddmmhhmm>`.
 
 2. **Collect commits since last release**
 

--- a/skills/release-hydra/SKILL.md
+++ b/skills/release-hydra/SKILL.md
@@ -20,17 +20,30 @@ Release a new version of the Hydra VS Code extension by creating a release PR.
    node -p "require('./package.json').version"
    ```
 
-   Hydra uses the format `0.<minor>.<yyyyddmmhhmm>`:
+   Hydra uses the format `0.<minor>.<yyyymmddNN>`:
    - The **second digit** is the major small-release version. Bump it only when the user requests a "major small release" or when there is a schema/breaking change.
-   - The **patch** is a UTC timestamp `yyyyddmmhhmm` (year, day, month, hour, minute) generated at release time:
+   - The **patch** is `<yyyymmdd><NN>` — today's UTC date followed by a 2-digit in-day counter. `NN` starts at `00` for the first release of the day and increments for each subsequent release that same day.
 
-     ```bash
-     date -u +%Y%d%m%H%M
-     ```
+   Compute the next patch:
 
-   Default behavior: keep the current minor, set patch to the current `yyyyddmmhhmm`. If the user asks for a "major small release" bump (or this release contains a schema/breaking change), increment the minor and use the same timestamp for patch.
+   ```bash
+   TODAY=$(date -u +%Y%m%d)
+   CURRENT=$(node -p "require('./package.json').version")
+   CURRENT_MINOR=$(echo "$CURRENT" | cut -d. -f2)
+   CURRENT_PATCH=$(echo "$CURRENT" | cut -d. -f3)
+   # If today's date matches the current patch's date prefix AND the minor is unchanged,
+   # increment the counter; otherwise reset to 00.
+   if [ "${CURRENT_PATCH:0:8}" = "$TODAY" ] && [ "$CURRENT_MINOR" = "<target-minor>" ]; then
+     NN=$(printf "%02d" $((10#${CURRENT_PATCH:8:2} + 1)))
+   else
+     NN="00"
+   fi
+   echo "0.<target-minor>.${TODAY}${NN}"
+   ```
 
-   Note: the `0.2.x` line was the last to use a sequential patch counter. The first release on the timestamp scheme jumped to `0.3.<yyyyddmmhhmm>`.
+   Default behavior: keep the current minor, set patch as above. If the user asks for a "major small release" bump (or this release contains a schema/breaking change), increment the minor and reset `NN` to `00`.
+
+   Note: the `0.2.x` line was the last to use a sequential patch counter. The first release on the date scheme jumped to `0.3.<yyyymmdd>00`.
 
 2. **Collect commits since last release**
 


### PR DESCRIPTION
Patch becomes a UTC timestamp generated at release time; minor only
bumps on schema/breaking changes. Next release jumps to 0.3.x.