### PR TITLE
chore: release v0.3.2026050800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.2026050800] - 2026-05-08
+
+### Added
+- Telemetry framework with swappable backend and default PostHog transport (#133, #137)
+- Repo registry CLI with auto-fetch wiring (#135)
+- Surface session ID and session file path in logs and `list` output (#132)
+
+### Fixed
+- Replace broken symlinks with NTFS junctions on Windows worktrees (#126)
+- Ensure Enter is sent after message text in worker send (#122)
+- Avoid shell injection in sidebar git commands
+- Guard against nested worker creation
+- Worker delete consistency and worker resume slug identity
+
 ## [0.3.2026050600] - 2026-05-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026050600",
+  "version": "0.3.2026050800",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026050600",
+      "version": "0.3.2026050800",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026050600",
+  "version": "0.3.2026050800",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026050800

## Highlights

### Added
- Telemetry framework with swappable backend and default PostHog transport (#133, #137)
- Repo registry CLI with auto-fetch wiring (#135)
- Surface session ID and session file path in logs and `list` output (#132)

### Fixed
- Replace broken symlinks with NTFS junctions on Windows worktrees (#126)
- Ensure Enter is sent after message text in worker send (#122)
- Avoid shell injection in sidebar git commands
- Guard against nested worker creation
- Worker delete consistency and worker resume slug identity

When merged, `auto-tag-release.yml` will tag `v0.3.2026050800` and the publish workflow will package and publish the extension.