### PR TITLE
[codex] Refresh sidebar when sessions change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
 import { attachCreate } from './commands/attachCreate';
 import { newTask } from './commands/newTask';
@@ -22,6 +23,9 @@ import { installCli, ensurePathInShellProfile } from './core/cliInstaller';
 import { detectAvailableAgents } from './utils/agentConfig';
 import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } from './utils/hydraEditorGroup';
 import { lookupWorkerId } from './core/sessionManager';
+import { getHydraSessionsFile } from './core/path';
+
+const SESSION_REFRESH_DEBOUNCE_MS = 200;
 
 export function activate(context: vscode.ExtensionContext) {
   const copilotProvider = new CopilotProvider();
@@ -61,6 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
   detectAndSetAgentContext();
 
   const refreshAll = () => { copilotProvider.refresh(); workerProvider.refresh(); };
+  registerSessionFileRefreshWatcher(context, refreshAll);
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
@@ -93,6 +98,38 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push({
       dispose: () => clearInterval(intervalId)
   });
+}
+
+function registerSessionFileRefreshWatcher(context: vscode.ExtensionContext, refreshAll: () => void): void {
+  const sessionsFile = getHydraSessionsFile();
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(path.dirname(sessionsFile), path.basename(sessionsFile)),
+  );
+  let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleRefresh = () => {
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+    }
+    refreshTimer = setTimeout(() => {
+      refreshTimer = undefined;
+      refreshAll();
+    }, SESSION_REFRESH_DEBOUNCE_MS);
+  };
+
+  context.subscriptions.push(
+    watcher,
+    watcher.onDidCreate(scheduleRefresh),
+    watcher.onDidChange(scheduleRefresh),
+    watcher.onDidDelete(scheduleRefresh),
+    {
+      dispose: () => {
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+        }
+      },
+    },
+  );
 }
 
 function getShortName(sessionName: string): string {


### PR DESCRIPTION
## Summary
- Refresh the Hydra Copilots and Workers tree views when `sessions.json` is created, changed, or deleted.
- Debounce file watcher events so atomic registry writes only trigger one refresh burst.
- Keep the existing 30s polling loop as a fallback for tmux/git changes and missed watcher events.

## Why
Hydra CLI actions update `~/.hydra/sessions.json` immediately, but the VS Code sidebar could remain stale until the next 30s poll. Watching the session registry gives users near-immediate sidebar updates after worker/copilot lifecycle changes.

Fixes #56.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `git diff --check`
- Launched an isolated VS Code Extension Development Host and confirmed it loaded this development extension from the worktree.
