### PR TITLE
Open review changes in a dedicated maximized editor group

### DIFF
--- a/src/commands/reviewChanges.ts
+++ b/src/commands/reviewChanges.ts
@@ -4,10 +4,20 @@ import * as fs from 'fs/promises';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
 import { resolveCommandPath } from '../core/exec';
+import { HYDRA_PREFIX_REVIEW, findReviewGroupColumn, focusEditorGroup } from '../utils/hydraEditorGroup';
 
 const execFile = promisify(execFileCallback);
 const REVIEW_SCHEME = 'hydra-git';
 const MAX_GIT_OUTPUT = 50 * 1024 * 1024;
+const REVIEW_LABEL_PREFIX = `${HYDRA_PREFIX_REVIEW} `;
+
+interface ReviewLayoutState {
+  column: vscode.ViewColumn;
+  maximized: boolean;
+}
+
+let reviewLayout: ReviewLayoutState | undefined;
+let layoutListenersRegistered = false;
 
 interface ReviewChange {
   status: string;
@@ -226,22 +236,27 @@ function getModifiedUri(worktreePath: string, change: ReviewChange): vscode.Uri 
 
 function getDiffTitle(worktreePath: string, baseRef: string, changes: ReviewChange[]): string {
   const name = path.basename(worktreePath);
-  return `${name}: ${changes.length} change${changes.length === 1 ? '' : 's'} since ${baseRef}`;
+  return `${REVIEW_LABEL_PREFIX}${name}: ${changes.length} change${changes.length === 1 ? '' : 's'} since ${baseRef}`;
+}
+
+function getFallbackDiffTitle(filePath: string, baseRef: string): string {
+  return `${REVIEW_LABEL_PREFIX}${filePath} (${baseRef} ↔ worker)`;
 }
 
 async function openFallbackDiff(
   worktreePath: string,
   baseCommit: string,
   baseRef: string,
-  changes: ReviewChange[]
+  changes: ReviewChange[],
+  targetColumn: vscode.ViewColumn,
 ): Promise<void> {
   const first = changes[0];
   await vscode.commands.executeCommand(
     'vscode.diff',
     getOriginalUri(worktreePath, baseCommit, first),
     getModifiedUri(worktreePath, first),
-    `${first.path} (${baseRef} ↔ worker)`,
-    { preview: false }
+    getFallbackDiffTitle(first.path, baseRef),
+    { preview: false, viewColumn: targetColumn }
   );
 
   if (changes.length > 1) {
@@ -251,8 +266,90 @@ async function openFallbackDiff(
   }
 }
 
+async function ensureReviewGroupFocused(): Promise<{ column: vscode.ViewColumn; created: boolean }> {
+  const existing = findReviewGroupColumn();
+  if (existing !== undefined) {
+    await focusEditorGroup(existing);
+    return { column: existing, created: false };
+  }
+
+  // Create a new group to the right of the active one. VS Code focuses the new group.
+  await vscode.commands.executeCommand('workbench.action.newGroupRight');
+  const column = vscode.window.tabGroups.activeTabGroup.viewColumn;
+  return { column, created: true };
+}
+
+async function maximizeReviewGroup(column: vscode.ViewColumn): Promise<boolean> {
+  // Only toggle when not already maximized by us — toggle is symmetric and would flip wrong direction.
+  if (reviewLayout?.maximized && reviewLayout.column === column) {
+    return true;
+  }
+  try {
+    await vscode.commands.executeCommand('workbench.action.toggleMaximizeEditorGroup');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureReviewLayoutListeners(): void {
+  if (layoutListenersRegistered) {
+    return;
+  }
+  layoutListenersRegistered = true;
+
+  vscode.window.tabGroups.onDidChangeTabs(() => { void onReviewLayoutMaybeChanged(); });
+  vscode.window.tabGroups.onDidChangeTabGroups(() => { void onReviewLayoutMaybeChanged(); });
+}
+
+async function onReviewLayoutMaybeChanged(): Promise<void> {
+  const state = reviewLayout;
+  if (!state) {
+    return;
+  }
+
+  const group = vscode.window.tabGroups.all.find(g => g.viewColumn === state.column);
+
+  // Group disappeared (VS Code auto-closed the empty group, or user closed it manually).
+  // VS Code clears its own maximize state when the maximized group is removed.
+  if (!group) {
+    reviewLayout = undefined;
+    return;
+  }
+
+  // Last review tab closed but group lingers (e.g. workbench.editor.closeEmptyGroups disabled,
+  // or user dragged a non-review tab in earlier).
+  if (group.tabs.length === 0) {
+    if (state.maximized) {
+      try {
+        await focusEditorGroup(state.column);
+        await vscode.commands.executeCommand('workbench.action.toggleMaximizeEditorGroup');
+      } catch {
+        // best-effort
+      }
+    }
+    try {
+      await vscode.window.tabGroups.close(group);
+    } catch {
+      // best-effort
+    }
+    reviewLayout = undefined;
+    return;
+  }
+
+  // Group still has tabs. If the active group moved away while we believed we were maximized,
+  // the user must have manually unmaximized — sync our flag so we don't re-toggle the wrong way.
+  if (state.maximized) {
+    const active = vscode.window.tabGroups.activeTabGroup;
+    if (active.viewColumn !== state.column) {
+      state.maximized = false;
+    }
+  }
+}
+
 export async function openChangesReview(worktreePath: string): Promise<void> {
   ensureReviewContentProvider();
+  ensureReviewLayoutListeners();
 
   const baseRef = await getReviewBaseRef(worktreePath);
   const baseCommit = await getMergeBase(worktreePath, baseRef);
@@ -269,9 +366,21 @@ export async function openChangesReview(worktreePath: string): Promise<void> {
     getModifiedUri(worktreePath, change),
   ]);
 
+  const { column: targetColumn, created } = await ensureReviewGroupFocused();
+
   try {
     await vscode.commands.executeCommand('vscode.changes', getDiffTitle(worktreePath, baseRef, changes), resources);
   } catch {
-    await openFallbackDiff(worktreePath, baseCommit, baseRef, changes);
+    await openFallbackDiff(worktreePath, baseCommit, baseRef, changes, targetColumn);
+  }
+
+  if (created) {
+    const ok = await maximizeReviewGroup(targetColumn);
+    reviewLayout = { column: targetColumn, maximized: ok };
+  } else if (!reviewLayout) {
+    // Group existed before this session — leave maximize state alone, assume not maximized by us.
+    reviewLayout = { column: targetColumn, maximized: false };
+  } else {
+    reviewLayout.column = targetColumn;
   }
 }

--- a/src/utils/hydraEditorGroup.ts
+++ b/src/utils/hydraEditorGroup.ts
@@ -4,6 +4,7 @@ import { HydraRole } from './multiplexer';
 
 export const HYDRA_PREFIX_COPILOT = 'Copilot:';
 export const HYDRA_PREFIX_WORKER = 'Worker:';
+export const HYDRA_PREFIX_REVIEW = 'Review:';
 
 /**
  * Scan tabGroups for a tab whose label starts with the given prefix.
@@ -36,6 +37,35 @@ export function getHydraEditorLocation(role?: HydraRole): vscode.TerminalEditorL
     existing = findGroupByPrefix(HYDRA_PREFIX_COPILOT) ?? findGroupByPrefix(HYDRA_PREFIX_WORKER);
   }
   return { viewColumn: existing ?? vscode.ViewColumn.Beside, preserveFocus: false };
+}
+
+/**
+ * Find the viewColumn of the editor group hosting Hydra review-changes diff tabs,
+ * identified by tab labels starting with HYDRA_PREFIX_REVIEW.
+ */
+export function findReviewGroupColumn(): vscode.ViewColumn | undefined {
+  return findGroupByPrefix(HYDRA_PREFIX_REVIEW);
+}
+
+const FOCUS_EDITOR_GROUP_COMMANDS = [
+  'workbench.action.focusFirstEditorGroup',
+  'workbench.action.focusSecondEditorGroup',
+  'workbench.action.focusThirdEditorGroup',
+  'workbench.action.focusFourthEditorGroup',
+  'workbench.action.focusFifthEditorGroup',
+  'workbench.action.focusSixthEditorGroup',
+  'workbench.action.focusSeventhEditorGroup',
+  'workbench.action.focusEighthEditorGroup',
+];
+
+/**
+ * Focus an editor group by 1-indexed viewColumn. No-op for out-of-range columns.
+ */
+export async function focusEditorGroup(column: vscode.ViewColumn): Promise<void> {
+  if (typeof column !== 'number' || column < 1 || column > FOCUS_EDITOR_GROUP_COMMANDS.length) {
+    return;
+  }
+  await vscode.commands.executeCommand(FOCUS_EDITOR_GROUP_COMMANDS[column - 1]);
 }
 
 const MAX_COPILOT_NAME_LENGTH = 20;


### PR DESCRIPTION
## Summary

- Route worker **Review Changes** diff into a Hydra-managed `Review:` editor group (mirrors existing `Worker:` / `Copilot:` group routing in `hydraEditorGroup.ts`).
- When the Review group is freshly created, toggle `workbench.action.toggleMaximizeEditorGroup` so the multi-file diff editor uses full width instead of being squeezed into whatever narrow column happened to be active. Subsequent reviews reuse the same group without re-toggling.
- When the last tab in the Review group is closed, unmaximize (if we were the ones who maximized) and close the empty group via `tabGroups.close`, restoring the prior layout.
- If the user manually unmaximizes, sync our flag via `activeTabGroup` change detection so cleanup doesn't flip the wrong way.
- Fallback `vscode.diff` now passes `viewColumn` so the single-file fallback also lands in the Review column.

## Why

Previously `vscode.changes` / `vscode.diff` were called without any `viewColumn`, so the diff opened in the currently active editor group. With many worker terminal tabs, the active group is often the narrow `Worker:` terminal column — the multi-file diff renders inside that narrow column and feels squeezed, while existing terminal tabs get pushed into overflow.

## Files

- `src/utils/hydraEditorGroup.ts` — add `HYDRA_PREFIX_REVIEW`, `findReviewGroupColumn()`, `focusEditorGroup(column)`.
- `src/commands/reviewChanges.ts` — group routing + maximize state machine; titles prefixed with `Review:` so the group can be discovered by prefix scan.

## Test plan

- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test` (27/27 smoke pass — note: smoke suite is Node-only and does **not** import `vscode`, so it does not exercise the new tabGroups / workbench-command behavior)
- [ ] **Manual GUI verification still required** via `/test-hydra` — the changes target VS Code's Extension Host APIs (`tabGroups`, `workbench.action.newGroupRight`, `workbench.action.toggleMaximizeEditorGroup`) which have no automated coverage in this repo. Scenarios to walk through:
  - First Review Changes → new group opens to the right and is maximized
  - Second Review Changes on a different worker → reuses same group, stays maximized, adds a new tab
  - Close last diff tab → group closes, layout restored
  - Manual ⤢ unmaximize then close diff → group closes without re-maximizing

## Known limitations

- VS Code does not expose maximize state to the API, so we infer manual unmaximize from `activeTabGroup` changes. If the user unmaximizes via ⤢ but never moves focus to another group before closing the last diff tab, our cleanup will toggle once (briefly maximizing the now-empty group) before closing it — visual blip only, final layout still correct.
- On window reload, restored `Review:` tabs are reused but not re-maximized (we don't override the user's restored layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)