### PR TITLE
[codex] Keep worker review changes in the current window

### DIFF
--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -13,6 +13,7 @@ import { getActiveBackend, HydraRole } from '../utils/multiplexer';
 import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
 import { exec } from '../utils/exec';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
+import { openChangesReview } from './reviewChanges';
 
 function getWorktreePath(item: TmuxItem): string | undefined {
   if (item instanceof CopilotItem) return item.worktreePath;
@@ -100,7 +101,17 @@ export async function openWorktree(item: TmuxItem): Promise<void> {
 }
 
 export async function reviewChanges(item: TmuxItem): Promise<void> {
-  await openWorktree(item);
+  const worktreePath = getWorktreePath(item);
+  if (!worktreePath) {
+    vscode.window.showErrorMessage('Worktree path not found');
+    return;
+  }
+
+  try {
+    await openChangesReview(worktreePath);
+  } catch (err) {
+    vscode.window.showErrorMessage(`Failed to review changes: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 export async function copyPath(item: TmuxItem): Promise<void> {

--- a/src/commands/reviewChanges.ts
+++ b/src/commands/reviewChanges.ts
@@ -1,0 +1,277 @@
+import * as path from 'path';
+import { execFile as execFileCallback } from 'child_process';
+import * as fs from 'fs/promises';
+import { promisify } from 'util';
+import * as vscode from 'vscode';
+import { resolveCommandPath } from '../core/exec';
+
+const execFile = promisify(execFileCallback);
+const REVIEW_SCHEME = 'hydra-git';
+const MAX_GIT_OUTPUT = 50 * 1024 * 1024;
+
+interface ReviewChange {
+  status: string;
+  path: string;
+  oldPath?: string;
+}
+
+interface SnapshotQuery {
+  worktreePath: string;
+  ref?: string;
+  filePath?: string;
+  empty?: boolean;
+  current?: boolean;
+}
+
+let gitBinary: string | undefined;
+let providerDisposable: vscode.Disposable | undefined;
+
+async function getGitBinary(): Promise<string> {
+  if (gitBinary) {
+    return gitBinary;
+  }
+
+  const resolved = await resolveCommandPath('git');
+  if (!resolved) {
+    throw new Error('git not found');
+  }
+  gitBinary = resolved;
+  return gitBinary;
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFile(await getGitBinary(), args, {
+    cwd,
+    maxBuffer: MAX_GIT_OUTPUT,
+  });
+  return stdout.toString();
+}
+
+async function tryGit(args: string[], cwd: string): Promise<string> {
+  try {
+    return await git(args, cwd);
+  } catch {
+    return '';
+  }
+}
+
+function ensureReviewContentProvider(): void {
+  if (providerDisposable) {
+    return;
+  }
+
+  providerDisposable = vscode.workspace.registerTextDocumentContentProvider(REVIEW_SCHEME, {
+    async provideTextDocumentContent(uri): Promise<string> {
+      const query = parseSnapshotQuery(uri);
+      if (!query || !query.filePath || query.empty) {
+        return '';
+      }
+
+      if (query.current) {
+        return tryReadFile(path.join(query.worktreePath, query.filePath));
+      }
+
+      if (!query.ref) {
+        return '';
+      }
+      return tryGit(['show', `${query.ref}:${query.filePath}`], query.worktreePath);
+    },
+  });
+}
+
+function parseSnapshotQuery(uri: vscode.Uri): SnapshotQuery | undefined {
+  try {
+    const parsed = JSON.parse(uri.query) as Partial<SnapshotQuery>;
+    if (typeof parsed.worktreePath !== 'string' || !parsed.worktreePath) {
+      return undefined;
+    }
+    return {
+      worktreePath: parsed.worktreePath,
+      ref: typeof parsed.ref === 'string' ? parsed.ref : undefined,
+      filePath: typeof parsed.filePath === 'string' ? parsed.filePath : undefined,
+      empty: parsed.empty === true,
+      current: parsed.current === true,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function tryReadFile(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function reviewUri(worktreePath: string, filePath: string, query: Omit<SnapshotQuery, 'worktreePath' | 'filePath'>): vscode.Uri {
+  return vscode.Uri.from({
+    scheme: REVIEW_SCHEME,
+    path: `/${filePath}`,
+    query: JSON.stringify({ worktreePath, filePath, ...query }),
+  });
+}
+
+function snapshotUri(worktreePath: string, ref: string, filePath: string): vscode.Uri {
+  return reviewUri(worktreePath, filePath, { ref });
+}
+
+function emptyUri(worktreePath: string, filePath: string): vscode.Uri {
+  return reviewUri(worktreePath, filePath, { empty: true });
+}
+
+function currentUri(worktreePath: string, filePath: string): vscode.Uri {
+  return reviewUri(worktreePath, filePath, { current: true });
+}
+
+function splitNul(output: string): string[] {
+  return output.split('\0').filter(Boolean);
+}
+
+function parseNameStatus(output: string): ReviewChange[] {
+  const tokens = splitNul(output);
+  const changes: ReviewChange[] = [];
+
+  for (let index = 0; index < tokens.length;) {
+    const status = tokens[index++];
+    if (!status) {
+      continue;
+    }
+
+    if (status.startsWith('R') || status.startsWith('C')) {
+      const oldPath = tokens[index++];
+      const newPath = tokens[index++];
+      if (oldPath && newPath) {
+        changes.push({ status, oldPath, path: newPath });
+      }
+      continue;
+    }
+
+    const filePath = tokens[index++];
+    if (filePath) {
+      changes.push({ status, path: filePath });
+    }
+  }
+
+  return changes;
+}
+
+async function getCurrentBranch(worktreePath: string): Promise<string> {
+  return (await tryGit(['branch', '--show-current'], worktreePath)).trim();
+}
+
+async function getReviewBaseRef(worktreePath: string): Promise<string> {
+  const branch = await getCurrentBranch(worktreePath);
+  if (branch) {
+    const configuredBase = (await tryGit(['config', '--get', `branch.${branch}.vscode-merge-base`], worktreePath)).trim();
+    if (configuredBase && await refExists(worktreePath, configuredBase)) {
+      return configuredBase;
+    }
+  }
+
+  const candidates = ['origin/main', 'main', 'origin/master', 'master'];
+  for (const candidate of candidates) {
+    if (await refExists(worktreePath, candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error('Unable to find a base branch for this worktree.');
+}
+
+async function refExists(worktreePath: string, ref: string): Promise<boolean> {
+  return Boolean((await tryGit(['rev-parse', '--verify', `${ref}^{commit}`], worktreePath)).trim());
+}
+
+async function getMergeBase(worktreePath: string, baseRef: string): Promise<string> {
+  const mergeBase = (await tryGit(['merge-base', baseRef, 'HEAD'], worktreePath)).trim();
+  return mergeBase || baseRef;
+}
+
+async function getReviewChanges(worktreePath: string, baseCommit: string): Promise<ReviewChange[]> {
+  const trackedChanges = parseNameStatus(
+    await tryGit(['diff', '--name-status', '--find-renames', '-z', baseCommit, '--'], worktreePath)
+  );
+  const seen = new Set(trackedChanges.map(change => change.path));
+
+  const untracked = splitNul(await tryGit(['ls-files', '--others', '--exclude-standard', '-z'], worktreePath));
+  for (const filePath of untracked) {
+    if (!seen.has(filePath)) {
+      trackedChanges.push({ status: 'A', path: filePath });
+      seen.add(filePath);
+    }
+  }
+
+  return trackedChanges.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function getResourceUri(worktreePath: string, change: ReviewChange): vscode.Uri {
+  return currentUri(worktreePath, change.path);
+}
+
+function getOriginalUri(worktreePath: string, baseCommit: string, change: ReviewChange): vscode.Uri {
+  if (change.status.startsWith('A')) {
+    return emptyUri(worktreePath, change.path);
+  }
+  return snapshotUri(worktreePath, baseCommit, change.oldPath || change.path);
+}
+
+function getModifiedUri(worktreePath: string, change: ReviewChange): vscode.Uri {
+  if (change.status.startsWith('D')) {
+    return emptyUri(worktreePath, change.path);
+  }
+  return currentUri(worktreePath, change.path);
+}
+
+function getDiffTitle(worktreePath: string, baseRef: string, changes: ReviewChange[]): string {
+  const name = path.basename(worktreePath);
+  return `${name}: ${changes.length} change${changes.length === 1 ? '' : 's'} since ${baseRef}`;
+}
+
+async function openFallbackDiff(
+  worktreePath: string,
+  baseCommit: string,
+  baseRef: string,
+  changes: ReviewChange[]
+): Promise<void> {
+  const first = changes[0];
+  await vscode.commands.executeCommand(
+    'vscode.diff',
+    getOriginalUri(worktreePath, baseCommit, first),
+    getModifiedUri(worktreePath, first),
+    `${first.path} (${baseRef} ↔ worker)`,
+    { preview: false }
+  );
+
+  if (changes.length > 1) {
+    vscode.window.showInformationMessage(
+      `Opened the first of ${changes.length} worker changes. Update VS Code to use the full changes editor.`
+    );
+  }
+}
+
+export async function openChangesReview(worktreePath: string): Promise<void> {
+  ensureReviewContentProvider();
+
+  const baseRef = await getReviewBaseRef(worktreePath);
+  const baseCommit = await getMergeBase(worktreePath, baseRef);
+  const changes = await getReviewChanges(worktreePath, baseCommit);
+
+  if (changes.length === 0) {
+    vscode.window.showInformationMessage('No worker changes to review.');
+    return;
+  }
+
+  const resources = changes.map(change => [
+    getResourceUri(worktreePath, change),
+    getOriginalUri(worktreePath, baseCommit, change),
+    getModifiedUri(worktreePath, change),
+  ]);
+
+  try {
+    await vscode.commands.executeCommand('vscode.changes', getDiffTitle(worktreePath, baseRef, changes), resources);
+  } catch {
+    await openFallbackDiff(worktreePath, baseCommit, baseRef, changes);
+  }
+}


### PR DESCRIPTION
## Summary

This PR changes `Review Changes` from a full worktree-open action into an in-place review action.

Instead of delegating to `Open in New Window`, the command now opens a VS Code native multi-diff editor in the current window. `Open in New Window` is still available as the explicit action when the user wants to enter the worker worktree for editing or full SCM operations.

## Root Cause

PR #144 added the menu item but implemented it by calling the same path as `Open in New Window`:

- `Review Changes` -> `openWorktree(item)`
- `openWorktree` -> `vscode.openFolder(worktreeUri, true)`

That made “review” feel heavier than expected: a quick diff check always created a new VS Code window.

## UX Decision

I explored three options:

1. Keep opening the worker worktree in a new window.
2. Add the worker worktree into the current workspace temporarily.
3. Open a read-only multi-diff in the current window.

This PR uses option 3 because it gives the best review experience:

- no forced window switch
- no mutation of the current workspace folders
- no VS Code Git prompt for a second repository
- no extension restart risk from turning a single-folder workspace into a multi-root workspace
- still uses the standard VS Code diff UI, including next/previous change navigation

## Implementation

- Adds `src/commands/reviewChanges.ts`.
- Resolves the review base from `branch.<branch>.vscode-merge-base`, falling back to `origin/main`, `main`, `origin/master`, then `master`.
- Uses `git merge-base` so the review compares the worker against the correct branch point.
- Lists tracked changes with `git diff --name-status --find-renames -z`.
- Includes untracked files with `git ls-files --others --exclude-standard -z`.
- Opens all worker changes through `vscode.changes`.
- Uses a `hydra-git:` virtual document provider for both base snapshots and current worker content, so the review editor stays read-only and does not register the worker worktree as another Git repository in the current VS Code window.
- Falls back to opening the first diff with `vscode.diff` if the current VS Code build does not support the multi-diff command.
- Keeps `Open in New Window` unchanged for users who want the full worker environment.

## User Impact

Clicking `Review Changes` now opens a focused review editor in the same window. The user sees all worker changes together, including added, modified, deleted, renamed, and untracked files, without losing their current context.

## Validation

Automated checks:

- `npm run compile`
- `npm run lint`
- `git diff --check`
- `npm test`

Manual Extension Development Host validation:

- Launched Hydra with `/test-hydra` isolated environment from this branch.
- Created an isolated git repo and a worker named `review-ux-current-window`.
- Added representative worker changes:
  - modified `README.md`
  - deleted `src/value.ts`
  - added tracked-style new file `src/added.ts`
  - added untracked `NOTES.md`
- Right-clicked the worker and selected `Review Changes`.
- Confirmed the review opened in the same Extension Host window.
- Confirmed the editor showed `4 changes since main`.
- Confirmed all four file states rendered in the multi-diff editor.
- Confirmed no new VS Code window was created.
- Confirmed the virtual review no longer triggered VS Code’s “found another Git repository” prompt.

Note: the Extension Development Host also showed an unrelated `atian25.eggjs` activation warning because the temporary test workspace has no `package.json`; it did not affect Hydra or the review flow.

Addresses #108.
