### PR TITLE
[codex] fix worker delete consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,7 +271,8 @@
     "e2e:isolated": "node scripts/e2e-isolated-runner.js",
     "e2e:isolated:shell": "node scripts/e2e-isolated-runner.js --shell --keep",
     "smoke:tmux-attach": "node out/smoke/tmuxAttachSmoke.js",
-    "smoke:codex-bypass": "node out/smoke/codexBypassSmoke.js"
+    "smoke:codex-bypass": "node out/smoke/codexBypassSmoke.js",
+    "smoke:worker-delete": "node out/smoke/workerDeleteFailClosedSmoke.js"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -492,21 +492,30 @@ export class SessionManager {
 
     const worker = this.readSessionState().workers[sessionName];
 
-    // Archive before removing
-    if (worker) {
-      this.archiveEntry('worker', worker.sessionName, worker.sessionId, worker);
-    }
-
     if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
       try {
         await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
-      } catch { /* Force removal fallback */ }
+      } catch (error) {
+        await this.updateSessionState((state) => {
+          if (state.workers[sessionName]) {
+            state.workers[sessionName].status = 'stopped';
+            state.workers[sessionName].attached = false;
+            state.updatedAt = new Date().toISOString();
+          }
+        });
+        throw error;
+      }
 
       if (worker.branch) {
         try {
           await exec(`git branch -D ${shellQuote(worker.branch)}`, { cwd: worker.repoRoot });
         } catch { /* Branch may not exist */ }
       }
+    }
+
+    // Archive only after destructive cleanup has succeeded, so failed deletes remain retryable.
+    if (worker) {
+      this.archiveEntry('worker', worker.sessionName, worker.sessionId, worker);
     }
 
     await this.updateSessionState((state) => {

--- a/src/smoke/workerDeleteFailClosedSmoke.ts
+++ b/src/smoke/workerDeleteFailClosedSmoke.ts
@@ -222,6 +222,9 @@ async function main(): Promise<void> {
   process.env.HOME = tempHome;
 
   const hydraDir = path.join(tempHome, '.hydra');
+  process.env.HYDRA_HOME = hydraDir;
+  delete process.env.HYDRA_CONFIG_PATH;
+
   const sessionsFile = path.join(hydraDir, 'sessions.json');
   const archiveFile = path.join(hydraDir, 'archive.json');
 
@@ -314,6 +317,56 @@ async function main(): Promise<void> {
     assert.equal(removeWorktreeCalls, 1);
     assert.equal(branchDeleteCommands.length, 1);
     assert.match(branchDeleteCommands[0] || '', /git branch -D/);
+  }
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-repo-'));
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-worktree-'));
+    const worker = buildWorker('worker-delete-worktree-fails', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeJson(archiveFile, { entries: [] });
+
+    const backend = new DeleteWorkerBackend([worker.sessionName]);
+
+    let removeWorktreeCalls = 0;
+    const branchDeleteCommands: string[] = [];
+    const restoreCoreGit = patchModule(coreGit, {
+      removeWorktree: async () => {
+        removeWorktreeCalls += 1;
+        throw makeExecError('worktree remove failed', 'contains modified or untracked files');
+      },
+    });
+    const restoreExec = patchModule(coreExec, {
+      exec: async (command: string) => {
+        branchDeleteCommands.push(command);
+        return '';
+      },
+    });
+
+    try {
+      const sm = new SessionManager(backend);
+      await assert.rejects(
+        sm.deleteWorker(worker.sessionName),
+        /worktree remove failed/,
+      );
+    } finally {
+      restoreExec();
+      restoreCoreGit();
+    }
+
+    const archive = readJson<{ entries: Array<Record<string, unknown>> }>(archiveFile, { entries: [] });
+    const state = readJson<{ workers: Record<string, { status?: string; attached?: boolean }> }>(
+      sessionsFile,
+      { workers: {} },
+    );
+    assert.equal(archive.entries.length, 0);
+    assert.ok(state.workers[worker.sessionName], 'sessions.json entry should remain after worktree removal failure');
+    assert.equal(state.workers[worker.sessionName]?.status, 'stopped');
+    assert.equal(state.workers[worker.sessionName]?.attached, false);
+    assert.equal(removeWorktreeCalls, 1);
+    assert.equal(branchDeleteCommands.length, 0);
+    assert.equal(await backend.hasSession(worker.sessionName), false);
+    assert.ok(fs.existsSync(workdir), 'worktree should remain after worktree removal failure');
   }
 
   {


### PR DESCRIPTION
## Summary

Fixes worker deletion state consistency when `git worktree remove` fails.

## What changed

- `SessionManager.deleteWorker` now stops deletion after `removeWorktree` fails instead of continuing to delete the branch and `sessions.json` entry.
- Failed worktree removal leaves the worker visible in `sessions.json` as `stopped` and unattached, so cleanup can be retried.
- Worker archive entries are written only after destructive cleanup succeeds, avoiding an archive that claims the worker was deleted while the worktree remains on disk.
- Added a worker-delete smoke test covering the failed `removeWorktree` path and exposed it through `npm run smoke:worker-delete`.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:worker-delete`
- `git diff --check`