### PR TITLE
fix: replace broken symlinks with NTFS junctions on Windows worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Compile
       run: npm run compile
 
-    - name: Test fixWindowsSymlinks
+    - name: Test fixWindowsSymlinks (synthetic)
       shell: pwsh
       run: |
         # Create a fake worktree directory with a broken symlink (text file containing target)
@@ -60,8 +60,6 @@ jobs:
         node -e "
           const path = require('path');
           const fs = require('fs');
-          // Load the compiled sessionManager to access fixWindowsSymlinks indirectly
-          // Since it's not exported, we inline the logic for testing
           const worktreeDir = process.argv[1];
           const KNOWN_SYMLINK_PATHS = ['.claude/skills'];
           for (const relPath of KNOWN_SYMLINK_PATHS) {
@@ -77,8 +75,69 @@ jobs:
           // Verify the junction works
           const marker = fs.readFileSync(path.join(worktreeDir, '.claude/skills/marker.txt'), 'utf-8');
           if (marker.trim() !== 'symlink-works') { console.error('Junction did not resolve correctly'); process.exit(1); }
-          console.log('fixWindowsSymlinks test PASSED');
+          console.log('fixWindowsSymlinks synthetic test PASSED');
         " "$worktree"
+
+    - name: Test fixWindowsSymlinks (real worktree clone)
+      shell: pwsh
+      run: |
+        # Clone the repo fresh (symlinks will become text files on Windows)
+        $cloneDir = "$env:RUNNER_TEMP\hydra-clone"
+        git clone --no-symlinks https://github.com/joezhoujinjing/hydra.git $cloneDir
+
+        # Show what git created for the symlink files (should be regular text files)
+        Write-Host "=== Before fix: .codex/skills is a file containing target path ==="
+        Get-Item "$cloneDir\.codex\skills" | Format-List
+        Get-Content "$cloneDir\.codex\skills"
+        Write-Host ""
+
+        # Create a worktree from the clone
+        Set-Location $cloneDir
+        git worktree add "$cloneDir\.hydra\worktrees\test-wt" -b test-wt-branch HEAD
+
+        Write-Host "=== Worktree .codex/skills (before fix) ==="
+        $wtSkills = "$cloneDir\.hydra\worktrees\test-wt\.codex\skills"
+        Get-Item $wtSkills | Format-List
+        Get-Content $wtSkills
+        Write-Host ""
+
+        # Apply the fix
+        node -e "
+          const path = require('path');
+          const fs = require('fs');
+          const worktreeDir = process.argv[1];
+          const KNOWN_SYMLINK_PATHS = ['.claude/skills', '.codex/skills', '.gemini/skills'];
+          for (const relPath of KNOWN_SYMLINK_PATHS) {
+            const fullPath = path.join(worktreeDir, relPath);
+            try {
+              const stat = fs.lstatSync(fullPath);
+              if (!stat.isFile()) { console.log(relPath + ' is not a file, skipping'); continue; }
+              const target = fs.readFileSync(fullPath, 'utf-8').trim();
+              console.log(relPath + ' contains target: ' + target);
+              const resolvedTarget = path.resolve(path.dirname(fullPath), target);
+              if (!fs.existsSync(resolvedTarget)) { console.log('  Target not found: ' + resolvedTarget + ', skipping'); continue; }
+              fs.unlinkSync(fullPath);
+              fs.symlinkSync(resolvedTarget, fullPath, 'junction');
+              console.log('  -> Replaced with junction to ' + resolvedTarget);
+            } catch (e) { console.log(relPath + ': ' + e.message); }
+          }
+        " "$cloneDir\.hydra\worktrees\test-wt"
+
+        Write-Host ""
+        Write-Host "=== After fix: ls .codex/skills/ ==="
+        Get-ChildItem "$cloneDir\.hydra\worktrees\test-wt\.codex\skills" | ForEach-Object { Write-Host $_.Name }
+
+        Write-Host ""
+        Write-Host "=== Reading .codex/skills/hydra content ==="
+        $hydraSkill = "$cloneDir\.hydra\worktrees\test-wt\.codex\skills\hydra"
+        if (Test-Path $hydraSkill) {
+          Get-ChildItem $hydraSkill | ForEach-Object { Write-Host $_.Name }
+        } else {
+          Write-Host "ERROR: .codex/skills/hydra not accessible!"
+          exit 1
+        }
+        Write-Host ""
+        Write-Host "Real worktree symlink fix test PASSED"
 
     - name: Doctor check (informational)
       run: node out/cli/index.js doctor --json || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,44 @@ jobs:
     - name: Compile
       run: npm run compile
 
+    - name: Test fixWindowsSymlinks
+      shell: pwsh
+      run: |
+        # Create a fake worktree directory with a broken symlink (text file containing target)
+        $worktree = "$env:RUNNER_TEMP\test-worktree"
+        $skillsDir = "$worktree\real-skills"
+        $claudeDir = "$worktree\.claude"
+        New-Item -ItemType Directory -Path $skillsDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $claudeDir -Force | Out-Null
+        # Write a marker file so we can verify the junction works
+        Set-Content -Path "$skillsDir\marker.txt" -Value "symlink-works"
+        # Simulate git's broken symlink: a text file with the relative target path
+        Set-Content -Path "$claudeDir\skills" -Value "../real-skills" -NoNewline
+
+        # Run the fixWindowsSymlinks function via a small script
+        node -e "
+          const path = require('path');
+          const fs = require('fs');
+          // Load the compiled sessionManager to access fixWindowsSymlinks indirectly
+          // Since it's not exported, we inline the logic for testing
+          const worktreeDir = process.argv[1];
+          const KNOWN_SYMLINK_PATHS = ['.claude/skills'];
+          for (const relPath of KNOWN_SYMLINK_PATHS) {
+            const fullPath = path.join(worktreeDir, relPath);
+            const stat = fs.lstatSync(fullPath);
+            if (!stat.isFile()) { process.exit(1); }
+            const target = fs.readFileSync(fullPath, 'utf-8').trim();
+            const resolvedTarget = path.resolve(path.dirname(fullPath), target);
+            if (!fs.existsSync(resolvedTarget)) { console.error('Target not found:', resolvedTarget); process.exit(1); }
+            fs.unlinkSync(fullPath);
+            fs.symlinkSync(resolvedTarget, fullPath, 'junction');
+          }
+          // Verify the junction works
+          const marker = fs.readFileSync(path.join(worktreeDir, '.claude/skills/marker.txt'), 'utf-8');
+          if (marker.trim() !== 'symlink-works') { console.error('Junction did not resolve correctly'); process.exit(1); }
+          console.log('fixWindowsSymlinks test PASSED');
+        " "$worktree"
+
     - name: Doctor check (informational)
       run: node out/cli/index.js doctor --json || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,12 @@ jobs:
     - name: Test fixWindowsSymlinks (real worktree clone)
       shell: pwsh
       run: |
-        # Clone the repo fresh (symlinks will become text files on Windows)
+        $ErrorActionPreference = "Stop"
+
+        # Clone the repo with core.symlinks=false to simulate typical Windows behavior
+        # (GitHub Actions runners have Developer Mode enabled, so we must force this)
         $cloneDir = "$env:RUNNER_TEMP\hydra-clone"
-        git clone --no-symlinks https://github.com/joezhoujinjing/hydra.git $cloneDir
+        git clone -c core.symlinks=false https://github.com/joezhoujinjing/hydra.git $cloneDir
 
         # Show what git created for the symlink files (should be regular text files)
         Write-Host "=== Before fix: .codex/skills is a file containing target path ==="
@@ -91,7 +94,7 @@ jobs:
         Get-Content "$cloneDir\.codex\skills"
         Write-Host ""
 
-        # Create a worktree from the clone
+        # Create a worktree from the clone (also inherits core.symlinks=false)
         Set-Location $cloneDir
         git worktree add "$cloneDir\.hydra\worktrees\test-wt" -b test-wt-branch HEAD
 

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -14,6 +14,48 @@ const SESSION_STATE_LOCK_TIMEOUT_MS = 10000;
 const SESSION_STATE_LOCK_RETRY_MS = 50;
 const SESSION_STATE_LOCK_STALE_MS = 120000;
 
+/** Known symlink paths that git may convert to plain text files on Windows. */
+const KNOWN_SYMLINK_PATHS = [
+  '.claude/skills',
+  '.codex/skills',
+  '.gemini/skills',
+  '.sudocode/skills',
+];
+
+/**
+ * On Windows, git converts symlinks to plain text files containing the target path.
+ * This function detects those broken symlinks and replaces them with NTFS junctions
+ * (which don't require admin privileges).
+ */
+function fixWindowsSymlinks(worktreeDir: string): void {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  for (const relPath of KNOWN_SYMLINK_PATHS) {
+    const fullPath = path.join(worktreeDir, relPath);
+    try {
+      const stat = fs.lstatSync(fullPath);
+      if (!stat.isFile()) {
+        continue;
+      }
+      // Git writes the symlink target as the file content
+      const target = fs.readFileSync(fullPath, 'utf-8').trim();
+      if (!target) {
+        continue;
+      }
+      const resolvedTarget = path.resolve(path.dirname(fullPath), target);
+      if (!fs.existsSync(resolvedTarget)) {
+        continue;
+      }
+      fs.unlinkSync(fullPath);
+      fs.symlinkSync(resolvedTarget, fullPath, 'junction');
+    } catch {
+      // Best-effort — skip if anything goes wrong
+    }
+  }
+}
+
 /**
  * Look up a worker's numeric ID from sessions.json.
  * Lightweight standalone function — no SessionManager instance needed.
@@ -335,6 +377,10 @@ export class SessionManager {
 
     // Create worktree
     const worktreePath = await coreGit.addWorktree(repoRoot, branchName, finalSlug, baseBranch);
+
+    // On Windows, git converts symlinks to plain text files containing the target path.
+    // Replace them with NTFS junctions so they work without admin privileges.
+    fixWindowsSymlinks(worktreePath);
 
     let taskFilename: string | undefined;
     if (taskFile) {


### PR DESCRIPTION
## Summary
- On Windows, git converts symlinks to plain text files containing the target path
- After `git worktree add`, known symlink paths (`.claude/skills`, `.codex/skills`, `.gemini/skills`, `.sudocode/skills`) are detected as broken (regular files instead of symlinks)
- These are replaced with NTFS junctions (`fs.symlinkSync(..., 'junction')`) which work without admin privileges

## Test plan
- [ ] Verify on Windows: create a worktree in a repo with `.claude/skills -> ../skills` symlink
- [ ] Confirm the symlink file is replaced with a working junction
- [ ] Verify on macOS/Linux: function is a no-op (platform check)
- [ ] `npm run compile` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)