### PR TITLE
feat: remote worker MVP (Epic #129 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,58 @@ for the full design and open questions.
 - [**Examples**](examples/) — Real-world scenarios like [Parity Ports](examples/parity-port.md) and [gRPC Generation](examples/grpc-generation.md).
 - [**Changelog**](CHANGELOG.md) — See what's new in the latest version.
 
+## Remote workers (preview)
+
+Run a worker in a tmux session on a different machine reached over SSH. Useful when you want a beefier box to do the heavy lifting while you keep the orchestrator on your laptop.
+
+```bash
+hydra worker create \
+  --remote claude-remote-test.us-west1-a.nexi-lab-888 \
+  --repo /home/sean/myrepo \
+  --branch feat/remote-experiment \
+  --agent claude
+
+hydra worker logs   <session> --lines 30
+hydra worker send   <session> "fix the failing test"
+hydra worker attach <session>      # interactive: ssh -t <host> tmux attach
+hydra worker delete <session>
+hydra list --json                   # remote workers appear with `remote: { host }`
+```
+
+**Prerequisites (one-time setup):**
+
+1. The remote machine has `tmux` and your agent (`claude`/`codex`/`gemini`) on PATH **for non-interactive SSH**. Hydra does **not** install them.
+   - **Watch out:** non-interactive `ssh <host> command` does **not** source `~/.profile` / `~/.bashrc`, so user-installed binaries in `~/.local/bin` (the default for `claude`'s installer, `npm install -g`, NVM-installed Node, pyenv, etc.) are invisible to Hydra's preflight. Verify with `ssh <host> 'command -v claude'` — if that returns empty, symlink the binary into a system PATH:
+     ```bash
+     ssh <host> "sudo ln -s ~/.local/bin/claude /usr/local/bin/claude"
+     ```
+     Phase 2 ([#129](https://github.com/joezhoujinjing/hydra/issues/129)) will wrap remote commands in `bash -lc` so this isn't needed.
+2. The repo is already cloned at `--repo` on the remote. Hydra does **not** sync code.
+3. `ssh <host>` resolves without prompts. The simplest way:
+   - Plain SSH: add an entry to `~/.ssh/config` with your `Host`, `User`, `IdentityFile`.
+   - GCP VMs: run `gcloud compute config-ssh` once — it generates an alias like
+     `<vm>.<zone>.<project>` that wraps `gcloud compute ssh --tunnel-through-iap`.
+     Then `ssh <vm>.<zone>.<project>` and `hydra worker create --remote <vm>.<zone>.<project>` both work.
+
+**Live-status contract:** `hydra list` shows the **last-known** status of each remote worker — it deliberately does **not** SSH-probe each remote on every call (that would slow `hydra list` to a crawl on networks with many hosts). Pretty output marks remote rows with `(status unverified)`. To verify a worker is actually alive, run `hydra worker logs <session>` — that round-trips through SSH and will surface a clear `RemoteSshError` if the host is unreachable.
+
+**Sidebar integration:** remote workers appear in the VS Code sidebar under their repo group with a ☁ cloud icon and a `(remote: <host>)` suffix. Clicking the row opens a terminal that runs `ssh -t <host> tmux attach -t <session>` — the same path `hydra worker attach` uses on the CLI. Local probes (git status, PR badge, CPU usage) are skipped for remote rows since the workdir lives on the remote.
+
+**Other phase-1 deferrals — fail-fast, not silent:**
+
+- `hydra worker stop` / `start` / `rename` for remote workers throw a clear "not yet supported (Epic #129 phase 2)" error rather than misbehaving on the local filesystem.
+- `--repo` must be an absolute path on the remote (e.g. `/home/sean/repo`). `~` is **not** shell-expanded on the remote, so the CLI rejects `~/repo` with a hint to use the absolute form.
+
+**MVP limitations (Epic [#129](https://github.com/joezhoujinjing/hydra/issues/129) phase 1):**
+
+- No initial `--task` / `--task-file` injection on remote workers — use `hydra worker send` after create.
+- No completion-hook injection on remote workers (the local hook scripts assume a local tmux socket).
+- No code sync; you clone the repo on the remote yourself.
+- No copilot-on-remote; only workers.
+- No registry sync between hosts; each machine has its own `sessions.json`.
+- No live-status probe in `hydra list` — see contract above.
+- `worker stop` / `start` / `rename` deferred to phase 2 (fail with explicit error today).
+
 ## Requirements
 - **tmux** — The engine of persistence.
 - **git** — The foundation of isolation.

--- a/package.json
+++ b/package.json
@@ -286,7 +286,9 @@
     "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
     "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields && npm run smoke:repo-registry"
+    "smoke:remote-worker": "node out/smoke/remoteWorkerSmoke.js",
+    "smoke:posix-quote": "node out/smoke/posixQuoteSmoke.js",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields && npm run smoke:repo-registry && npm run smoke:posix-quote && npm run smoke:remote-worker"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -46,6 +46,7 @@ export function registerListCommand(program: Command): void {
             sessionId: w.sessionId,
             sessionFile: resolveAgentSessionFile(w.agent, w.workdir, w.sessionId),
             agentSessionId: w.sessionId,
+            remote: w.remote ? { host: w.remote.host, statusVerified: false } : null,
           })),
           count: copilots.length + workers.length,
         };
@@ -103,7 +104,11 @@ export function registerListCommand(program: Command): void {
                 const branch = w.branch ? ` (${w.branch})` : '';
                 const name = w.displayName || w.slug || w.sessionName || w.tmuxSession;
                 const num = w.workerId != null ? `#${w.workerId} ` : '';
-                console.log(`    ${statusIcon} ${num}${name}${branch}  [${w.agent}]${attached}`);
+                // Remote workers' status is last-known, not live — `hydra list`
+                // never SSH-probes. Make that visible inline so users don't
+                // mistake a stale "running" for a verified one.
+                const remoteSuffix = w.remote ? ` (remote: ${w.remote.host}; status unverified)` : '';
+                console.log(`    ${statusIcon} ${num}${name}${branch}  [${w.agent}]${attached}${remoteSuffix}`);
                 if (w.workdir) console.log(`      workdir: ${w.workdir}`);
               }
             }

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -1,12 +1,31 @@
+import { spawn } from 'child_process';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { SessionManager } from '../../core/sessionManager';
 import { getRepoRootFromPath, localBranchExists } from '../../core/git';
 import { resolveAgentSessionFile } from '../../core/path';
 import { resolveRepoInput } from '../../core/repoRegistry';
+import { RemoteTmuxBackend } from '../../core/remoteTmux';
+import { DEFAULT_AGENT_COMMANDS } from '../../core/agentConfig';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { detectCurrentTmuxIdentity, detectIdentity, getWorkerCreationBlockedMessage } from '../identity';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
+
+/**
+ * Resolve a worker by session name. Returns whether it's remote and (if so)
+ * a backend handle bound to its host.
+ */
+async function resolveWorker(sm: SessionManager, sessionName: string): Promise<{
+  isRemote: boolean;
+  remote?: RemoteTmuxBackend;
+  host?: string;
+}> {
+  const worker = await sm.getWorker(sessionName);
+  if (worker?.remote) {
+    return { isRemote: true, remote: new RemoteTmuxBackend(worker.remote.host), host: worker.remote.host };
+  }
+  return { isRemote: false };
+}
 
 export function registerWorkerCommands(program: Command): void {
   const worker = program
@@ -16,7 +35,7 @@ export function registerWorkerCommands(program: Command): void {
   worker
     .command('create')
     .description('Create a new worker')
-    .requiredOption('--repo <path>', 'Path to the repository')
+    .requiredOption('--repo <path>', 'Path to the repository (local; or remote path on the SSH host when --remote is set)')
     .requiredOption('--branch <name>', 'Branch name')
     .option('--agent <type>', 'Agent type (claude, codex, gemini)', 'claude')
     .option('--base <branch>', 'Base branch override')
@@ -25,6 +44,7 @@ export function registerWorkerCommands(program: Command): void {
     .option('--copilot <session>', 'Session name of the parent copilot (auto-detected if inside a copilot)')
     .option('--notify-copilot', 'Notify parent copilot when worker completes (default: true)', true)
     .option('--no-notify-copilot', 'Disable completion notification to parent copilot')
+    .option('--remote <ssh-host>', 'SSH alias of a remote host to run the worker on. The repo at --repo must already exist on that host.')
     .action(async (opts: {
       repo: string;
       branch: string;
@@ -34,6 +54,7 @@ export function registerWorkerCommands(program: Command): void {
       taskFile?: string;
       copilot?: string;
       notifyCopilot: boolean;
+      remote?: string;
     }) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -41,17 +62,6 @@ export function registerWorkerCommands(program: Command): void {
         if (identity?.role === 'worker') {
           throw new Error(getWorkerCreationBlockedMessage(identity));
         }
-
-        // Single dispatch helper: handles short-form, abs paths, and explicit
-        // relative paths (`.`, `./foo`, `../foo`). Decides managed-ness against
-        // the resolved (pre-rev-parse) path so the macOS /var → /private/var
-        // realpath flip in `git rev-parse --show-toplevel` doesn't defeat the
-        // comparison against ~/.hydra/repos/.
-        const { path: repoPath, isManaged: isManagedRepo } = resolveRepoInput(opts.repo);
-        const repoRoot = await getRepoRootFromPath(repoPath);
-
-        // Check if branch exists before create to detect resume
-        const branchExisted = await localBranchExists(repoRoot, opts.branch);
 
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
@@ -63,6 +73,89 @@ export function registerWorkerCommands(program: Command): void {
             copilotSessionName = identity.sessionName;
           }
         }
+
+        // ── Remote dispatch ──
+        if (opts.remote) {
+          if (opts.task || opts.taskFile) {
+            // Initial task injection on remote isn't part of the MVP — Phase 2
+            // (sendInitialPrompt) requires the local lifecycle wait+capture, which
+            // we don't replicate over SSH. User can `hydra worker send <session> ...`
+            // after creation to send a follow-up prompt.
+            throw new Error('--task and --task-file are not supported with --remote in the MVP. Send the prompt with `hydra worker send <session>` after create.');
+          }
+          // Reject ~ — it's not shell-expanded on the remote (the path goes
+          // through posixQuote and lands inside single quotes), so a literal
+          // `~` directory would silently appear under the remote cwd. Force
+          // users to give an absolute path so the failure is loud, not weird.
+          if (opts.repo.startsWith('~')) {
+            throw new Error(
+              `--repo with --remote must be an absolute path on the remote host. ` +
+              `\`~\` is not shell-expanded over SSH (Hydra single-quotes the path), so \`${opts.repo}\` would create a literal "~" directory. ` +
+              `Use the absolute form, e.g. /home/<user>/${opts.repo.replace(/^~\/?/, '')}.`,
+            );
+          }
+          if (!opts.repo.startsWith('/')) {
+            throw new Error(
+              `--repo with --remote must be an absolute path on the remote host (got "${opts.repo}"). ` +
+              `Relative paths can't be resolved without knowing the remote cwd.`,
+            );
+          }
+
+          // --notify-copilot is intentionally NOT forwarded to createRemoteWorker:
+          // the completion-hook system writes hook scripts into the worktree's
+          // settings dir (claude/codex/gemini) and arms via a local tmux pane
+          // event. Both pieces are local-only — cross-host hook delivery is
+          // deferred to #129 phase 2. We silently ignore the flag for remote
+          // workers (default is true; throwing on the default would be hostile).
+          const agentBinary = DEFAULT_AGENT_COMMANDS[opts.agent] || opts.agent;
+          const workerInfo = await sm.createRemoteWorker({
+            host: opts.remote,
+            remoteRepoPath: opts.repo,
+            branchName: opts.branch,
+            agentType: opts.agent,
+            agentBinary,
+            baseBranch: opts.base,
+            copilotSessionName,
+          });
+
+          getTelemetry().capture('worker_created', {
+            agent: normalizeAgentForTelemetry(workerInfo.agent),
+            is_remote: true,
+          });
+
+          outputResult(
+            {
+              status: 'created',
+              session: workerInfo.sessionName,
+              branch: workerInfo.branch,
+              agent: workerInfo.agent,
+              workdir: workerInfo.workdir,
+              remote: { host: opts.remote },
+            },
+            globalOpts,
+            () => {
+              console.log(`Worker created (remote): ${workerInfo.sessionName}`);
+              console.log(`  Host:     ${opts.remote}`);
+              console.log(`  Branch:   ${workerInfo.branch}`);
+              console.log(`  Agent:    ${workerInfo.agent}`);
+              console.log(`  Workdir:  ${workerInfo.workdir}`);
+              console.log(`  Session:  ${workerInfo.tmuxSession}`);
+            },
+          );
+          return;
+        }
+
+        // ── Local dispatch ──
+        // resolveRepoInput handles short-form (<owner>/<name>), absolute paths,
+        // and explicit relative paths (`.`, `./foo`, `../foo`). Decides
+        // managed-ness against the resolved (pre-rev-parse) path so the macOS
+        // /var → /private/var realpath flip in `git rev-parse --show-toplevel`
+        // doesn't defeat the comparison against ~/.hydra/repos/.
+        const { path: repoPath, isManaged: isManagedRepo } = resolveRepoInput(opts.repo);
+        const repoRoot = await getRepoRootFromPath(repoPath);
+
+        // Check if branch exists before create to detect resume
+        const branchExisted = await localBranchExists(repoRoot, opts.branch);
 
         const { workerInfo, postCreatePromise } = await sm.createWorker({
           repoRoot,
@@ -227,11 +320,17 @@ export function registerWorkerCommands(program: Command): void {
 
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const [output, worker] = await Promise.all([
-          backend.capturePane(sessionName, lines),
-          sm.getWorker(sessionName),
-        ]);
-        const sessionFile = worker
+        const worker = await sm.getWorker(sessionName);
+        const remote = worker?.remote ? new RemoteTmuxBackend(worker.remote.host) : undefined;
+
+        const output = remote
+          ? await remote.capturePane(sessionName, lines)
+          : await backend.capturePane(sessionName, lines);
+
+        // sessionFile resolves a LOCAL agent transcript (e.g. ~/.claude/projects/...).
+        // For remote workers the transcript lives on the remote host, so we surface
+        // null — exposing a non-existent local path would only mislead callers.
+        const sessionFile = worker && !worker.remote
           ? resolveAgentSessionFile(worker.agent, worker.workdir, worker.sessionId)
           : null;
 
@@ -268,10 +367,18 @@ export function registerWorkerCommands(program: Command): void {
 
           const sent: string[] = [];
           for (const worker of running) {
-            if (identity?.role === 'copilot' && worker.copilotSessionName === identity.sessionName) {
-              sm.armCompletionNotification(worker.sessionName);
+            if (worker.remote) {
+              // Remote workers: skip completion-hook arm. Hook delivery
+              // assumes a local tmux socket, which we don't have for remote
+              // sessions — cross-host hook is phase-2 (#129).
+              const remote = new RemoteTmuxBackend(worker.remote.host);
+              await remote.sendMessage(worker.sessionName, message);
+            } else {
+              if (identity?.role === 'copilot' && worker.copilotSessionName === identity.sessionName) {
+                sm.armCompletionNotification(worker.sessionName);
+              }
+              await backend.sendMessage(worker.sessionName, message);
             }
-            await backend.sendMessage(worker.sessionName, message);
             sent.push(worker.sessionName);
           }
 
@@ -290,10 +397,16 @@ export function registerWorkerCommands(program: Command): void {
           const message = messageOrUndefined;
           const sm = new SessionManager(backend);
           const worker = await sm.getWorker(session);
-          if (identity?.role === 'copilot' && worker?.copilotSessionName === identity.sessionName) {
-            sm.armCompletionNotification(session);
+          if (worker?.remote) {
+            // Remote: skip completion-hook arm; route through SSH.
+            const remote = new RemoteTmuxBackend(worker.remote.host);
+            await remote.sendMessage(session, message);
+          } else {
+            if (identity?.role === 'copilot' && worker?.copilotSessionName === identity.sessionName) {
+              sm.armCompletionNotification(session);
+            }
+            await backend.sendMessage(session, message);
           }
-          await backend.sendMessage(session, message);
 
           outputResult(
             { status: 'sent', session, message },
@@ -304,6 +417,59 @@ export function registerWorkerCommands(program: Command): void {
             },
           );
         }
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  worker
+    .command('attach <session>')
+    .description('Attach to a worker tmux session in the foreground (interactive). For remote workers, runs `ssh -t <host> tmux attach`.')
+    .action(async (sessionName: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const { isRemote, remote, host } = await resolveWorker(sm, sessionName);
+
+        if (isRemote) {
+          const { command, args } = remote!.buildAttachArgv(sessionName);
+          if (!process.stdout.isTTY) {
+            throw new Error(`worker attach requires a TTY (cannot pipe). For remote logs, use \`hydra worker logs ${sessionName}\` instead.`);
+          }
+          if (globalOpts.json) {
+            // For --json callers we don't actually attach (can't), just describe
+            // the command they'd need to run.
+            outputResult(
+              { status: 'attach', session: sessionName, remote: { host }, command: [command, ...args].join(' ') },
+              globalOpts,
+              () => undefined,
+            );
+            return;
+          }
+          const child = spawn(command, args, { stdio: 'inherit' });
+          await new Promise<void>((resolve, reject) => {
+            child.on('error', reject);
+            child.on('exit', code => {
+              process.exit(code ?? 0);
+              resolve();
+            });
+          });
+          return;
+        }
+
+        // Local: spawn `tmux attach -t <session>`
+        if (!process.stdout.isTTY) {
+          throw new Error(`worker attach requires a TTY (cannot pipe). Use \`hydra worker logs ${sessionName}\` for non-interactive output.`);
+        }
+        const child = spawn('tmux', ['attach', '-t', sessionName], { stdio: 'inherit' });
+        await new Promise<void>((resolve, reject) => {
+          child.on('error', reject);
+          child.on('exit', code => {
+            process.exit(code ?? 0);
+            resolve();
+          });
+        });
       } catch (error) {
         outputError(error, globalOpts);
       }

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -1,11 +1,57 @@
 import * as vscode from 'vscode';
 import { getRepoRoot } from '../utils/git';
 import { getActiveBackend } from '../utils/multiplexer';
-import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem } from '../providers/tmuxSessionProvider';
+import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem, TmuxSessionItem } from '../providers/tmuxSessionProvider';
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
 import { SessionManager } from '../core/sessionManager';
 import { TmuxBackendCore } from '../core/tmux';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
+
+/**
+ * Open a VS Code terminal that runs `ssh -t <host> tmux attach -t <session>`
+ * for a remote worker. Hydra speaks plain ssh — the alias must already work
+ * (`~/.ssh/config` / `gcloud compute config-ssh`). If the host is unreachable
+ * the terminal will simply show the ssh stderr and exit.
+ *
+ * Windows: the published Hydra extension targets darwin/linux for now; on
+ * win32 we fall back to PowerShell which can also exec `ssh ...` directly,
+ * so the same shape works.
+ */
+function attachRemoteSession(host: string, sessionName: string): vscode.Terminal {
+  // Single-quote the session name for the remote shell. Host is never quoted —
+  // ssh treats it as an opaque alias and accepts at most user@host syntax,
+  // neither of which contains shell metacharacters in practice.
+  const escSession = sessionName.replace(/'/g, "'\\''");
+  const remoteCmd = `tmux attach -t '${escSession}'`;
+  const sshArgs = [
+    '-t',
+    '-o', 'ServerAliveInterval=10',
+    '-o', 'ServerAliveCountMax=3',
+    host,
+    remoteCmd,
+  ];
+
+  const terminal = vscode.window.createTerminal({
+    name: `[hydra] remote ${sessionName}`,
+    shellPath: 'ssh',
+    shellArgs: sshArgs,
+    iconPath: new vscode.ThemeIcon('cloud'),
+    location: { viewColumn: vscode.ViewColumn.Active },
+    // Scrub VS Code shell-integration env vars so they don't leak into the
+    // ssh process (ssh itself ignores them, but `SendEnv` / `LANG` interplay
+    // can confuse some sshd configs). Matches the hygiene we already do on
+    // the local tmux attach path in src/utils/tmuxBackend.ts.
+    env: {
+      'TERM': 'xterm-256color',
+      'TERM_PROGRAM': null,
+      'TERM_PROGRAM_VERSION': null,
+      'VSCODE_SHELL_INTEGRATION': null,
+      'VSCODE_INJECTION': null,
+    },
+  });
+  terminal.show();
+  return terminal;
+}
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
@@ -32,6 +78,14 @@ async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
 }
 
 async function handleTreeViewItem(item: TmuxItem): Promise<void> {
+    // Remote workers route through ssh — local tmux doesn't have the session
+    // and never will. Dispatch BEFORE the local-listSessions probe so we don't
+    // spuriously hit the "session not found, try to start" fallback below.
+    if (item instanceof TmuxSessionItem && item.remote && item.sessionName) {
+        attachRemoteSession(item.remote.host, item.sessionName);
+        return;
+    }
+
     const backend = getActiveBackend();
     const sessionName = item.sessionName || item.label;
 

--- a/src/core/remoteTmux.ts
+++ b/src/core/remoteTmux.ts
@@ -1,0 +1,477 @@
+import { execFile } from 'child_process';
+import { ChildProcess } from 'child_process';
+
+/**
+ * RemoteTmuxBackend — runs tmux commands on a remote host over SSH.
+ *
+ * Surface mirrors the local TmuxBackendCore methods that worker lifecycle
+ * needs (newSession, capturePane, sendKeys, sendMessage, killSession,
+ * listSessions, hasSession). It is NOT a drop-in MultiplexerBackendCore
+ * implementation — things like env scrubbing, role/agent metadata helpers,
+ * and pane-pid introspection are local-tmux-specific and not used in the
+ * remote MVP.
+ *
+ * SSH model:
+ *   - Plain `ssh <host>` only — Hydra never invokes gcloud/cloud SDKs.
+ *   - User configures their ~/.ssh/config (or runs `gcloud compute config-ssh`)
+ *     so the alias resolves.
+ *   - Connection options: BatchMode=yes (no password prompts) and
+ *     ConnectTimeout=10 to fail fast on unreachable hosts.
+ */
+
+const SSH_DEFAULT_TIMEOUT_MS = 30000;
+const SSH_PREFLIGHT_TIMEOUT_MS = 15000;
+
+const SSH_BASE_OPTS = [
+  '-o', 'BatchMode=yes',
+  '-o', 'ConnectTimeout=10',
+  '-o', 'ServerAliveInterval=10',
+  '-o', 'ServerAliveCountMax=3',
+];
+
+export interface RemoteTmuxSession {
+  name: string;
+  windows: number;
+  attached: boolean;
+}
+
+export class RemoteSshError extends Error {
+  constructor(
+    public readonly host: string,
+    public readonly stderr: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RemoteSshError';
+  }
+}
+
+/** POSIX single-quote escape — for use in the remote shell. */
+/**
+ * POSIX single-quote escape for embedding arbitrary strings inside a remote
+ * shell command. Wraps the value in single quotes and escapes any embedded
+ * single quotes with the standard `'\''` close/escape/open sequence.
+ *
+ * Exported for {@link ../smoke/posixQuoteSmoke.ts} adversarial coverage.
+ */
+export function posixQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Detect ssh's own transport-layer stderr signatures so we can surface a
+ * clear error instead of letting `allowNonZeroExit` resolve the call as a
+ * normal "remote command exited non-zero" outcome. ssh prefixes its own
+ * messages with `ssh:` (or sometimes `ssh_exchange_identification:`); a few
+ * classic auth / dns / config failures also show up unprefixed.
+ */
+function isSshTransportStderr(stderr: string): boolean {
+  if (!stderr) return false;
+  const lines = stderr.split('\n').map(l => l.trim().toLowerCase()).filter(Boolean);
+  return lines.some(line =>
+    line.startsWith('ssh:') ||
+    line.startsWith('ssh_exchange_identification:') ||
+    line.includes('could not resolve hostname') ||
+    line.includes('permission denied (publickey') ||
+    line.includes('host key verification failed') ||
+    line.includes('connection refused') ||
+    line.includes('connection timed out') ||
+    line.includes('connection closed by') ||
+    line.includes('proxycommand') ||
+    line.includes('kex_exchange_identification') ||
+    line.includes('no route to host') ||
+    line.includes('network is unreachable') ||
+    line.includes('operation timed out') ||
+    line.includes('lost connection') ||
+    line.includes('broken pipe'),
+  );
+}
+
+const SSH_CONFIG_HINT = 'Hydra speaks plain `ssh <host>` — make sure the alias works (`ssh <host> echo ok`). For GCP VMs, run `gcloud compute config-ssh` or add a ProxyCommand entry to ~/.ssh/config.';
+
+/**
+ * Detect benign `git worktree remove` failures — the worktree is already
+ * gone, so the desired end state of `removeWorktree` is already achieved.
+ * Anything else (locked, validation failure, ENOENT mid-removal, etc.) is
+ * a real failure that should propagate so the caller can refuse to drop
+ * its registry entry.
+ */
+function isBenignWorktreeRemoveStderr(stderr: string): boolean {
+  if (!stderr) return false;
+  const lower = stderr.toLowerCase();
+  return (
+    lower.includes('is not a working tree') ||
+    lower.includes('is not a valid worktree') ||
+    lower.includes('not a working tree')
+  );
+}
+
+export class RemoteTmuxBackend {
+  constructor(public readonly host: string) {}
+
+  // ── Low-level SSH execution ─────────────────────────────────────────
+
+  /**
+   * Run a shell command on the remote host. The remote shell sees `remoteCmd`
+   * as its full command line (the local OS does NOT re-interpret it — we pass
+   * it as a single argv element after the host).
+   */
+  private runRemote(
+    remoteCmd: string,
+    opts: { input?: string; timeoutMs?: number; allowNonZeroExit?: boolean } = {},
+  ): Promise<{ stdout: string; stderr: string; code: number }> {
+    return new Promise((resolve, reject) => {
+      const args = [...SSH_BASE_OPTS, this.host, remoteCmd];
+      let stdout = '';
+      let stderr = '';
+      const timeoutMs = opts.timeoutMs ?? SSH_DEFAULT_TIMEOUT_MS;
+
+      const child: ChildProcess = execFile('ssh', args, {
+        timeout: timeoutMs,
+        maxBuffer: 32 * 1024 * 1024,
+        encoding: 'utf-8',
+      }, (err, out, errOut) => {
+        stdout = String(out ?? '');
+        stderr = String(errOut ?? '');
+        if (err) {
+          const e = err as Error & { code?: number | string; signal?: string; killed?: boolean };
+          // SSH transport failures (auth, ProxyCommand, unknown host, broken
+          // connection) always come back as exit 255 OR with classic ssh
+          // stderr signatures. Honor allowNonZeroExit ONLY for genuine remote
+          // command exits, never for transport problems — otherwise an SSH
+          // outage masquerades as "repo not found" / "no such session".
+          if (e.signal === 'SIGTERM' || e.killed) {
+            reject(this.translateSshError(e, stderr));
+            return;
+          }
+          if (e.code === 255 || isSshTransportStderr(stderr)) {
+            reject(this.translateSshError(e, stderr));
+            return;
+          }
+          if (opts.allowNonZeroExit && typeof e.code === 'number') {
+            resolve({ stdout, stderr, code: e.code });
+            return;
+          }
+          reject(this.translateSshError(e, stderr));
+          return;
+        }
+        resolve({ stdout, stderr, code: 0 });
+      });
+
+      if (opts.input != null) {
+        child.stdin?.end(opts.input);
+      }
+    });
+  }
+
+  private translateSshError(
+    err: Error & { code?: number | string; signal?: string; killed?: boolean },
+    stderr: string,
+  ): Error {
+    const trimmed = stderr.trim();
+    const lower = trimmed.toLowerCase();
+
+    if (err.signal === 'SIGTERM' || (err as { killed?: boolean }).killed) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: connection timed out (>10s) — is the host reachable? ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    if (lower.includes('could not resolve hostname')) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh: could not resolve hostname "${this.host}". ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    if (lower.includes('permission denied')) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: permission denied (check SSH keys / agent / OS Login user). ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    if (lower.includes('host key verification failed')) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: host key verification failed — accept the host key once (\`ssh ${this.host}\`) and retry. ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    if (lower.includes('proxycommand') || lower.includes('kex_exchange_identification')) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: proxy/transport failure — ${trimmed || 'see stderr'}. ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    if (
+      lower.includes('connection refused') ||
+      lower.includes('connection timed out') ||
+      lower.includes('connection closed by') ||
+      lower.includes('no route to host') ||
+      lower.includes('network is unreachable') ||
+      lower.includes('operation timed out') ||
+      lower.includes('lost connection') ||
+      lower.includes('broken pipe')
+    ) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: cannot connect — ${trimmed || 'host unreachable'}. ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    // Exit 255 or any other un-categorized transport noise — surface stderr
+    // verbatim plus the SSH config hint so users can self-diagnose.
+    if (err.code === 255) {
+      return new RemoteSshError(
+        this.host,
+        trimmed,
+        `ssh ${this.host}: transport failure (exit 255) — ${trimmed || 'no stderr'}. ${SSH_CONFIG_HINT}`,
+      );
+    }
+
+    const baseMsg = err.message || String(err);
+    return new RemoteSshError(
+      this.host,
+      trimmed,
+      trimmed
+        ? `ssh ${this.host} failed: ${trimmed}`
+        : `ssh ${this.host} failed: ${baseMsg}`,
+    );
+  }
+
+  // ── Preflight ──────────────────────────────────────────────────────
+
+  /**
+   * Verify the remote has tmux and the requested agent binary. Throws with
+   * a clear message if either is missing.
+   */
+  async preflight(agentBinary: string): Promise<void> {
+    const cmd = `command -v tmux >/dev/null 2>&1 && command -v ${posixQuote(agentBinary)} >/dev/null 2>&1`;
+    const { code, stderr } = await this.runRemote(cmd, {
+      timeoutMs: SSH_PREFLIGHT_TIMEOUT_MS,
+      allowNonZeroExit: true,
+    });
+    if (code !== 0) {
+      throw new RemoteSshError(
+        this.host,
+        stderr,
+        `Remote preflight failed on ${this.host}: tmux or agent "${agentBinary}" not found on PATH. Install both on the remote and retry.`,
+      );
+    }
+  }
+
+  /** Return true if `<repoPath>/.git` exists on the remote. */
+  async repoExists(repoPath: string): Promise<boolean> {
+    const cmd = `test -d ${posixQuote(`${repoPath}/.git`)} || test -f ${posixQuote(`${repoPath}/.git`)}`;
+    const { code } = await this.runRemote(cmd, {
+      timeoutMs: SSH_PREFLIGHT_TIMEOUT_MS,
+      allowNonZeroExit: true,
+    });
+    return code === 0;
+  }
+
+  // ── Worktree management on the remote ──────────────────────────────
+
+  /**
+   * `git -C <repoPath> worktree add <worktreePath> -b <branch>` (or attach to
+   * an existing branch via `--checkout`). Returns the absolute worktree path.
+   */
+  async addWorktree(
+    repoPath: string,
+    branch: string,
+    worktreePath: string,
+    baseBranch?: string,
+  ): Promise<void> {
+    const args = [
+      'worktree', 'add',
+      posixQuote(worktreePath),
+      '-b', posixQuote(branch),
+    ];
+    if (baseBranch) {
+      args.push(posixQuote(baseBranch));
+    }
+    const cmd = `git -C ${posixQuote(repoPath)} ${args.join(' ')}`;
+    const { code, stderr } = await this.runRemote(cmd, { allowNonZeroExit: true });
+    if (code !== 0) {
+      throw new RemoteSshError(
+        this.host,
+        stderr,
+        `Remote git worktree add failed on ${this.host}: ${stderr.trim() || 'unknown error'}`,
+      );
+    }
+  }
+
+  /**
+   * Remove a remote worktree with `git worktree remove --force`.
+   *
+   * Inspects the command result rather than swallowing non-zero exits — the
+   * caller (`SessionManager.deleteRemoteWorker`) relies on this throwing to
+   * surface its manual-cleanup warning and refuse to drop the registry entry
+   * when cleanup actually failed.
+   *
+   * Tolerates the one benign non-zero case: "is not a working tree" — that
+   * means the worktree is already gone, which is the desired end state of
+   * this operation. Anything else (locked, validation failure, partial fs
+   * removal, etc.) throws with stderr attached so the caller can show it.
+   */
+  async removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+    const cmd = `git -C ${posixQuote(repoPath)} worktree remove --force ${posixQuote(worktreePath)}`;
+    const { code, stderr } = await this.runRemote(cmd, { allowNonZeroExit: true });
+    if (code === 0) return;
+    if (isBenignWorktreeRemoveStderr(stderr)) {
+      // Worktree already gone on the remote — desired state already achieved.
+      return;
+    }
+    const trimmed = stderr.trim();
+    throw new Error(
+      `git worktree remove --force ${worktreePath} failed on ${this.host} (exit ${code}): ${trimmed || '(no stderr)'}`,
+    );
+  }
+
+  async deleteBranch(repoPath: string, branch: string): Promise<void> {
+    const cmd = `git -C ${posixQuote(repoPath)} branch -D ${posixQuote(branch)}`;
+    await this.runRemote(cmd, { allowNonZeroExit: true });
+  }
+
+  // ── tmux session management on the remote ─────────────────────────
+
+  /**
+   * `tmux new-session -d -s <name> -c <cwd> <command>`. The agent command is
+   * passed positionally so tmux invokes it as the pane's main process.
+   */
+  async newSession(sessionName: string, workdir: string, command: string): Promise<void> {
+    const remoteCmd = [
+      'tmux', 'new-session', '-d',
+      '-s', posixQuote(sessionName),
+      '-c', posixQuote(workdir),
+      posixQuote(command),
+    ].join(' ');
+    await this.runRemote(remoteCmd);
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    const cmd = `tmux kill-session -t ${posixQuote(sessionName)}`;
+    await this.runRemote(cmd, { allowNonZeroExit: true });
+  }
+
+  async hasSession(sessionName: string): Promise<boolean> {
+    const cmd = `tmux has-session -t ${posixQuote(sessionName)}`;
+    const { code } = await this.runRemote(cmd, { allowNonZeroExit: true });
+    return code === 0;
+  }
+
+  async listSessions(): Promise<RemoteTmuxSession[]> {
+    const cmd = `tmux list-sessions -F '#{session_name}|||#{session_windows}|||#{session_attached}'`;
+    const { code, stdout, stderr } = await this.runRemote(cmd, { allowNonZeroExit: true });
+    if (code !== 0) {
+      // No tmux server → empty list. Anything else bubbles up.
+      if (/no server running|no such file/i.test(stderr)) return [];
+      throw new RemoteSshError(this.host, stderr, `Remote tmux list-sessions failed: ${stderr.trim()}`);
+    }
+    return stdout.split('\n').filter(l => l.trim()).map(line => {
+      const [name, windows, attached] = line.split('|||');
+      return {
+        name,
+        windows: parseInt(windows, 10) || 1,
+        attached: attached === '1',
+      };
+    });
+  }
+
+  async capturePane(sessionName: string, lines?: number): Promise<string> {
+    const startArg = lines && lines > 0 ? `-S -${lines}` : '';
+    const cmd = `tmux capture-pane -t ${posixQuote(sessionName)} -p ${startArg}`.trim();
+    const { stdout } = await this.runRemote(cmd);
+    return stdout;
+  }
+
+  async sendKeys(sessionName: string, keys: string): Promise<void> {
+    const cmd = `tmux send-keys -t ${posixQuote(sessionName)} ${posixQuote(keys)} Enter`;
+    await this.runRemote(cmd);
+  }
+
+  /**
+   * Send a message to the agent prompt safely:
+   *   1. base64-encode locally
+   *   2. ship via the remote command string (single-quoted, base64 charset is safe)
+   *   3. decode + tmux load-buffer + paste-buffer + Enter on the remote
+   *
+   * This mirrors PR #122's local behaviour (load-buffer/paste-buffer + separate
+   * Enter) so long or special-character messages don't lose their trailing Enter.
+   */
+  async sendMessage(sessionName: string, message: string): Promise<void> {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const bufferName = `hydra-send-${suffix}`;
+    const tmpFile = `/tmp/hydra-send-${suffix}`;
+    const b64 = Buffer.from(message, 'utf-8').toString('base64');
+
+    // The remote command is a heredoc-free shell pipeline. base64 chars are
+    // [A-Za-z0-9+/=], so embedding them in single quotes is shell-safe.
+    const remoteCmd = [
+      `set -e`,
+      `printf %s ${posixQuote(b64)} | base64 -d > ${posixQuote(tmpFile)}`,
+      `tmux load-buffer -b ${posixQuote(bufferName)} ${posixQuote(tmpFile)}`,
+      `rm -f ${posixQuote(tmpFile)}`,
+      `tmux paste-buffer -b ${posixQuote(bufferName)} -t ${posixQuote(sessionName)} -d`,
+      `sleep 0.1`,
+      `tmux send-keys -t ${posixQuote(sessionName)} Enter`,
+    ].join('; ');
+
+    await this.runRemote(remoteCmd);
+  }
+
+  /**
+   * Run an arbitrary shell command on the remote with a SHORT timeout, used
+   * by callers who need a "live data probe" (e.g. the VS Code panel render
+   * loop that wants to show actual git status / tmux liveness without
+   * blocking the UI on a slow ssh).
+   *
+   * Returns the raw command result on success, or `null` on ANY failure
+   * (timeout, transport error, command exit error). The caller is expected
+   * to fall back to last-known data on `null` — no exception ever escapes.
+   *
+   * NOTE on cost: every call pays one full SSH handshake (~500ms typical,
+   * worse on cold IAP tunnels). User-configured ControlMaster brings this
+   * down to ~10ms but Hydra deliberately doesn't auto-configure it (out of
+   * scope for #129 phase 1; tracked as a phase-2 follow-up).
+   */
+  async probe(
+    remoteCmd: string,
+    opts: { timeoutMs?: number } = {},
+  ): Promise<{ stdout: string; stderr: string; code: number } | null> {
+    const timeoutMs = opts.timeoutMs ?? 1500;
+    try {
+      return await this.runRemote(remoteCmd, { timeoutMs, allowNonZeroExit: true });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Build the local shell command that, when exec'd, attaches to the remote
+   * tmux session interactively. Returns argv for `child_process.spawn`.
+   *
+   * Caller must spawn this with stdio: 'inherit' and pass the user's TTY.
+   */
+  buildAttachArgv(sessionName: string): { command: string; args: string[] } {
+    return {
+      command: 'ssh',
+      args: [
+        '-t',
+        '-o', 'ServerAliveInterval=10',
+        '-o', 'ServerAliveCountMax=3',
+        this.host,
+        `tmux attach -t ${posixQuote(sessionName)}`,
+      ],
+    };
+  }
+}

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig } from './hydraGlobalConfig';
@@ -8,6 +8,7 @@ import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMAND
 import { exec, resolveCommandPath } from './exec';
 import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
+import { RemoteTmuxBackend } from './remoteTmux';
 
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 15000;
 const SESSION_STATE_LOCK_TIMEOUT_MS = 10000;
@@ -56,6 +57,23 @@ function fixWindowsSymlinks(worktreeDir: string): void {
   }
 }
 
+/** POSIX basename for remote (always /) paths. */
+function pathBasename(p: string): string {
+  const trimmed = p.replace(/\/+$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+/** Same sanitization rule TmuxBackendCore.sanitizeSessionName uses. */
+function sanitizeForSession(name: string): string {
+  return name.replace(/[/\\\s.:]/g, '-');
+}
+
+/** Short hash for collision-resistant session-name namespacing. */
+function shortHash(value: string): string {
+  return createHash('sha1').update(value).digest('hex').slice(0, 7);
+}
+
 /**
  * Look up a worker's numeric ID from sessions.json.
  * Lightweight standalone function — no SessionManager instance needed.
@@ -94,6 +112,15 @@ export interface WorkerInfo {
   sessionId: string | null;
   /** Session name of the copilot that spawned this worker, if any. */
   copilotSessionName: string | null;
+  /**
+   * Set when this worker runs on a remote machine reached over SSH.
+   * Local workers leave this field undefined.
+   *
+   * For remote workers, `repoRoot` and `workdir` are paths on the remote host
+   * — never on the local filesystem. Subcommands (logs, send, attach, delete)
+   * route through {@link RemoteTmuxBackend} when this is set.
+   */
+  remote?: { host: string };
 }
 
 export interface CopilotInfo {
@@ -221,6 +248,13 @@ export class SessionManager {
         // Backfill workerId for workers created before this feature
         if (worker.workerId == null) {
           worker.workerId = state.nextWorkerId++;
+        }
+        if (worker.remote) {
+          // Remote workers are not in the local tmux server. We don't probe
+          // the remote on every sync (would slow `hydra list` to a crawl),
+          // so we trust the last-known status. Liveness is verified
+          // on-demand by the per-command dispatch.
+          continue;
         }
         const live = liveSessionMap.get(worker.sessionName);
         if (live) {
@@ -543,9 +577,14 @@ export class SessionManager {
   }
 
   async deleteWorker(sessionName: string): Promise<void> {
-    await this.killSessionOrConfirmAbsent(sessionName);
-
     const worker = this.readSessionState().workers[sessionName];
+
+    if (worker?.remote) {
+      await this.deleteRemoteWorker(worker);
+      return;
+    }
+
+    await this.killSessionOrConfirmAbsent(sessionName);
 
     if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
       try {
@@ -581,7 +620,236 @@ export class SessionManager {
     });
   }
 
+  // ── Remote worker lifecycle (MVP — Epic #129 phase 1) ──
+  //
+  // Remote workers run in a tmux session on a host reachable via SSH. Hydra
+  // does NOT provision the remote (no code sync, no agent install) and does
+  // NOT inject completion hooks (cross-host hook delivery is its own design
+  // problem — see TODO in createRemoteWorker).
+
+  /**
+   * Create a worker on a remote host. The repo must already exist at
+   * `opts.remoteRepoPath` on the remote machine.
+   */
+  async createRemoteWorker(opts: {
+    host: string;
+    remoteRepoPath: string;
+    branchName: string;
+    agentType: string;
+    agentBinary: string;
+    baseBranch?: string;
+    copilotSessionName?: string | null;
+  }): Promise<WorkerInfo> {
+    ensureHydraGlobalConfig();
+
+    const validationError = coreGit.validateBranchName(opts.branchName);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    const remote = new RemoteTmuxBackend(opts.host);
+
+    // ── Preflight ──
+    await remote.preflight(opts.agentBinary);
+    if (!await remote.repoExists(opts.remoteRepoPath)) {
+      throw new Error(
+        `Remote repo "${opts.remoteRepoPath}" not found on ${opts.host} (or is not a git repo). ` +
+        `Clone it on the remote first; Hydra MVP does not sync code.`,
+      );
+    }
+
+    // ── Slug + session name ──
+    // We can't reuse the local repo-namespace logic (that hashes a local
+    // path); instead we hash host+remoteRepoPath so two remote repos with
+    // the same basename don't collide.
+    const repoBaseName = sanitizeForSession(pathBasename(opts.remoteRepoPath)) || 'remote';
+    const slug = sanitizeForSession(opts.branchName);
+    const namespaceHash = shortHash(`${opts.host}:${opts.remoteRepoPath}`);
+    const sessionName = `${repoBaseName}-${namespaceHash}_${slug}`;
+
+    // Reject if the local registry or remote tmux already has this session.
+    const existing = this.readSessionState().workers[sessionName];
+    if (existing) {
+      throw new Error(`Worker "${sessionName}" already exists in registry`);
+    }
+    if (await remote.hasSession(sessionName)) {
+      throw new Error(
+        `Remote tmux session "${sessionName}" already exists on ${opts.host}. ` +
+        `Kill it (\`ssh ${opts.host} tmux kill-session -t ${sessionName}\`) or pick a different branch.`,
+      );
+    }
+
+    // ── Worktree + tmux session on remote ──
+    const worktreePath = `${opts.remoteRepoPath.replace(/\/+$/, '')}/.hydra-worktrees/${slug}`;
+    await remote.addWorktree(opts.remoteRepoPath, opts.branchName, worktreePath, opts.baseBranch);
+
+    const launchCmd = buildAgentLaunchCommand(
+      opts.agentType,
+      opts.agentBinary,
+      undefined,
+      opts.agentType === 'claude' ? randomUUID() : undefined,
+    );
+
+    try {
+      await remote.newSession(sessionName, worktreePath, launchCmd);
+    } catch (err) {
+      // Best-effort cleanup of the worktree we just created.
+      await remote.removeWorktree(opts.remoteRepoPath, worktreePath).catch(() => {});
+      await remote.deleteBranch(opts.remoteRepoPath, opts.branchName).catch(() => {});
+      throw err;
+    }
+
+    // TODO(#129 phase 2): inject completion hooks on the remote. The local
+    // hook scripts assume a local tmux socket; remote hook delivery needs
+    // its own design (probably a small daemon or polling-based status).
+
+    const now = new Date().toISOString();
+    return this.updateSessionState((state) => {
+      const workerId = state.nextWorkerId++;
+      const nextWorker: WorkerInfo = {
+        sessionName,
+        displayName: slug,
+        workerId,
+        repo: repoBaseName,
+        repoRoot: opts.remoteRepoPath,
+        branch: opts.branchName,
+        slug,
+        status: 'running',
+        attached: false,
+        agent: opts.agentType,
+        workdir: worktreePath,
+        tmuxSession: sessionName,
+        createdAt: now,
+        lastSeenAt: now,
+        sessionId: null,
+        copilotSessionName: opts.copilotSessionName ?? null,
+        remote: { host: opts.host },
+      };
+      state.workers[sessionName] = nextWorker;
+      state.updatedAt = now;
+      return nextWorker;
+    });
+  }
+
+  /**
+   * Tear down a remote worker: kill the remote tmux session, remove the
+   * remote worktree, delete the remote branch (best-effort), then drop the
+   * registry entry.
+   *
+   * Critical invariant — registry is preserved on transport failure:
+   *   If `kill-session` or `remove-worktree` raises a {@link RemoteSshError}
+   *   (i.e. SSH itself couldn't reach the host, NOT just "session not found"
+   *   exit 1), we leave the registry entry intact so the user can retry. The
+   *   alternative — silently archive a still-running remote worker — leaves
+   *   tmux + worktree orphaned with no recovery path from `hydra list`.
+   *
+   *   `delete-branch` failures are downgraded to warnings: branches are
+   *   recoverable, and the user usually only cares that tmux + worktree are
+   *   gone (which they are by the time deleteBranch runs).
+   *
+   * On any transport failure we throw with a LOUD manual-cleanup message so
+   * operators know exactly what to type if Hydra can't reach the host again.
+   */
+  async deleteRemoteWorker(worker: WorkerInfo): Promise<void> {
+    if (!worker.remote) {
+      throw new Error(`Worker "${worker.sessionName}" is not a remote worker`);
+    }
+
+    const remote = new RemoteTmuxBackend(worker.remote.host);
+    const host = worker.remote.host;
+    const warnings: string[] = [];
+
+    // ── Step 1: kill remote tmux session ──
+    // killSession uses allowNonZeroExit, so "no such session" exit 1 RESOLVES
+    // (not throws). Anything that throws here is therefore a transport failure
+    // (SSH exit 255 / unreachable / auth) — abort and keep the registry entry
+    // so the user can retry once the network is back.
+    try {
+      await remote.killSession(worker.sessionName);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Remote delete aborted: cannot reach ${host} to kill tmux session.\n` +
+        `  ssh error: ${msg}\n` +
+        `Registry entry kept so you can retry. To clean up by hand:\n` +
+        `  ssh ${host} tmux kill-session -t ${worker.sessionName}\n` +
+        (worker.repoRoot && worker.workdir
+          ? `  ssh ${host} git -C ${worker.repoRoot} worktree remove --force ${worker.workdir}\n`
+          : '') +
+        (worker.branch && worker.repoRoot
+          ? `  ssh ${host} git -C ${worker.repoRoot} branch -D ${worker.branch}\n`
+          : '') +
+        `Then \`hydra worker delete ${worker.sessionName}\` again to drop the registry entry.`,
+      );
+    }
+
+    if (worker.repoRoot && worker.workdir) {
+      // Tiny pause: tmux's pane shell holds the worktree dir as its cwd; without
+      // a beat, `git worktree remove --force` can race and leave a dangling dir.
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      // ── Step 2: remove worktree (any failure → keep registry) ──
+      // removeWorktree throws for both SSH transport failures AND real git
+      // failures (locked, partial fs state, etc.) — only "is not a working
+      // tree" is tolerated as already-gone. Either way we refuse to drop the
+      // registry entry so the user has a recovery path from `hydra list`.
+      try {
+        await remote.removeWorktree(worker.repoRoot, worker.workdir);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Remote delete partially complete: tmux session killed on ${host}, but worktree removal failed.\n` +
+          `  cause: ${msg}\n` +
+          `Registry entry kept so you can retry. To clean up by hand:\n` +
+          `  ssh ${host} git -C ${worker.repoRoot} worktree remove --force ${worker.workdir}\n` +
+          (worker.branch
+            ? `  ssh ${host} git -C ${worker.repoRoot} branch -D ${worker.branch}\n`
+            : '') +
+          `Then \`hydra worker delete ${worker.sessionName}\` again to drop the registry entry.`,
+        );
+      }
+
+      // ── Step 3: delete branch (transport failure → warn, proceed) ──
+      // By this point tmux + worktree are gone. A branch left dangling is
+      // benign and recoverable, so we don't block the registry cleanup on it.
+      if (worker.branch) {
+        try {
+          await remote.deleteBranch(worker.repoRoot, worker.branch);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          const w = `[hydra] remote delete: branch -D ${worker.branch} on ${host} failed: ${msg}. Run \`ssh ${host} git -C ${worker.repoRoot} branch -D ${worker.branch}\` to clean up.`;
+          console.warn(w);
+          warnings.push(w);
+        }
+      }
+    }
+
+    this.archiveEntry('worker', worker.sessionName, worker.sessionId, worker);
+
+    await this.updateSessionState((state) => {
+      if (state.workers[worker.sessionName]) {
+        delete state.workers[worker.sessionName];
+        state.updatedAt = new Date().toISOString();
+      }
+    });
+
+    if (warnings.length > 0) {
+      // Surface a single rolled-up notice on stderr so callers see it even when
+      // they only consume stdout (e.g. JSON mode).
+      console.warn(`[hydra] remote delete completed with ${warnings.length} warning(s) — see above.`);
+    }
+  }
+
   async stopWorker(sessionName: string): Promise<void> {
+    const existing = this.readSessionState().workers[sessionName];
+    if (existing?.remote) {
+      throw new Error(
+        `worker stop is not yet supported for remote workers (Epic #129 phase 2). ` +
+        `For now, use \`hydra worker delete ${sessionName}\` to tear it down, or ` +
+        `\`ssh ${existing.remote.host} tmux kill-session -t ${sessionName}\` to stop tmux without removing the worktree.`,
+      );
+    }
+
     try {
       await this.backend.killSession(sessionName);
     } catch { /* Already dead */ }
@@ -599,6 +867,13 @@ export class SessionManager {
     const existingWorker = this.readSessionState().workers[sessionName];
     if (!existingWorker) {
       throw new Error(`Worker "${sessionName}" not found in sessions.json`);
+    }
+
+    if (existingWorker.remote) {
+      throw new Error(
+        `worker start is not yet supported for remote workers (Epic #129 phase 2). ` +
+        `The local restart path uses local-only fs/git checks (cwd existence, agent-readiness polling) that don't translate to SSH.`,
+      );
     }
 
     if (!existingWorker.workdir || !fs.existsSync(existingWorker.workdir)) {
@@ -766,6 +1041,13 @@ export class SessionManager {
     const worker = state.workers[oldSessionName];
     if (!worker) {
       throw new Error(`Worker "${oldSessionName}" not found`);
+    }
+
+    if (worker.remote) {
+      throw new Error(
+        `worker rename is not yet supported for remote workers (Epic #129 phase 2). ` +
+        `Renaming requires git branch -m, worktree move, and tmux rename-session — none of which are wired up over SSH yet.`,
+      );
     }
 
     if (!worker.repoRoot) {
@@ -1134,6 +1416,7 @@ export class SessionManager {
         for (const w of Object.values(state.workers)) {
           w.sessionId ??= null;
           w.displayName ??= w.slug || this.extractSlugFromSessionName(w.sessionName);
+          // `remote` is intentionally left undefined for legacy/local workers.
         }
         for (const c of Object.values(state.copilots)) {
           c.sessionId ??= null;

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -7,6 +7,7 @@ import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multip
 import { toCanonicalPath } from '../utils/path';
 import { SessionManager, WorkerInfo } from '../core/sessionManager';
 import { Worktree } from '../core/types';
+import { RemoteTmuxBackend, posixQuote } from '../core/remoteTmux';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
 
@@ -123,6 +124,83 @@ async function getWorktreeBranchLabel(worktreePath: string, fallbackLabel: strin
   }
 
   return fallbackLabel;
+}
+
+/**
+ * Probe a remote worker over SSH to fetch tmux liveness AND git porcelain
+ * status in a SINGLE round trip. Returns `null` if the probe times out or
+ * fails for any reason — the caller falls back to last-known registry data
+ * with a "(stale)" badge.
+ *
+ * Single-round-trip matters: every probe pays one full SSH handshake
+ * (~500ms typical, worse on cold tunnels). We can't afford one handshake
+ * per data field — it'd block the panel render for seconds. ControlMaster
+ * is the proper fix (~10ms per probe) but is out of scope for phase 1; user
+ * can opt in via their `~/.ssh/config`.
+ *
+ * Output format we ask the remote to produce:
+ *
+ *     tmux:alive | tmux:dead
+ *     ---
+ *     <git status --porcelain --branch output, possibly empty>
+ *
+ * 1500ms hard timeout per probe; ssh's own SIGTERM kills the process.
+ */
+interface RemoteWorkerProbe {
+  tmuxAlive: boolean;
+  branch: string;
+  gitDirty: number;
+  gitModified: number;
+  gitAdded: number;
+  gitDeleted: number;
+  gitUntracked: number;
+  commitsAhead: number;
+}
+
+async function probeRemoteWorker(
+  host: string,
+  sessionName: string,
+  worktreePath: string,
+): Promise<RemoteWorkerProbe | null> {
+  // Single-shot script: tmux liveness, separator, then git porcelain.
+  // Fails-soft on every line: missing tmux/git just leaves the section empty.
+  const script = [
+    `tmux has-session -t ${posixQuote(sessionName)} 2>/dev/null && echo tmux:alive || echo tmux:dead`,
+    `echo ---`,
+    `git -C ${posixQuote(worktreePath)} status --porcelain --branch 2>/dev/null || true`,
+  ].join('\n');
+
+  const remote = new RemoteTmuxBackend(host);
+  const result = await remote.probe(script, { timeoutMs: 1500 });
+  if (!result) return null;
+
+  // Parse: split into tmux marker + git block, ignore anything before/after.
+  const lines = result.stdout.split('\n');
+  const sepIdx = lines.findIndex(l => l.trim() === '---');
+  if (sepIdx < 0) return null;
+
+  const tmuxLine = lines.slice(0, sepIdx).map(l => l.trim()).find(Boolean) ?? '';
+  const tmuxAlive = tmuxLine === 'tmux:alive';
+
+  const gitLines = lines.slice(sepIdx + 1).filter(l => l.length > 0);
+  // First git line (if present) is `## branch...origin/branch [ahead N, behind M]`.
+  const branchLine = gitLines[0] ?? '';
+  let branch = '';
+  let commitsAhead = 0;
+  if (branchLine.startsWith('## ')) {
+    const branchMatch = branchLine.match(/^## ([^\s.]+)/);
+    if (branchMatch) branch = branchMatch[1];
+    const aheadMatch = branchLine.match(/\bahead (\d+)/);
+    if (aheadMatch) commitsAhead = parseInt(aheadMatch[1], 10) || 0;
+  }
+  const porcelain = parseGitPorcelainStatus(branchLine.startsWith('## ') ? gitLines.slice(1) : gitLines);
+
+  return {
+    tmuxAlive,
+    branch,
+    commitsAhead,
+    ...porcelain,
+  };
 }
 
 async function getWorktreeGitStatus(worktreePath: string): Promise<Pick<
@@ -535,6 +613,16 @@ export class TmuxSessionItem extends WorktreeItem {
   public readonly session: SessionWithStatus;
   public readonly detailItem: TmuxDetailItem;
   public readonly gitStatusItem?: GitStatusItem;
+  /**
+   * Set when this worker runs on a remote SSH host. Click-to-attach reads
+   * this and routes through `ssh -t <host> tmux attach` instead of the local
+   * tmux backend.
+   *
+   * `stale: true` means the panel render couldn't reach the host within the
+   * 1500ms probe budget — the row's data is the last-known state from
+   * sessions.json, NOT live. Visually shown as a dim cloud + " (stale)".
+   */
+  public readonly remote?: { host: string; stale?: boolean };
 
   constructor(
     session: SessionWithStatus,
@@ -547,7 +635,8 @@ export class TmuxSessionItem extends WorktreeItem {
     agentType?: string,
     repoRoot?: string,
     workerId?: number,
-    displayName?: string
+    displayName?: string,
+    remote?: { host: string; stale?: boolean },
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -567,12 +656,33 @@ export class TmuxSessionItem extends WorktreeItem {
 
     this.session = session;
     this.detailItem = new TmuxDetailItem(session, repoName, worktree, extensionUri);
+    this.remote = remote;
 
     const descParts: string[] = [];
     if (this.description) descParts.push(String(this.description));
     if (workerId != null) descParts.push(`#${workerId}`);
     if (agentType) descParts.push(`[${agentType}]`);
+    if (remote) {
+      const remoteLabel = remote.stale
+        ? `(remote: ${remote.host}; stale)`
+        : `(remote: ${remote.host})`;
+      descParts.push(remoteLabel);
+    }
     if (descParts.length > 0) this.description = descParts.join(' ');
+
+    if (remote) {
+      // Live → green cloud (data was fetched fresh over SSH within budget).
+      // Stale → dim cloud (we couldn't reach the host; row uses last-known
+      // registry data so user can still see the worker exists, but knows
+      // not to trust the git/tmux fields).
+      this.iconPath = remote.stale
+        ? new vscode.ThemeIcon('cloud', new vscode.ThemeColor('disabledForeground'))
+        : new vscode.ThemeIcon('cloud', new vscode.ThemeColor('charts.green'));
+      // Distinct contextValue so menu contributions can scope themselves to
+      // remote rows in the future (delete, attach, send) without changing
+      // existing menu entries that target 'workerItem'.
+      this.contextValue = 'remoteWorkerItem';
+    }
 
     const hasGitChanges = session.status.commitsAhead > 0 || session.status.gitModified > 0 ||
       session.status.gitDeleted > 0 || session.status.gitAdded > 0 || session.status.gitUntracked > 0;
@@ -888,7 +998,83 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
     const prMap = await fetchRepoPrStatuses(repoRoot);
     const items: TmuxItem[] = [];
 
+    // ── Parallel SSH probe for remote workers ──
+    // Fire ALL remote probes in parallel via Promise.allSettled so one slow
+    // host doesn't stall another's row. Each probe has its own 1500ms cap;
+    // failures resolve to `null` and the row falls back to last-known state
+    // with a "(stale)" badge. We never throw out of here — the panel must
+    // keep rendering even when nothing remote is reachable.
+    const remoteWorkers = workers.filter(w => w.remote);
+    const probeResults = remoteWorkers.length === 0
+      ? new Map<string, RemoteWorkerProbe | null>()
+      : new Map(
+          (await Promise.allSettled(
+            remoteWorkers.map(async w => {
+              const probe = await probeRemoteWorker(w.remote!.host, w.sessionName, w.workdir).catch(() => null);
+              return [w.sessionName, probe] as const;
+            }),
+          )).map(r => r.status === 'fulfilled' ? r.value : ['', null as RemoteWorkerProbe | null]),
+        );
+
     for (const w of workers) {
+      if (w.remote) {
+        const probe = probeResults.get(w.sessionName) ?? null;
+        const stale = probe === null;
+        const tmuxAlive = probe ? probe.tmuxAlive : (w.status === 'running');
+
+        // When the probe succeeds we use its live data; when it fails we keep
+        // the row visible with last-known fields (zeroes from the registry,
+        // since we never persisted git counters there) so the user can still
+        // click-to-attach and try to recover.
+        const status: SessionStatus = {
+          attached: false,
+          panes: 1,
+          lastActive: 0,
+          classification: tmuxAlive ? 'idle' : 'stopped',
+          cpuUsage: 0,
+          gitDirty: probe?.gitDirty ?? 0,
+          gitModified: probe?.gitModified ?? 0,
+          gitAdded: probe?.gitAdded ?? 0,
+          gitDeleted: probe?.gitDeleted ?? 0,
+          gitUntracked: probe?.gitUntracked ?? 0,
+          commitsAhead: probe?.commitsAhead ?? 0,
+        };
+
+        // PR badge: same lookup as local rows. Use the live branch from the
+        // probe when present (handles renamed branches on the remote);
+        // otherwise fall back to the registry-recorded branch.
+        const branchLabel = probe?.branch || w.branch || w.slug;
+        const pr = prMap.get(branchLabel);
+        if (pr) {
+          status.prNumber = pr.number;
+          status.prState = pr.state;
+        }
+
+        const session: SessionWithStatus = {
+          name: w.sessionName,
+          windows: 1,
+          attached: false,
+          status,
+          worktreePath: w.workdir,
+          slug: w.slug,
+          hydraRole: 'worker',
+          hydraAgent: w.agent,
+        };
+        const worktree: Worktree = { path: w.workdir, branch: branchLabel, isMain: false };
+        items.push(new TmuxSessionItem(
+          session, repoName, worktree, /* isCurrentWs */ false, /* hasGit */ false,
+          this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName,
+          { host: w.remote.host, stale },
+        ));
+
+        if (stale) {
+          // One debug log per render cycle is fine; the user already sees the
+          // (stale) badge so we don't spam them with notifications.
+          console.debug(`[hydra] remote probe missed budget for ${w.sessionName} on ${w.remote.host}; rendering stale.`);
+        }
+        continue;
+      }
+
       const isCurrentWs = activePath
         ? isCurrentWorkspacePath(w.workdir, activePath)
         : false;

--- a/src/smoke/posixQuoteSmoke.ts
+++ b/src/smoke/posixQuoteSmoke.ts
@@ -1,0 +1,149 @@
+/**
+ * Adversarial smoke test for {@link posixQuote} in src/core/remoteTmux.ts.
+ *
+ * `posixQuote` is the single thin layer between user-supplied strings (branch
+ * names, repo paths, agent commands, send-message payloads) and the remote
+ * shell that ssh executes them in. A bug here is shell injection on every
+ * remote box Hydra ever talks to — so this smoke runs a real `sh -c` over
+ * each adversarial input and asserts the shell sees the bytes verbatim with
+ * zero side effects.
+ *
+ * Each case writes the quoted value via `printf` into a tmpfile, then reads
+ * the tmpfile back and asserts byte equality with the original. Tmpfiles are
+ * compared instead of stdout because side-effect detection (e.g. `$(touch
+ * /tmp/PWNED)` succeeding) only shows up on disk.
+ *
+ * Run:  node out/smoke/posixQuoteSmoke.js
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { posixQuote } from '../core/remoteTmux';
+
+interface Case {
+  name: string;
+  input: string;
+}
+
+const CASES: Case[] = [
+  { name: 'empty string', input: '' },
+  { name: 'plain ascii', input: 'hello world' },
+  { name: 'single quote', input: "It's a test" },
+  { name: 'multiple single quotes', input: "''''" },
+  { name: 'double quote', input: 'a "quoted" b' },
+  { name: 'backtick', input: 'a `whoami` b' },
+  { name: '$(...) command sub', input: 'before $(touch /tmp/HYDRA_PWN_DOLLAR_PAREN) after' },
+  { name: '`...` command sub', input: 'before `touch /tmp/HYDRA_PWN_BACKTICK` after' },
+  { name: '${VAR} expansion attempt', input: 'home=${HOME} path=$PATH' },
+  { name: '; chaining attempt', input: 'a; rm -rf / ; b' },
+  { name: '&& chaining attempt', input: 'a && rm -rf / && b' },
+  { name: '| pipe attempt', input: 'a | tee /tmp/HYDRA_PWN_PIPE | b' },
+  { name: 'redirect attempt', input: 'a > /tmp/HYDRA_PWN_REDIR' },
+  { name: 'newline embedded', input: 'line1\nline2\nline3' },
+  { name: 'CR embedded', input: 'line1\rline2' },
+  { name: 'tab embedded', input: 'a\tb\tc' },
+  { name: 'backslash literal', input: 'C:\\Users\\test\\path' },
+  { name: 'mixed special chars', input: `"hello" 'world' \`cmd\` $HOME \\path (parens) {braces} [brackets] | & ; # ~ !` },
+  { name: 'quote-break injection', input: `'; rm -rf /; '` },
+  { name: 'escape attempt', input: `'\\''; rm -rf /; '\\''` },
+  { name: 'unicode', input: '中文 emoji 🐉 ümlaut' },
+  { name: 'long input', input: 'x'.repeat(8 * 1024) },
+  { name: 'NUL not allowed in shell args', input: 'a' }, // sentinel: real NUL would crash sh; we don't try it
+];
+
+function shExec(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    execFile('/bin/sh', args, { encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 }, (err, stdout, stderr) => {
+      const code = err ? (typeof (err as { code?: number }).code === 'number' ? (err as { code: number }).code : 1) : 0;
+      if (err && code === 0) {
+        reject(err);
+        return;
+      }
+      resolve({ stdout: String(stdout), stderr: String(stderr), code });
+    });
+  });
+}
+
+async function runCase(tc: Case): Promise<{ pass: boolean; detail?: string }> {
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `hydra-posix-smoke-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  // Sentinel files we'll check for side effects from injection attempts.
+  const sentinels = [
+    '/tmp/HYDRA_PWN_DOLLAR_PAREN',
+    '/tmp/HYDRA_PWN_BACKTICK',
+    '/tmp/HYDRA_PWN_PIPE',
+    '/tmp/HYDRA_PWN_REDIR',
+  ];
+  for (const f of sentinels) {
+    try { fs.unlinkSync(f); } catch { /* ok */ }
+  }
+
+  try {
+    const quoted = posixQuote(tc.input);
+
+    // Two checks per case:
+    //   (a) `printf %s <quoted> > tmp` writes input bytes verbatim
+    //   (b) any sentinel file from an injection attempt does NOT exist after (a)
+    const cmd = `printf %s ${quoted} > ${posixQuote(tmpFile)}`;
+    const result = await shExec(['-c', cmd]);
+    if (result.code !== 0) {
+      return { pass: false, detail: `sh -c exited ${result.code}: ${result.stderr.trim()}` };
+    }
+
+    const wrote = fs.readFileSync(tmpFile, 'utf-8');
+    if (wrote !== tc.input) {
+      return {
+        pass: false,
+        detail: `roundtrip mismatch — input.length=${tc.input.length}, wrote.length=${wrote.length}`
+              + (tc.input.length < 200 ? `\n            input:  ${JSON.stringify(tc.input)}\n            wrote:  ${JSON.stringify(wrote)}` : ''),
+      };
+    }
+
+    for (const f of sentinels) {
+      if (fs.existsSync(f)) {
+        return { pass: false, detail: `INJECTION SUCCEEDED — sentinel created: ${f}` };
+      }
+    }
+
+    return { pass: true };
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch { /* ok */ }
+    for (const f of sentinels) {
+      try { fs.unlinkSync(f); } catch { /* ok */ }
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  if (process.platform === 'win32') {
+    console.log('posixQuoteSmoke: skipped on win32 (POSIX shell not available)');
+    process.exit(0);
+  }
+
+  let failed = 0;
+  for (const tc of CASES) {
+    const r = await runCase(tc);
+    const icon = r.pass ? 'PASS' : 'FAIL';
+    console.log(`  [${icon}] ${tc.name}`);
+    if (!r.pass) {
+      console.log(`         ${r.detail}`);
+      failed++;
+    }
+  }
+
+  if (failed > 0) {
+    console.log(`\nposixQuoteSmoke: ${failed}/${CASES.length} FAILED`);
+    process.exit(1);
+  }
+  console.log(`\nposixQuoteSmoke: ok (${CASES.length}/${CASES.length})`);
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(2);
+});

--- a/src/smoke/remoteWorkerSmoke.ts
+++ b/src/smoke/remoteWorkerSmoke.ts
@@ -1,0 +1,173 @@
+/**
+ * Smoke test for the remote worker MVP (Epic #129 phase 1).
+ *
+ * Skipped automatically unless SMOKE_REMOTE_HOST is set.
+ *
+ *   SMOKE_REMOTE_HOST=claude-remote-test.us-west1-a.nexi-lab-888 \
+ *   SMOKE_REMOTE_REPO=/home/sean/smoke-repo \
+ *   node out/smoke/remoteWorkerSmoke.js
+ *
+ * SMOKE_REMOTE_HOST  — SSH alias (must resolve via ~/.ssh/config; for GCP run
+ *                     `gcloud compute config-ssh` first).
+ * SMOKE_REMOTE_REPO  — Absolute path to a git repo on the remote that we can
+ *                     `git worktree add` against. Defaults to /tmp/hydra-smoke-repo
+ *                     and we initialize one there if missing.
+ *
+ * The test:
+ *   1. Preflight (tmux + claude on the remote).
+ *   2. Create a remote worker (branch hydra-smoke-<ts>) on a throwaway repo.
+ *   3. send a `pwd` keystroke and capture the pane — assert the worktree
+ *      path appears in the output.
+ *   4. Delete the worker (kill session + remove worktree + delete branch).
+ *
+ * Returns non-zero on failure so CI / manual operators see the failure clearly.
+ */
+
+import { RemoteTmuxBackend } from '../core/remoteTmux';
+
+const HOST = process.env.SMOKE_REMOTE_HOST;
+const REPO = process.env.SMOKE_REMOTE_REPO || '/tmp/hydra-smoke-repo';
+const AGENT_BIN = process.env.SMOKE_REMOTE_AGENT || 'claude';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+async function ensureSmokeRepo(remote: RemoteTmuxBackend, repoPath: string): Promise<void> {
+  if (await remote.repoExists(repoPath)) return;
+  // Bootstrap a tiny repo so the test is self-contained.
+  // We use the same private SSH machinery via the public preflight surface.
+  // Run a small init script.
+  const initScript = [
+    'set -e',
+    `mkdir -p ${shQ(repoPath)}`,
+    `cd ${shQ(repoPath)}`,
+    'if [ ! -d .git ]; then',
+    'git init -q',
+    'git config user.email "smoke@hydra.local"',
+    'git config user.name "Hydra Smoke"',
+    'echo "smoke" > README.md',
+    'git add README.md',
+    'git commit -q -m "init"',
+    'fi',
+  ].join('\n');
+  await runRaw(remote, initScript);
+}
+
+function shQ(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// Reach into the backend's runRemote path via newSession-style commands.
+// For test setup we want a simple shell exec — easiest is to spawn ssh ourselves.
+import { execFile } from 'child_process';
+async function runRaw(remote: RemoteTmuxBackend, cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'ssh',
+      ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=10', remote.host, cmd],
+      { timeout: 30000, maxBuffer: 8 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(`ssh ${remote.host} failed: ${stderr || err.message}`));
+          return;
+        }
+        resolve(String(stdout));
+      },
+    );
+  });
+}
+
+async function main(): Promise<void> {
+  if (!HOST) {
+    console.log('SMOKE_REMOTE_HOST not set — skipping remote worker smoke test.');
+    process.exit(0);
+  }
+
+  console.log(`=== remoteWorkerSmoke ===`);
+  console.log(`host:   ${HOST}`);
+  console.log(`repo:   ${REPO}`);
+  console.log(`agent:  ${AGENT_BIN}`);
+  console.log();
+
+  const remote = new RemoteTmuxBackend(HOST);
+
+  // 1. preflight
+  console.log('[1/5] Preflight (tmux + agent)…');
+  await remote.preflight(AGENT_BIN);
+  console.log('  OK');
+
+  // 2. ensure repo exists
+  console.log('[2/5] Ensuring smoke repo exists on remote…');
+  await ensureSmokeRepo(remote, REPO);
+  console.log('  OK');
+
+  const ts = Date.now();
+  const branch = `hydra-smoke-${ts}`;
+  const slug = branch.replace(/[/\\\s.:]/g, '-');
+  const sessionName = `hydra-smoke_${slug}`;
+  const worktreePath = `${REPO.replace(/\/+$/, '')}/.hydra-worktrees/${slug}`;
+
+  let createdWorktree = false;
+  let createdSession = false;
+
+  try {
+    // 3. create worker (worktree + tmux session running a no-op command for testability)
+    console.log(`[3/5] Creating worker (branch=${branch}, session=${sessionName})…`);
+    await remote.addWorktree(REPO, branch, worktreePath);
+    createdWorktree = true;
+    // For the smoke test we run `bash` in tmux instead of the actual agent —
+    // we want to send `pwd` and read deterministic output, not boot a TUI.
+    await remote.newSession(sessionName, worktreePath, 'bash');
+    createdSession = true;
+    console.log('  OK');
+
+    // Give bash a moment to initialize.
+    await sleep(800);
+
+    // 4. send pwd, capture pane, assert worktreePath is present
+    console.log('[4/5] Sending `pwd` and capturing pane…');
+    await remote.sendMessage(sessionName, 'pwd');
+    await sleep(800);
+    const pane = await remote.capturePane(sessionName, 50);
+    if (!pane.includes(worktreePath)) {
+      console.error('  FAIL — pane did not contain worktree path:');
+      console.error('    expected substring:', worktreePath);
+      console.error('    pane output:');
+      console.error(pane.split('\n').map(l => '      ' + l).join('\n'));
+      throw new Error('Worktree path not found in pane output');
+    }
+    console.log('  OK — pane contains worktree path');
+
+    // 5. delete (kill session + remove worktree + delete branch)
+    console.log('[5/5] Tearing down…');
+    await remote.killSession(sessionName);
+    createdSession = false;
+    await remote.removeWorktree(REPO, worktreePath);
+    createdWorktree = false;
+    await remote.deleteBranch(REPO, branch);
+    console.log('  OK');
+
+    console.log('\n=== Smoke test PASSED ===');
+    process.exit(0);
+  } catch (err) {
+    console.error('\n=== Smoke test FAILED ===');
+    console.error(err instanceof Error ? err.message : String(err));
+    // Best-effort cleanup.
+    if (createdSession) {
+      console.error('Cleaning up tmux session…');
+      await remote.killSession(sessionName).catch(() => {});
+    }
+    if (createdWorktree) {
+      console.error('Cleaning up worktree…');
+      await remote.removeWorktree(REPO, worktreePath).catch(() => {});
+      await remote.deleteBranch(REPO, branch).catch(() => {});
+    }
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
First delivery of [Epic #129](https://github.com/joezhoujinjing/hydra/issues/129) — running a Hydra worker on a remote SSH host. The repo and agents must already exist on the remote; Hydra does not provision.

## What's in this PR

1. **`RemoteTmuxBackend`** (`src/core/remoteTmux.ts`) — wraps an SSH alias and exposes the subset of `TmuxBackendCore` methods worker lifecycle uses (`newSession`, `capturePane`, `sendKeys`, `sendMessage`, `killSession`, `listSessions`, `hasSession`) plus remote git-worktree helpers, an SSH preflight, and a generic short-budget `probe()` for "live status" callers. Connection options: `BatchMode=yes` + `ConnectTimeout=10` for fail-fast.

2. **`hydra worker create --remote <ssh-host>`** — plain `ssh <host>` (no gcloud shimming). Runs `git -C <repo> worktree add` then `tmux new-session -d -s ... -c ... <agent-cmd>` over SSH. Persists `remote: { host }` in `sessions.json`.

3. **Subcommand routing**: `worker logs/send/delete/attach` look up the worker in `sessions.json` and dispatch to either local `TmuxBackendCore` or a `RemoteTmuxBackend` bound to the worker's host.

4. **New `worker attach <session>`** — interactive foreground attach. Remote shells out to `ssh -t <host> tmux attach -t <session>`.

5. **`worker send` uses base64-over-SSH** (matches PR #122 load-buffer + paste-buffer + Enter so long/special-character messages don't lose their trailing Enter).

6. **`hydra list` / `list --json` surfaces `remote: { host, statusVerified: false }`** plus a `(status unverified)` suffix in pretty output (CLI never SSH-probes for `list` — too slow at scale).

7. **Sync skips reconciliation for remote workers** — old sync deleted them as orphans because `workdir` doesn't exist locally. Liveness verified per-command on demand.

8. **Adversarial `posixQuote` smoke** (`src/smoke/posixQuoteSmoke.ts`) — 23 cases covering single-quote, newline, backslash, `$(...)`, backticks, `'\\''` escape, quote-break injection, unicode, 8KB long input. Each round-trips through real `/bin/sh -c` and asserts byte-for-byte equality + 4 sentinel injection-detection files.

9. **Fail-loud `deleteRemoteWorker`** — refuses to drop the registry entry if `kill-session` or `worktree remove` fails (transport OR real git failure like locked worktree). Surfaces a multi-line manual-cleanup message with the exact `ssh ...` commands to run. Tolerates the one benign git case ("is not a working tree" = already gone).

10. **SSH transport translation** — `runRemote` checks exit 255 + stderr signatures (`ssh:` prefix, `kex_exchange_identification`, `Permission denied`, `Connection refused/closed/timed out`, `ProxyCommand`, `Host key verification failed`, etc.) **before** honoring `allowNonZeroExit`, so a transport outage never masquerades as "no such session" / "repo not found". All transport messages append a consistent `~/.ssh/config` hint (`gcloud compute config-ssh` for GCP).

11. **Stop / start / rename refuse remote workers** — clear "not yet supported (Epic #129 phase 2)" errors; the `stop` message includes a paste-able `ssh ... tmux kill-session` workaround.

12. **`--repo` validation for remote** — rejects `~/...` (single-quoted by `posixQuote`, would create a literal `~` directory) and rejects relative paths (no remote cwd to anchor to).

13. **Telemetry** — `worker_created` capture on the remote path includes `is_remote: true` so adoption signal isn't lost.

14. **Sidebar integration (VS Code panel)** — remote workers render in the Workers tree under their repo group with a ☁ cloud icon. Click-to-attach opens a terminal that runs `ssh -t <host> tmux attach -t <session>`. `contextValue: 'remoteWorkerItem'` is reserved for phase-2 menu contributions.

15. **Live SSH probe in panel render** — every panel refresh fires one parallel SSH probe per remote worker (`Promise.allSettled`), single round trip per host that returns:

    ```
    tmux:alive | tmux:dead
    ---
    <git status --porcelain --branch output>
    ```

    Probe result feeds the same `SessionStatus` shape used for local rows — git modified/added/deleted/untracked counters, commits-ahead, branch label, PR badge from `prMap` (uses the live branch name from the probe so renames on the remote are picked up). Hard 1500ms budget per probe via `runRemote` timeout. **Graceful fallback**: any probe that times out, throws, or returns malformed output → row keeps rendering with last-known data + dim cloud icon (`disabledForeground`) + `(stale)` description suffix. One slow remote can't stall another's row.

## Explicitly deferred (phase 2)

- **SSH ControlMaster auto-config.** Without it every probe pays one full SSH handshake (~500ms typical, 1.5s+ on cold IAP tunnels — exactly the budget). With user-configured ControlMaster, ~10ms. Hydra deliberately doesn't auto-configure user `~/.ssh/config`; `(stale)` is the visible fallback when probes can't keep up.
- Completion-hook injection on remote workers (cross-host hook delivery design).
- Code sync (assume pre-cloned).
- Initial `--task` / `--task-file` on remote (CLI rejects with clear error).
- Remote copilots.
- Cross-host `sessions.json` sync.
- `worker stop` / `start` / `rename` for remote.
- Live-status probe in `hydra list` CLI (panel does it; CLI keeps the no-SSH contract).
- Tracked finding from PR #138 (demo): the marketplace-installed extension (pre-#136) drops remote registry entries during its sync. Self-resolves once #136 ships and marketplace updates. Schema-versioning + idempotent reconciliation are tracked phase-2 follow-ups.

## Verification

- `npm run compile && npm run lint` ✅
- `npm test` ✅ — 11 smokes (tmuxAttach, codexBypass, workerDelete, telemetry, telemetryE2e, sessionFileResolve, cliSessionFields, repoRegistry 27/27, posixQuote 23/23, remoteWorker — skips without env)
- `SMOKE_REMOTE_HOST=claude-remote-test SMOKE_REMOTE_AGENT=claude SMOKE_REMOTE_REPO=/tmp/hydra-smoke-repo node out/smoke/remoteWorkerSmoke.js` ✅ — all 5 steps PASS
- End-to-end demo PR #138 — remote worker created a real commit on the gcloud VM; pulled to local; pushed to GitHub; PR opened.
- Live SSH probe sanity-checked against the gcloud VM with `RemoteTmuxBackend.probe()` directly: parser correctly extracts `tmuxAlive`, `branch`, `commitsAhead`, porcelain counters from the combined output. With cold IAP tunnels (~1.5–3.2s handshake), the 1500ms budget triggers the (stale) fallback as designed; users with ControlMaster see live data.

## SSH setup used for testing

`claude-remote-test` is a GCP VM (zone `us-west1-a`, project `nexi-lab-888`, Ubuntu 24.04). `gcloud compute config-ssh` doesn't connect on Ubuntu 24.04 (google-guest-agent reload issue), so `~/.ssh/config` has a hand-written entry with `ProxyCommand gcloud compute start-iap-tunnel %h %p ...` — documented in the README "Remote workers (preview)" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)