### PR TITLE
feat: expose sessionId and session file path in logs and list output

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,8 @@
     "smoke:telemetry": "node out/smoke/telemetrySmoke.js",
     "smoke:telemetry-e2e": "node out/smoke/telemetryE2eSmoke.js",
     "smoke:telemetry-posthog-real": "node out/smoke/telemetryPostHogRealSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e"
+    "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -278,7 +278,8 @@
     "smoke:telemetry-e2e": "node out/smoke/telemetryE2eSmoke.js",
     "smoke:telemetry-posthog-real": "node out/smoke/telemetryPostHogRealSmoke.js",
     "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve"
+    "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -169,11 +169,10 @@ export function registerCopilotCommands(program: Command): void {
 
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const [output, state] = await Promise.all([
+        const [output, copilot] = await Promise.all([
           backend.capturePane(sessionName, lines),
-          sm.sync(),
+          sm.getCopilot(sessionName),
         ]);
-        const copilot = state.copilots[sessionName];
         const sessionFile = copilot
           ? resolveAgentSessionFile(copilot.agent, copilot.workdir, copilot.sessionId)
           : null;

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
-import { toCanonicalPath } from '../../core/path';
+import { toCanonicalPath, resolveAgentSessionFile } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
 
@@ -168,10 +168,18 @@ export function registerCopilotCommands(program: Command): void {
         }
 
         const backend = new TmuxBackendCore();
-        const output = await backend.capturePane(sessionName, lines);
+        const sm = new SessionManager(backend);
+        const [output, state] = await Promise.all([
+          backend.capturePane(sessionName, lines),
+          sm.sync(),
+        ]);
+        const copilot = state.copilots[sessionName];
+        const sessionFile = copilot
+          ? resolveAgentSessionFile(copilot.agent, copilot.workdir, copilot.sessionId)
+          : null;
 
         outputResult(
-          { session: sessionName, lines, output },
+          { session: sessionName, lines, output, sessionId: copilot?.sessionId ?? null, sessionFile },
           globalOpts,
           () => process.stdout.write(output),
         );

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
+import { resolveAgentSessionFile } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 
 export function registerListCommand(program: Command): void {
@@ -27,6 +28,8 @@ export function registerListCommand(program: Command): void {
             status: c.status,
             attached: c.attached,
             workdir: c.workdir || null,
+            sessionId: c.sessionId,
+            sessionFile: resolveAgentSessionFile(c.agent, c.workdir, c.sessionId),
             agentSessionId: c.sessionId,
           })),
           workers: workers.map(w => ({
@@ -40,6 +43,8 @@ export function registerListCommand(program: Command): void {
             attached: w.attached,
             workdir: w.workdir || null,
             copilotSessionName: w.copilotSessionName || null,
+            sessionId: w.sessionId,
+            sessionFile: resolveAgentSessionFile(w.agent, w.workdir, w.sessionId),
             agentSessionId: w.sessionId,
           })),
           count: copilots.length + workers.length,

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
 import { getRepoRootFromPath, localBranchExists } from '../../core/git';
-import { toCanonicalPath } from '../../core/path';
+import { toCanonicalPath, resolveAgentSessionFile } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { detectCurrentTmuxIdentity, detectIdentity, getWorkerCreationBlockedMessage } from '../identity';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
@@ -220,10 +220,17 @@ export function registerWorkerCommands(program: Command): void {
         }
 
         const backend = new TmuxBackendCore();
-        const output = await backend.capturePane(sessionName, lines);
+        const sm = new SessionManager(backend);
+        const [output, worker] = await Promise.all([
+          backend.capturePane(sessionName, lines),
+          sm.getWorker(sessionName),
+        ]);
+        const sessionFile = worker
+          ? resolveAgentSessionFile(worker.agent, worker.workdir, worker.sessionId)
+          : null;
 
         outputResult(
-          { session: sessionName, lines, output },
+          { session: sessionName, lines, output, sessionId: worker?.sessionId ?? null, sessionFile },
           globalOpts,
           () => process.stdout.write(output),
         );

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -21,9 +21,12 @@ export function toCanonicalPath(targetPath?: string): string | undefined {
 /**
  * Resolves the on-disk transcript file for a given agent session.
  *   - claude:  ~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl
- *              (workdir encoded by replacing `/` and `.` with `-`)
+ *              (workdir encoded by replacing `/`, `\`, `.`, `:`, and whitespace
+ *              with `-`, mirroring Claude Code's own slugify behavior on POSIX
+ *              and Windows)
  *   - codex:   ~/.codex/sessions/YYYY/MM/DD/rollout-<datetime>-<sessionId>.jsonl
- *              (located via a recursive scan; sessionId required, workdir unused)
+ *              (UUIDv7 sessionIds let us probe the date directory in O(1);
+ *              falls back to a recursive scan otherwise)
  *   - gemini:  ~/.gemini/tmp/<projectName>/logs.json
  *              (projectName looked up by workdir in ~/.gemini/projects.json;
  *              the file is per-project and may contain multiple sessions)
@@ -45,17 +48,66 @@ export function resolveAgentSessionFile(agent: string, workdir: string, sessionI
 
 function resolveClaudeSessionFile(workdir: string, sessionId: string | null): string | null {
   if (!workdir || !sessionId) return null;
-  const encoded = workdir.replace(/[/.]/g, '-');
+  const encoded = encodeClaudeWorkdir(workdir);
   const file = path.join(os.homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`);
   return fs.existsSync(file) ? file : null;
+}
+
+/**
+ * Encodes a workdir into Claude Code's project directory slug. Replaces path
+ * separators (`/`, `\`), drive-letter colons, dots, and whitespace with `-`
+ * so the rule works for both POSIX (`/Users/x/.foo`) and Windows
+ * (`C:\Users\x\proj`) workdirs.
+ */
+export function encodeClaudeWorkdir(workdir: string): string {
+  return workdir.replace(/[/\\.:\s]/g, '-');
 }
 
 function resolveCodexSessionFile(sessionId: string | null): string | null {
   if (!sessionId) return null;
   const root = path.join(os.homedir(), '.codex', 'sessions');
   if (!fs.existsSync(root)) return null;
-  const suffix = `-${sessionId}.jsonl`;
 
+  // Fast path: codex uses UUIDv7 ids whose first 48 bits encode unix ms, and
+  // it partitions storage by UTC date — so we can usually probe a single dir
+  // instead of walking the whole tree.
+  const direct = probeCodexDateDir(root, sessionId);
+  if (direct) return direct;
+
+  return scanCodexSessions(root, sessionId);
+}
+
+function probeCodexDateDir(root: string, sessionId: string): string | null {
+  const compact = sessionId.replace(/-/g, '');
+  // UUIDv7: 13th hex character (after dashes stripped) is the version `7`.
+  if (compact.length < 13 || compact[12] !== '7') return null;
+  const ms = parseInt(compact.slice(0, 12), 16);
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return null;
+
+  const yyyy = String(d.getUTCFullYear()).padStart(4, '0');
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  const dir = path.join(root, yyyy, mm, dd);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const suffix = `-${sessionId}.jsonl`;
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith(suffix)) {
+      return path.join(dir, entry.name);
+    }
+  }
+  return null;
+}
+
+function scanCodexSessions(root: string, sessionId: string): string | null {
+  const suffix = `-${sessionId}.jsonl`;
   // Walk ~/.codex/sessions/YYYY/MM/DD/ for a file named rollout-*-<sessionId>.jsonl.
   // Newest dates first so the common case (recent session) hits early.
   const stack: string[] = [root];
@@ -103,7 +155,21 @@ function resolveGeminiSessionFile(workdir: string): string | null {
     return null;
   }
 
-  const projectName = projects[workdir];
+  // Gemini stores keys produced by Node's path.resolve(); incoming workdirs may
+  // have trailing slashes or differ in casing on case-insensitive filesystems.
+  // Try an exact lookup first, then fall back to a normalized comparison.
+  let projectName: string | undefined = projects[workdir];
+  if (!projectName) {
+    const normalizedTarget = toCanonicalPath(workdir);
+    if (normalizedTarget) {
+      for (const [key, value] of Object.entries(projects)) {
+        if (toCanonicalPath(key) === normalizedTarget) {
+          projectName = value;
+          break;
+        }
+      }
+    }
+  }
   if (!projectName) return null;
 
   const logsFile = path.join(os.homedir(), '.gemini', 'tmp', projectName, 'logs.json');

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -18,6 +18,19 @@ export function toCanonicalPath(targetPath?: string): string | undefined {
   return path.normalize(path.resolve(expanded));
 }
 
+/**
+ * Resolves the Claude Code session JSONL file for a given workdir + sessionId.
+ * Claude Code stores transcripts at `~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl`,
+ * where the encoded workdir replaces `/` and `.` characters with `-`.
+ * Returns null for non-Claude agents, missing sessionId, or when the file does not exist.
+ */
+export function resolveAgentSessionFile(agent: string, workdir: string, sessionId: string | null): string | null {
+  if (!sessionId || agent !== 'claude' || !workdir) return null;
+  const encoded = workdir.replace(/[/.]/g, '-');
+  const file = path.join(os.homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`);
+  return fs.existsSync(file) ? file : null;
+}
+
 export interface HydraCliConfig {
   extensionPath?: string;
   version?: string;

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -19,16 +19,95 @@ export function toCanonicalPath(targetPath?: string): string | undefined {
 }
 
 /**
- * Resolves the Claude Code session JSONL file for a given workdir + sessionId.
- * Claude Code stores transcripts at `~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl`,
- * where the encoded workdir replaces `/` and `.` characters with `-`.
- * Returns null for non-Claude agents, missing sessionId, or when the file does not exist.
+ * Resolves the on-disk transcript file for a given agent session.
+ *   - claude:  ~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl
+ *              (workdir encoded by replacing `/` and `.` with `-`)
+ *   - codex:   ~/.codex/sessions/YYYY/MM/DD/rollout-<datetime>-<sessionId>.jsonl
+ *              (located via a recursive scan; sessionId required, workdir unused)
+ *   - gemini:  ~/.gemini/tmp/<projectName>/logs.json
+ *              (projectName looked up by workdir in ~/.gemini/projects.json;
+ *              the file is per-project and may contain multiple sessions)
+ * Returns null when the agent is unknown, required inputs are missing, or the
+ * file does not exist.
  */
 export function resolveAgentSessionFile(agent: string, workdir: string, sessionId: string | null): string | null {
-  if (!sessionId || agent !== 'claude' || !workdir) return null;
+  switch (agent) {
+    case 'claude':
+      return resolveClaudeSessionFile(workdir, sessionId);
+    case 'codex':
+      return resolveCodexSessionFile(sessionId);
+    case 'gemini':
+      return resolveGeminiSessionFile(workdir);
+    default:
+      return null;
+  }
+}
+
+function resolveClaudeSessionFile(workdir: string, sessionId: string | null): string | null {
+  if (!workdir || !sessionId) return null;
   const encoded = workdir.replace(/[/.]/g, '-');
   const file = path.join(os.homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`);
   return fs.existsSync(file) ? file : null;
+}
+
+function resolveCodexSessionFile(sessionId: string | null): string | null {
+  if (!sessionId) return null;
+  const root = path.join(os.homedir(), '.codex', 'sessions');
+  if (!fs.existsSync(root)) return null;
+  const suffix = `-${sessionId}.jsonl`;
+
+  // Walk ~/.codex/sessions/YYYY/MM/DD/ for a file named rollout-*-<sessionId>.jsonl.
+  // Newest dates first so the common case (recent session) hits early.
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    const subdirs: string[] = [];
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        subdirs.push(entry.name);
+      } else if (
+        entry.isFile()
+        && entry.name.startsWith('rollout-')
+        && entry.name.endsWith(suffix)
+      ) {
+        return path.join(dir, entry.name);
+      }
+    }
+    // Push subdirs in ascending order so the largest (newest) is popped first.
+    subdirs.sort();
+    for (const name of subdirs) {
+      stack.push(path.join(dir, name));
+    }
+  }
+  return null;
+}
+
+function resolveGeminiSessionFile(workdir: string): string | null {
+  if (!workdir) return null;
+  const projectsFile = path.join(os.homedir(), '.gemini', 'projects.json');
+  if (!fs.existsSync(projectsFile)) return null;
+
+  let projects: Record<string, string>;
+  try {
+    const raw = JSON.parse(fs.readFileSync(projectsFile, 'utf-8'));
+    const map = raw?.projects;
+    if (!map || typeof map !== 'object') return null;
+    projects = map as Record<string, string>;
+  } catch {
+    return null;
+  }
+
+  const projectName = projects[workdir];
+  if (!projectName) return null;
+
+  const logsFile = path.join(os.homedir(), '.gemini', 'tmp', projectName, 'logs.json');
+  return fs.existsSync(logsFile) ? logsFile : null;
 }
 
 export interface HydraCliConfig {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -319,6 +319,11 @@ export class SessionManager {
     return state.workers[sessionName];
   }
 
+  async getCopilot(sessionName: string): Promise<CopilotInfo | undefined> {
+    const state = await this.sync();
+    return state.copilots[sessionName];
+  }
+
   // ── Worker Lifecycle ──
 
   async createWorker(opts: CreateWorkerOpts): Promise<CreateWorkerResult> {

--- a/src/smoke/cliSessionFieldsSmoke.ts
+++ b/src/smoke/cliSessionFieldsSmoke.ts
@@ -1,0 +1,216 @@
+/**
+ * Smoke test: end-to-end CLI verification that `hydra list --json` exposes
+ * sessionId, sessionFile, and agentSessionId for both copilots and workers.
+ *
+ * The smoke creates an isolated HYDRA_HOME with a seeded sessions.json, points
+ * HOME at a fixture transcript layout, and runs the compiled CLI in a
+ * subprocess. tmux is steered onto a unique socket so live-session reconcile
+ * sees an empty server (the seeded worker therefore persists as `stopped`).
+ *
+ * Skipped cleanly when tmux is not on PATH.
+ *
+ * Run:  node out/smoke/cliSessionFieldsSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { encodeClaudeWorkdir } from '../core/path';
+
+const cliPath = path.resolve(__dirname, '..', 'cli', 'index.js');
+
+interface ListJsonEntry {
+  sessionId: string | null;
+  sessionFile: string | null;
+  agentSessionId: string | null;
+  [k: string]: unknown;
+}
+interface ListJson {
+  copilots: ListJsonEntry[];
+  workers: ListJsonEntry[];
+  count: number;
+}
+
+function tmuxAvailable(): boolean {
+  const result = spawnSync('tmux', ['-V'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+function setupFixture(): {
+  tmp: string;
+  home: string;
+  hydraHome: string;
+  workdir: string;
+  workerSession: string;
+  copilotSession: string;
+  workerSessionId: string;
+  copilotSessionId: string;
+  workerTranscript: string;
+  copilotTranscript: string;
+  tmuxSocket: string;
+} {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-cli-fields-'));
+  const home = path.join(tmp, 'home');
+  const hydraHome = path.join(tmp, 'hydra');
+  const workdir = path.join(tmp, 'workdir');
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(hydraHome, { recursive: true });
+  fs.mkdirSync(workdir, { recursive: true });
+
+  const workerSession = 'hydra-cli-fields-worker';
+  const copilotSession = 'hydra-cli-fields-copilot';
+  const workerSessionId = '11111111-2222-3333-4444-555555555555';
+  const copilotSessionId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  // Seed transcript files so resolveAgentSessionFile returns a non-null path.
+  const workerTranscript = path.join(
+    home, '.claude', 'projects', encodeClaudeWorkdir(workdir), `${workerSessionId}.jsonl`,
+  );
+  const copilotTranscript = path.join(
+    home, '.claude', 'projects', encodeClaudeWorkdir(workdir), `${copilotSessionId}.jsonl`,
+  );
+  fs.mkdirSync(path.dirname(workerTranscript), { recursive: true });
+  fs.writeFileSync(workerTranscript, '');
+  fs.writeFileSync(copilotTranscript, '');
+
+  const now = new Date().toISOString();
+  const sessions = {
+    copilots: {
+      [copilotSession]: {
+        sessionName: copilotSession,
+        displayName: copilotSession,
+        status: 'running', // overridden by sync; non-live + no live → deleted, so include below as live via tmux
+        attached: false,
+        agent: 'claude',
+        workdir,
+        tmuxSession: copilotSession,
+        createdAt: now,
+        lastSeenAt: now,
+        sessionId: copilotSessionId,
+      },
+    },
+    workers: {
+      [workerSession]: {
+        sessionName: workerSession,
+        displayName: 'cli-fields',
+        workerId: 1,
+        repo: 'fixture',
+        repoRoot: workdir,
+        branch: 'main',
+        slug: 'cli-fields',
+        status: 'running',
+        attached: false,
+        agent: 'claude',
+        workdir,
+        tmuxSession: workerSession,
+        createdAt: now,
+        lastSeenAt: now,
+        sessionId: workerSessionId,
+        copilotSessionName: null,
+      },
+    },
+    nextWorkerId: 2,
+    updatedAt: now,
+  };
+  fs.writeFileSync(
+    path.join(hydraHome, 'sessions.json'),
+    JSON.stringify(sessions, null, 2),
+  );
+
+  // Unique tmux socket name so we never collide with a real tmux server.
+  const tmuxSocket = `hydra-cli-fields-${process.pid}-${Date.now()}`;
+
+  return {
+    tmp, home, hydraHome, workdir,
+    workerSession, copilotSession,
+    workerSessionId, copilotSessionId,
+    workerTranscript, copilotTranscript,
+    tmuxSocket,
+  };
+}
+
+function startTmuxFixtures(socket: string, sessions: string[], cwd: string): void {
+  for (const name of sessions) {
+    spawnSync('tmux', ['-L', socket, 'new-session', '-d', '-s', name, '-c', cwd], {
+      stdio: 'ignore',
+    });
+  }
+}
+
+function killTmuxServer(socket: string): void {
+  spawnSync('tmux', ['-L', socket, 'kill-server'], { stdio: 'ignore' });
+}
+
+function runCli(args: string[], env: Record<string, string | undefined>): string {
+  return execFileSync('node', [cliPath, ...args], {
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function assertSessionFields(entry: ListJsonEntry | undefined, sessionId: string, transcript: string, label: string): void {
+  assert.ok(entry, `expected ${label} entry in list output`);
+  assert.equal(entry!.sessionId, sessionId, `${label}.sessionId`);
+  assert.equal(entry!.agentSessionId, sessionId, `${label}.agentSessionId`);
+  assert.equal(entry!.sessionFile, transcript, `${label}.sessionFile`);
+}
+
+function main(): void {
+  if (!tmuxAvailable()) {
+    console.log('cliSessionFieldsSmoke: skipped (tmux not on PATH)');
+    return;
+  }
+  if (!fs.existsSync(cliPath)) {
+    console.log(`cliSessionFieldsSmoke: skipped (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const ctx = setupFixture();
+  // Start a tmux server on the isolated socket with two sessions so the
+  // seeded copilot/worker reconcile to `running` and stay in the JSON output.
+  startTmuxFixtures(ctx.tmuxSocket, [ctx.copilotSession, ctx.workerSession], ctx.workdir);
+
+  try {
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      HOME: ctx.home,
+      USERPROFILE: ctx.home,
+      HYDRA_HOME: ctx.hydraHome,
+      HYDRA_TMUX_SOCKET: ctx.tmuxSocket,
+      // Force telemetry off so the smoke does not emit network/IO noise.
+      HYDRA_TELEMETRY: '0',
+    };
+
+    const listOut = runCli(['list', '--json'], env);
+    const list = JSON.parse(listOut) as ListJson;
+    assert.ok(Array.isArray(list.workers), 'list.workers must be an array');
+    assert.ok(Array.isArray(list.copilots), 'list.copilots must be an array');
+
+    const worker = list.workers.find(w => w.session === ctx.workerSession);
+    const copilot = list.copilots.find(c => c.session === ctx.copilotSession);
+    assertSessionFields(worker, ctx.workerSessionId, ctx.workerTranscript, 'worker');
+    assertSessionFields(copilot, ctx.copilotSessionId, ctx.copilotTranscript, 'copilot');
+
+    // worker logs --json: confirm sessionId/sessionFile present.
+    const workerLogsOut = runCli(['worker', 'logs', ctx.workerSession, '--lines', '1', '--json'], env);
+    const workerLogs = JSON.parse(workerLogsOut) as { sessionId: string | null; sessionFile: string | null };
+    assert.equal(workerLogs.sessionId, ctx.workerSessionId, 'worker logs sessionId');
+    assert.equal(workerLogs.sessionFile, ctx.workerTranscript, 'worker logs sessionFile');
+
+    // copilot logs --json: confirm sessionId/sessionFile present.
+    const copilotLogsOut = runCli(['copilot', 'logs', ctx.copilotSession, '--lines', '1', '--json'], env);
+    const copilotLogs = JSON.parse(copilotLogsOut) as { sessionId: string | null; sessionFile: string | null };
+    assert.equal(copilotLogs.sessionId, ctx.copilotSessionId, 'copilot logs sessionId');
+    assert.equal(copilotLogs.sessionFile, ctx.copilotTranscript, 'copilot logs sessionFile');
+
+    console.log('cliSessionFieldsSmoke: ok');
+  } finally {
+    killTmuxServer(ctx.tmuxSocket);
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/src/smoke/sessionFileResolveSmoke.ts
+++ b/src/smoke/sessionFileResolveSmoke.ts
@@ -9,7 +9,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { resolveAgentSessionFile } from '../core/path';
+import { encodeClaudeWorkdir, resolveAgentSessionFile } from '../core/path';
 
 function withFakeHome<T>(fn: (home: string) => T): T {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-session-resolve-'));
@@ -35,7 +35,7 @@ function testClaude(): void {
   withFakeHome((home) => {
     const workdir = '/Users/dev/code/myproj/.hydra/worktrees/feat-x';
     const sessionId = '11111111-2222-3333-4444-555555555555';
-    const encoded = workdir.replace(/[/.]/g, '-');
+    const encoded = encodeClaudeWorkdir(workdir);
     const expected = path.join(home, '.claude', 'projects', encoded, `${sessionId}.jsonl`);
     writeFile(expected, '{}\n');
 
@@ -43,6 +43,22 @@ function testClaude(): void {
     assert.equal(resolveAgentSessionFile('claude', workdir, 'missing-id'), null);
     assert.equal(resolveAgentSessionFile('claude', workdir, null), null);
     assert.equal(resolveAgentSessionFile('claude', '', sessionId), null);
+  });
+}
+
+function testClaudeWindowsEncoding(): void {
+  // The encoder must work for Windows-style paths (drive-letter colon,
+  // backslashes) and squash whitespace too, mirroring Claude Code's slugify.
+  assert.equal(encodeClaudeWorkdir('C:\\Users\\dev\\proj'), 'C--Users-dev-proj');
+  assert.equal(encodeClaudeWorkdir('C:\\Users\\dev\\My Project'), 'C--Users-dev-My-Project');
+  assert.equal(encodeClaudeWorkdir('/Users/dev/.config'), '-Users-dev--config');
+
+  withFakeHome((home) => {
+    const workdir = 'C:\\Users\\dev\\proj';
+    const sessionId = 'aaaa1111-bbbb-2222-cccc-333333333333';
+    const expected = path.join(home, '.claude', 'projects', 'C--Users-dev-proj', `${sessionId}.jsonl`);
+    writeFile(expected);
+    assert.equal(resolveAgentSessionFile('claude', workdir, sessionId), expected);
   });
 }
 
@@ -84,6 +100,24 @@ function testGemini(): void {
   });
 }
 
+function testGeminiPathNormalization(): void {
+  withFakeHome((home) => {
+    const projectName = 'myproj';
+    // Map key has trailing slash and an unnormalized `..` segment; the input
+    // workdir is the canonical form. Lookup must succeed via canonicalization.
+    const mapKey = '/Users/dev/code/sub/../myproj/';
+    const inputWorkdir = '/Users/dev/code/myproj';
+    writeFile(
+      path.join(home, '.gemini', 'projects.json'),
+      JSON.stringify({ projects: { [mapKey]: projectName } }),
+    );
+    const expected = path.join(home, '.gemini', 'tmp', projectName, 'logs.json');
+    writeFile(expected, '[]');
+
+    assert.equal(resolveAgentSessionFile('gemini', inputWorkdir, null), expected);
+  });
+}
+
 function testGeminiMissingLogs(): void {
   withFakeHome((home) => {
     const workdir = '/Users/dev/code/myproj';
@@ -102,10 +136,47 @@ function testUnknownAgent(): void {
   });
 }
 
+function testCodexUuidV7FastPath(): void {
+  withFakeHome((home) => {
+    // UUIDv7 with first 48 bits = 0x019deccc251c (~ 2026-05-03 UTC).
+    const sessionId = '019deccc-251c-7192-bf0d-e8ff36a0bb5e';
+    const expected = path.join(
+      home, '.codex', 'sessions', '2026', '05', '03',
+      `rollout-2026-05-03T00-44-55-${sessionId}.jsonl`,
+    );
+    writeFile(expected);
+    // Decoy on a different (closer in date) day with a different sessionId; the
+    // fast path should never even visit this directory.
+    writeFile(path.join(
+      home, '.codex', 'sessions', '2026', '05', '04',
+      'rollout-2026-05-04T00-00-00-019decff-ffff-7000-8000-000000000000.jsonl',
+    ));
+
+    assert.equal(resolveAgentSessionFile('codex', '/any', sessionId), expected);
+  });
+}
+
+function testCodexNonV7FallsBackToScan(): void {
+  withFakeHome((home) => {
+    // Non-v7 sessionId → fast path returns null, scan must still find it.
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const expected = path.join(
+      home, '.codex', 'sessions', '2025', '12', '01',
+      `rollout-2025-12-01T10-00-00-${sessionId}.jsonl`,
+    );
+    writeFile(expected);
+    assert.equal(resolveAgentSessionFile('codex', '/any', sessionId), expected);
+  });
+}
+
 function main(): void {
   testClaude();
+  testClaudeWindowsEncoding();
   testCodex();
+  testCodexUuidV7FastPath();
+  testCodexNonV7FallsBackToScan();
   testGemini();
+  testGeminiPathNormalization();
   testGeminiMissingLogs();
   testUnknownAgent();
   console.log('sessionFileResolveSmoke: ok');

--- a/src/smoke/sessionFileResolveSmoke.ts
+++ b/src/smoke/sessionFileResolveSmoke.ts
@@ -1,0 +1,114 @@
+/**
+ * Smoke test: resolveAgentSessionFile resolves transcript paths for claude,
+ * codex, and gemini against fixture homes laid out under a temp directory.
+ *
+ * Run:  node out/smoke/sessionFileResolveSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveAgentSessionFile } from '../core/path';
+
+function withFakeHome<T>(fn: (home: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-session-resolve-'));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+  try {
+    return fn(dir);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeFile(p: string, contents = ''): void {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, contents);
+}
+
+function testClaude(): void {
+  withFakeHome((home) => {
+    const workdir = '/Users/dev/code/myproj/.hydra/worktrees/feat-x';
+    const sessionId = '11111111-2222-3333-4444-555555555555';
+    const encoded = workdir.replace(/[/.]/g, '-');
+    const expected = path.join(home, '.claude', 'projects', encoded, `${sessionId}.jsonl`);
+    writeFile(expected, '{}\n');
+
+    assert.equal(resolveAgentSessionFile('claude', workdir, sessionId), expected);
+    assert.equal(resolveAgentSessionFile('claude', workdir, 'missing-id'), null);
+    assert.equal(resolveAgentSessionFile('claude', workdir, null), null);
+    assert.equal(resolveAgentSessionFile('claude', '', sessionId), null);
+  });
+}
+
+function testCodex(): void {
+  withFakeHome((home) => {
+    const sessionId = '019deccc-251c-7192-bf0d-e8ff36a0bb5e';
+    const expected = path.join(
+      home, '.codex', 'sessions', '2026', '05', '03',
+      `rollout-2026-05-03T00-44-55-${sessionId}.jsonl`,
+    );
+    writeFile(expected, '');
+    // Decoy from a different day with a different sessionId.
+    writeFile(path.join(
+      home, '.codex', 'sessions', '2026', '05', '02',
+      'rollout-2026-05-02T10-00-00-deadbeef-dead-beef-dead-beefdeadbeef.jsonl',
+    ));
+
+    assert.equal(resolveAgentSessionFile('codex', '/any/workdir', sessionId), expected);
+    assert.equal(resolveAgentSessionFile('codex', '/any/workdir', 'no-such-id'), null);
+    assert.equal(resolveAgentSessionFile('codex', '/any/workdir', null), null);
+  });
+}
+
+function testGemini(): void {
+  withFakeHome((home) => {
+    const workdir = '/Users/dev/code/myproj';
+    const projectName = 'myproj';
+    writeFile(
+      path.join(home, '.gemini', 'projects.json'),
+      JSON.stringify({ projects: { [workdir]: projectName, '/other/path': 'other' } }),
+    );
+    const expected = path.join(home, '.gemini', 'tmp', projectName, 'logs.json');
+    writeFile(expected, '[]');
+
+    assert.equal(resolveAgentSessionFile('gemini', workdir, 'unused-session-id'), expected);
+    assert.equal(resolveAgentSessionFile('gemini', workdir, null), expected);
+    assert.equal(resolveAgentSessionFile('gemini', '/not/in/projects', 'x'), null);
+    assert.equal(resolveAgentSessionFile('gemini', '', 'x'), null);
+  });
+}
+
+function testGeminiMissingLogs(): void {
+  withFakeHome((home) => {
+    const workdir = '/Users/dev/code/myproj';
+    writeFile(
+      path.join(home, '.gemini', 'projects.json'),
+      JSON.stringify({ projects: { [workdir]: 'myproj' } }),
+    );
+    // No logs.json on disk.
+    assert.equal(resolveAgentSessionFile('gemini', workdir, null), null);
+  });
+}
+
+function testUnknownAgent(): void {
+  withFakeHome(() => {
+    assert.equal(resolveAgentSessionFile('unknown', '/x', 'y'), null);
+  });
+}
+
+function main(): void {
+  testClaude();
+  testCodex();
+  testGemini();
+  testGeminiMissingLogs();
+  testUnknownAgent();
+  console.log('sessionFileResolveSmoke: ok');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `resolveAgentSessionFile(agent, workdir, sessionId)` helper in `src/core/path.ts` that builds the Claude Code transcript path (`~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl`) and returns it only when the file exists. Encoding replaces `/` and `.` in the workdir with `-`, matching how Claude Code names project directories. Returns `null` for non-Claude agents.
- `hydra worker logs --json` and `hydra copilot logs --json` now include `sessionId` and `sessionFile` fields by looking up the session in `sessions.json`.
- `hydra list --json` now includes `sessionId` and `sessionFile` for every copilot and worker entry. The existing `agentSessionId` field is preserved for backward compatibility.

## Test plan
- [ ] `npm run compile` passes
- [ ] `npm run lint` passes
- [ ] `hydra list --json` shows `sessionId` and `sessionFile` (or `null`) for each entry
- [ ] `hydra worker logs <session> --json` shows `sessionId` and `sessionFile`
- [ ] `hydra copilot logs <session> --json` shows `sessionId` and `sessionFile`
- [ ] For a Claude worker with a real transcript, `sessionFile` resolves to an existing `.jsonl` path; for codex/gemini agents or missing transcripts, it is `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)