### PR TITLE
[codex] Add native Codex session sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,8 +300,9 @@
     "smoke:telemetry-posthog-real": "node out/smoke/telemetryPostHogRealSmoke.js",
     "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
     "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
+    "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields && npm run smoke:repo-registry"
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields && npm run smoke:share && npm run smoke:repo-registry"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -1,0 +1,408 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Command } from 'commander';
+import { TmuxBackendCore } from '../../core/tmux';
+import { SessionManager, type CopilotInfo, type WorkerInfo } from '../../core/sessionManager';
+import {
+  branchNameToSlug,
+  ensureWorktreesDir,
+  getRepoName,
+  getRepoRootFromPath,
+  listWorktrees,
+} from '../../core/git';
+import { exec } from '../../core/exec';
+import { shellQuote } from '../../core/shell';
+import { resolveAgentSessionFile, toCanonicalPath } from '../../core/path';
+import { resolveRepoInput } from '../../core/repoRegistry';
+import { createShareBundle, readBundle, writeBundle, type ShareableSession } from '../../share/bundle';
+import {
+  buildGcsBundleUrl,
+  downloadBundle,
+  downloadHttpBundle,
+  isHttpBundleUrl,
+  resolveShareRef,
+  uploadBundle,
+} from '../../share/gcpStorage';
+import { importCodexNativeSession } from '../../share/codexAdapter';
+import { ensureLocalBranchFromRemote, validateRepoMatch } from '../../share/repo';
+import type { HydraShareBundle, ShareHydraWorkerInfo } from '../../share/types';
+import { outputError, outputResult, type OutputOpts } from '../output';
+
+interface CreateShareOpts {
+  bucket?: string;
+  prefix?: string;
+  out?: string;
+  stop?: boolean;
+  yes?: boolean;
+}
+
+interface AcceptShareOpts {
+  bucket?: string;
+  prefix?: string;
+  repo: string;
+  session?: string;
+  agentCommand?: string;
+  force?: boolean;
+  allowMismatch?: boolean;
+}
+
+function expandPath(inputPath: string): string {
+  return toCanonicalPath(inputPath) || path.resolve(inputPath);
+}
+
+function findShareableSession(
+  state: Awaited<ReturnType<SessionManager['sync']>>,
+  sessionName: string,
+): ShareableSession | null {
+  const copilot = state.copilots[sessionName];
+  if (copilot) {
+    return { type: 'copilot', data: copilot };
+  }
+
+  const worker = state.workers[sessionName];
+  if (worker) {
+    return { type: 'worker', data: worker };
+  }
+
+  return null;
+}
+
+function warnUnencrypted(globalOpts: OutputOpts, yes?: boolean): void {
+  if (!globalOpts.quiet && !yes) {
+    console.error(
+      'Warning: Hydra share bundles are not encrypted yet. Anyone with access to this GCS object can read the Codex session contents.',
+    );
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForNativeSessionFile(
+  session: ShareableSession,
+  timeoutMs = 30000,
+): Promise<string | null> {
+  const sessionId = session.data.sessionId;
+  if (!sessionId) {
+    return null;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const sessionFile = resolveAgentSessionFile(session.data.agent, session.data.workdir, sessionId);
+    if (sessionFile) {
+      return sessionFile;
+    }
+    await sleep(1000);
+  }
+
+  return resolveAgentSessionFile(session.data.agent, session.data.workdir, sessionId);
+}
+
+async function stopSessionForExport(
+  backend: TmuxBackendCore,
+  session: ShareableSession,
+): Promise<void> {
+  await backend.sendMessage(session.data.sessionName, '/quit');
+  const sessionFile = await waitForNativeSessionFile(session);
+  if (!sessionFile) {
+    throw new Error(
+      `Timed out waiting for Codex to flush native session data for "${session.data.sessionName}". ` +
+      'Try again after the agent has exited.',
+    );
+  }
+}
+
+async function writeTempBundle(bundle: Awaited<ReturnType<typeof createShareBundle>>): Promise<string> {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hydra-share-'));
+  const bundlePath = path.join(tempDir, 'bundle.json');
+  writeBundle(bundlePath, bundle);
+  return bundlePath;
+}
+
+function resolveOutputPath(outputPath: string): string {
+  return expandPath(outputPath);
+}
+
+async function downloadTempBundle(gcsUrl: string): Promise<string> {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hydra-share-'));
+  const bundlePath = path.join(tempDir, 'bundle.json');
+  await downloadBundle(gcsUrl, bundlePath);
+  return bundlePath;
+}
+
+async function downloadTempHttpBundle(url: string): Promise<string> {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'hydra-share-'));
+  const bundlePath = path.join(tempDir, 'bundle.json');
+  await downloadHttpBundle(url, bundlePath);
+  return bundlePath;
+}
+
+async function resolveBundleInput(shareRef: string, opts: AcceptShareOpts): Promise<{ bundlePath: string; source: string }> {
+  if (isHttpBundleUrl(shareRef)) {
+    return {
+      bundlePath: await downloadTempHttpBundle(shareRef.trim()),
+      source: shareRef.trim(),
+    };
+  }
+
+  if (shareRef.trim().startsWith('gs://') || opts.bucket) {
+    const gcsUrl = resolveShareRef(shareRef, {
+      bucket: opts.bucket,
+      prefix: opts.prefix,
+    });
+    return {
+      bundlePath: await downloadTempBundle(gcsUrl),
+      source: gcsUrl,
+    };
+  }
+
+  const bundlePath = expandPath(shareRef);
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(`Share bundle file not found: ${bundlePath}`);
+  }
+  return { bundlePath, source: bundlePath };
+}
+
+async function ensureWorkerWorktree(
+  repoRoot: string,
+  worker: ShareHydraWorkerInfo,
+  backend: TmuxBackendCore,
+): Promise<{ workdir: string; slug: string }> {
+  await ensureLocalBranchFromRemote(repoRoot, worker.branch);
+
+  const worktrees = await listWorktrees(repoRoot);
+  const existing = worktrees.find(worktree => worktree.branch === worker.branch);
+  if (existing) {
+    return { workdir: existing.path, slug: worker.slug || branchNameToSlug(worker.branch, backend) };
+  }
+
+  const worktreesDir = await ensureWorktreesDir(repoRoot);
+  const baseSlug = worker.slug || branchNameToSlug(worker.branch, backend);
+  let slug = baseSlug;
+  let worktreePath = path.join(worktreesDir, slug);
+  let suffix = 1;
+  while (fs.existsSync(worktreePath)) {
+    suffix++;
+    slug = `${baseSlug}-${suffix}`;
+    worktreePath = path.join(worktreesDir, slug);
+  }
+
+  await exec(`git worktree add ${shellQuote(worktreePath)} ${shellQuote(worker.branch)}`, { cwd: repoRoot });
+  return { workdir: worktreePath, slug };
+}
+
+function buildImportedWorkerInfo(
+  source: ShareHydraWorkerInfo,
+  bundleSession: HydraShareBundle['hydraSession'],
+  repoRoot: string,
+  workdir: string,
+  slug: string,
+  sessionName: string,
+): WorkerInfo {
+  const now = new Date().toISOString();
+  return {
+    sessionName,
+    displayName: bundleSession.displayName || slug,
+    workerId: source.workerId,
+    repo: getRepoName(repoRoot),
+    repoRoot,
+    branch: source.branch,
+    slug,
+    status: 'stopped',
+    attached: false,
+    agent: 'codex',
+    workdir,
+    tmuxSession: sessionName,
+    createdAt: now,
+    lastSeenAt: now,
+    sessionId: bundleSession.agentSessionId,
+    copilotSessionName: null,
+  };
+}
+
+async function acceptCopilot(
+  sm: SessionManager,
+  backend: TmuxBackendCore,
+  bundle: HydraShareBundle,
+  repoRoot: string,
+  opts: AcceptShareOpts,
+): Promise<CopilotInfo> {
+  const sessionName = backend.sanitizeSessionName(opts.session || bundle.hydraSession.sessionName);
+  return sm.createCopilotAndFinalize({
+    workdir: repoRoot,
+    agentType: 'codex',
+    name: bundle.hydraSession.displayName,
+    sessionName,
+    agentCommand: opts.agentCommand,
+    resumeSessionId: bundle.hydraSession.agentSessionId,
+  });
+}
+
+async function acceptWorker(
+  sm: SessionManager,
+  backend: TmuxBackendCore,
+  bundle: HydraShareBundle,
+  repoRoot: string,
+  opts: AcceptShareOpts,
+): Promise<WorkerInfo> {
+  const worker = bundle.hydraSession.worker;
+  if (!worker) {
+    throw new Error('Worker share bundle is missing worker metadata');
+  }
+
+  const { workdir, slug } = await ensureWorkerWorktree(repoRoot, worker, backend);
+  const sessionName = backend.sanitizeSessionName(opts.session || bundle.hydraSession.sessionName);
+  const preservedWorkerInfo = buildImportedWorkerInfo(
+    worker,
+    bundle.hydraSession,
+    repoRoot,
+    workdir,
+    slug,
+    sessionName,
+  );
+
+  const { workerInfo, postCreatePromise } = await sm.createWorker({
+    repoRoot,
+    branchName: worker.branch,
+    agentType: 'codex',
+    agentCommand: opts.agentCommand,
+    resumeSessionId: bundle.hydraSession.agentSessionId,
+    preservedWorkerInfo,
+    notifyCopilot: false,
+    fetchMode: 'best-effort',
+  });
+  await postCreatePromise;
+  return workerInfo;
+}
+
+export function registerShareCommands(program: Command): void {
+  const share = program
+    .command('share')
+    .description('Share Hydra sessions through native agent resume data');
+
+  share
+    .command('create <session>')
+    .description('Create a native Codex share bundle locally or upload it to GCS')
+    .option('--bucket <bucket>', 'GCS bucket for share bundles')
+    .option('--prefix <prefix>', 'GCS object prefix', 'shares')
+    .option('--out <path>', 'Write the share bundle to a local file instead of GCS')
+    .option('--stop', 'Send /quit before exporting so Codex flushes native session data')
+    .option('--yes', 'Acknowledge that the bundle is not encrypted')
+    .action(async (sessionName: string, opts: CreateShareOpts) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        if (!!opts.bucket === !!opts.out) {
+          throw new Error('Specify exactly one destination: --out <path> for local testing or --bucket <bucket> for GCS.');
+        }
+        warnUnencrypted(globalOpts, opts.yes);
+
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const state = await sm.sync();
+        const session = findShareableSession(state, sessionName);
+        if (!session) {
+          throw new Error(`Session "${sessionName}" not found`);
+        }
+
+        if (opts.stop) {
+          await stopSessionForExport(backend, session);
+        }
+
+        const bundle = await createShareBundle(session);
+        const localBundlePath = opts.out ? resolveOutputPath(opts.out) : await writeTempBundle(bundle);
+        writeBundle(localBundlePath, bundle);
+
+        let destination = localBundlePath;
+        if (opts.bucket) {
+          destination = buildGcsBundleUrl({
+            bucket: opts.bucket,
+            prefix: opts.prefix,
+            shareId: bundle.shareId,
+          });
+          await uploadBundle(localBundlePath, destination);
+        }
+
+        outputResult(
+          {
+            status: 'created',
+            shareId: bundle.shareId,
+            destination,
+            session: session.data.sessionName,
+            type: session.type,
+            agent: 'codex',
+            agentSessionId: session.data.sessionId,
+            encryption: bundle.encryption,
+          },
+          globalOpts,
+          () => {
+            console.log(`Created share: ${bundle.shareId}`);
+            console.log(`  Location:   ${destination}`);
+            console.log(`  Session:    ${session.data.sessionName}`);
+            console.log(`  Type:       ${session.type}`);
+            console.log(`  Agent:      codex`);
+            console.log(`  Session ID: ${session.data.sessionId}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  share
+    .command('accept <share-ref>')
+    .description('Accept a local, GCS, or HTTPS native Codex share bundle and resume it locally')
+    .requiredOption('--repo <path>', 'Path to the local copy of the shared repository')
+    .option('--bucket <bucket>', 'GCS bucket when share-ref is a share ID')
+    .option('--prefix <prefix>', 'GCS object prefix', 'shares')
+    .option('--session <name>', 'Override the local Hydra session name')
+    .option('--agent-command <command>', 'Override the Codex command used to resume the shared session')
+    .option('--force', 'Overwrite an existing Codex session file if contents differ')
+    .option('--allow-mismatch', 'Allow repo remote or commit mismatch')
+    .action(async (shareRef: string, opts: AcceptShareOpts) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const { bundlePath: localBundlePath, source } = await resolveBundleInput(shareRef, opts);
+        const bundle = readBundle(localBundlePath);
+
+        const resolvedRepoInput = resolveRepoInput(opts.repo);
+        const repoRoot = await getRepoRootFromPath(expandPath(resolvedRepoInput.path));
+        await validateRepoMatch(bundle.repo, repoRoot, opts.allowMismatch);
+        const nativeImport = importCodexNativeSession(bundle.agents.codex, { force: opts.force });
+
+        const backend = new TmuxBackendCore();
+        const sm = new SessionManager(backend);
+        const result = bundle.hydraSession.type === 'copilot'
+          ? await acceptCopilot(sm, backend, bundle, repoRoot, opts)
+          : await acceptWorker(sm, backend, bundle, repoRoot, opts);
+
+        outputResult(
+          {
+            status: 'accepted',
+            shareId: bundle.shareId,
+            source,
+            type: bundle.hydraSession.type,
+            session: result.sessionName,
+            agent: 'codex',
+            agentSessionId: bundle.hydraSession.agentSessionId,
+            workdir: result.workdir,
+            nativeSessionFiles: nativeImport,
+          },
+          globalOpts,
+          () => {
+            console.log(`Accepted share: ${bundle.shareId}`);
+            console.log(`  Source:     ${source}`);
+            console.log(`  Session:    ${result.sessionName}`);
+            console.log(`  Type:       ${bundle.hydraSession.type}`);
+            console.log(`  Agent:      codex`);
+            console.log(`  Workdir:    ${result.workdir}`);
+            console.log(`  Session ID: ${bundle.hydraSession.agentSessionId}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { registerRepoCommands } from './commands/repo';
 import { registerDoctorCommand } from './commands/doctor';
 import { registerWhoamiCommand } from './commands/whoami';
 import { registerTestCommand } from './commands/test';
+import { registerShareCommands } from './commands/share';
 import { peekTelemetry } from '../core/telemetry';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
@@ -57,5 +58,6 @@ registerRepoCommands(program);
 registerDoctorCommand(program);
 registerWhoamiCommand(program);
 registerTestCommand(program);
+registerShareCommands(program);
 
 program.parse();

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -61,7 +61,7 @@ export const CLAUDE_READY_DELAY_MS = 5000;
  */
 export const AGENT_READY_PATTERNS: Record<string, RegExp> = {
   claude: /⏵/,
-  codex: /⏵/,
+  codex: /⏵|(?:^|\n)\s*›\s*/m,
   gemini: /⏵/,
 };
 
@@ -70,6 +70,13 @@ export const AGENT_READY_PATTERNS: Record<string, RegExp> = {
  * When detected, send Enter to accept it before waiting for the actual input prompt.
  */
 export const CLAUDE_TRUST_PROMPT_PATTERN = /trust this folder/;
+
+/**
+ * Codex can ask which working directory to use when a session is resumed on
+ * another machine/path. Hydra passes -C where possible, but accepts the prompt
+ * as a fallback for older/newer Codex picker flows.
+ */
+export const CODEX_RESUME_CWD_PROMPT_PATTERN = /Choose working directory to resume this session/i;
 
 /** Maximum time (ms) to wait for agent readiness before giving up */
 export const AGENT_READY_TIMEOUT_MS = 30000;
@@ -97,6 +104,7 @@ export function buildAgentResumeCommand(
   agentType: string,
   agentBinary: string,
   sessionId: string,
+  workdir?: string,
 ): string | null {
   const quotedSessionId = shellQuoteForDisplay(sessionId);
   switch (agentType) {
@@ -105,7 +113,8 @@ export function buildAgentResumeCommand(
     }
     case 'codex': {
       const command = ensureCommandFlag(agentBinary, AGENT_YOLO_FLAGS.codex);
-      return appendCommandArgs(command, 'resume', quotedSessionId);
+      const cdArgs = workdir ? ['-C', shellQuoteForDisplay(workdir)] : [];
+      return appendCommandArgs(command, 'resume', ...cdArgs, quotedSessionId);
     }
     case 'gemini':
       return appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`);

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -4,12 +4,12 @@ import { randomUUID } from 'crypto';
 import { MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig } from './hydraGlobalConfig';
-import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN } from './agentConfig';
+import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN } from './agentConfig';
 import { exec, resolveCommandPath } from './exec';
 import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 
-const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 15000;
+const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 75000;
 const SESSION_STATE_LOCK_TIMEOUT_MS = 10000;
 const SESSION_STATE_LOCK_RETRY_MS = 50;
 const SESSION_STATE_LOCK_STALE_MS = 120000;
@@ -480,7 +480,7 @@ export class SessionManager {
 
     if (isResume) {
       sessionId = opts.resumeSessionId!;
-      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId);
+      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId, worktreePath);
       if (!resumeCmd) {
         throw new Error(`Agent "${agentType}" does not support session resume`);
       }
@@ -616,7 +616,7 @@ export class SessionManager {
     // Resume from stored session ID if available; otherwise fresh start
     const storedSessionId = existingWorker.sessionId;
     const resumeCmd = storedSessionId
-      ? buildAgentResumeCommand(agent, command, storedSessionId)
+      ? buildAgentResumeCommand(agent, command, storedSessionId, existingWorker.workdir)
       : null;
 
     let workerInfo: WorkerInfo;
@@ -703,7 +703,7 @@ export class SessionManager {
 
     if (isResume) {
       sessionId = opts.resumeSessionId!;
-      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId);
+      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId, opts.workdir);
       if (!resumeCmd) {
         throw new Error(`Agent "${agentType}" does not support session resume`);
       }
@@ -1605,6 +1605,7 @@ export class SessionManager {
 
     const deadline = Date.now() + AGENT_READY_TIMEOUT_MS;
     let trustPromptHandled = false;
+    let codexResumeCwdPromptHandled = false;
 
     // Initial delay before first poll (agent needs time to start the process)
     await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
@@ -1613,16 +1614,31 @@ export class SessionManager {
       try {
         const output = await this.backend.capturePane(sessionName, 50);
 
-        if (pattern.test(output)) {
-          // Brief settle delay — TUI input handler may not be fully interactive yet
-          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
-          return;
-        }
-
         // Handle trust prompt: send Enter to accept "Yes, I trust this folder"
         if (!trustPromptHandled && CLAUDE_TRUST_PROMPT_PATTERN.test(output)) {
           await this.backend.sendKeys(sessionName, '');
           trustPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        // Handle Codex resume cwd picker: accept the default selection and keep
+        // polling until the actual idle input prompt appears.
+        if (
+          agentType === 'codex' &&
+          !codexResumeCwdPromptHandled &&
+          CODEX_RESUME_CWD_PROMPT_PATTERN.test(output)
+        ) {
+          await this.backend.sendKeys(sessionName, '');
+          codexResumeCwdPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        if (pattern.test(output)) {
+          // Brief settle delay — TUI input handler may not be fully interactive yet
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          return;
         }
       } catch {
         // Session may not be ready yet — keep polling
@@ -1648,24 +1664,30 @@ export class SessionManager {
     if (!config) return null;
 
     try {
-      // For Codex, accept the trust prompt first
+      // For Codex, wait for the TUI prompt before sending /status. Starting
+      // with Codex 0.129, the trust prompt and first paint can take long enough
+      // that fixed sleeps race the input handler and lose the status command.
       if (agentType === 'codex') {
-        await this.sleep(3000);
-        await this.backend.sendKeys(sessionName, ''); // Enter to accept trust prompt
-        await this.sleep(config.readyDelayMs);
+        await this.waitForAgentReady(sessionName, agentType);
       } else {
         await this.sleep(config.readyDelayMs);
+      }
+
+      const existingOutput = await this.backend.capturePane(sessionName, 400);
+      const existingMatch = existingOutput.match(config.sessionIdPattern);
+      if (existingMatch?.[1]) {
+        return existingMatch[1];
       }
 
       // Send status slash command (use sendMessage for reliable Enter delivery to TUIs)
       await this.backend.sendMessage(sessionName, config.statusCommand);
 
       // Poll pane output until session ID is found
-      const maxAttempts = 10;
+      const maxAttempts = agentType === 'codex' ? 30 : 10;
       const pollInterval = config.captureDelayMs;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         await this.sleep(pollInterval);
-        const output = await this.backend.capturePane(sessionName, 200);
+        const output = await this.backend.capturePane(sessionName, 400);
         const match = output.match(config.sessionIdPattern);
         if (match?.[1]) {
           return match[1];
@@ -1936,7 +1958,7 @@ export class SessionManager {
 
       // Resume or fresh start
       const resumeCmd = storedSessionId
-        ? buildAgentResumeCommand(agentType, agentCommand, storedSessionId)
+        ? buildAgentResumeCommand(agentType, agentCommand, storedSessionId, worktreePath)
         : null;
 
       let postCreatePromise: Promise<void>;

--- a/src/share/bundle.ts
+++ b/src/share/bundle.ts
@@ -1,0 +1,119 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveAgentSessionFile } from '../core/path';
+import type { CopilotInfo, WorkerInfo } from '../core/sessionManager';
+import { exportCodexNativeSession } from './codexAdapter';
+import { collectRepoInfo } from './repo';
+import type { HydraShareBundle, ShareHydraSessionInfo } from './types';
+
+export type ShareableSession =
+  | { type: 'copilot'; data: CopilotInfo }
+  | { type: 'worker'; data: WorkerInfo };
+
+export function generateShareId(): string {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+function assertCodexSession(session: ShareableSession): string {
+  if (session.data.agent !== 'codex') {
+    throw new Error(`Only Codex sessions can be shared natively. Session agent is "${session.data.agent}".`);
+  }
+  if (!session.data.sessionId) {
+    throw new Error(`Session "${session.data.sessionName}" does not have a captured Codex session ID yet.`);
+  }
+  const sessionFile = resolveAgentSessionFile('codex', session.data.workdir, session.data.sessionId);
+  if (!sessionFile) {
+    throw new Error(`Codex session file not found for session "${session.data.sessionName}".`);
+  }
+  return session.data.sessionId;
+}
+
+function buildHydraSessionInfo(session: ShareableSession, sessionId: string): ShareHydraSessionInfo {
+  if (session.type === 'copilot') {
+    return {
+      type: 'copilot',
+      sessionName: session.data.sessionName,
+      displayName: session.data.displayName || session.data.sessionName,
+      agent: 'codex',
+      workdir: session.data.workdir,
+      agentSessionId: sessionId,
+    };
+  }
+
+  return {
+    type: 'worker',
+    sessionName: session.data.sessionName,
+    displayName: session.data.displayName || session.data.slug || session.data.sessionName,
+    agent: 'codex',
+    workdir: session.data.workdir,
+    agentSessionId: sessionId,
+    worker: {
+      workerId: session.data.workerId,
+      repo: session.data.repo,
+      repoRoot: session.data.repoRoot,
+      branch: session.data.branch,
+      slug: session.data.slug,
+      copilotSessionName: session.data.copilotSessionName,
+    },
+  };
+}
+
+export async function createShareBundle(
+  session: ShareableSession,
+  shareId = generateShareId(),
+): Promise<HydraShareBundle> {
+  const sessionId = assertCodexSession(session);
+  const repo = await collectRepoInfo(session.data.workdir);
+
+  return {
+    schemaVersion: 1,
+    shareId,
+    createdAt: new Date().toISOString(),
+    encryption: {
+      enabled: false,
+      algorithm: null,
+      keyHint: null,
+    },
+    repo,
+    hydraSession: buildHydraSessionInfo(session, sessionId),
+    agents: {
+      codex: exportCodexNativeSession(session.data.workdir, sessionId),
+    },
+  };
+}
+
+export function writeBundle(filePath: string, bundle: HydraShareBundle): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(bundle, null, 2)}\n`, 'utf-8');
+}
+
+export function readBundle(filePath: string): HydraShareBundle {
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as HydraShareBundle;
+  validateBundle(parsed);
+  return parsed;
+}
+
+export function validateBundle(bundle: HydraShareBundle): void {
+  if (!bundle || typeof bundle !== 'object') {
+    throw new Error('Invalid share bundle');
+  }
+  if (bundle.schemaVersion !== 1) {
+    throw new Error(`Unsupported share bundle schema version: ${bundle.schemaVersion}`);
+  }
+  if (bundle.encryption?.enabled) {
+    throw new Error('Encrypted share bundles are not supported by this Hydra version yet.');
+  }
+  if (!bundle.shareId) {
+    throw new Error('Share bundle is missing shareId');
+  }
+  if (bundle.hydraSession?.agent !== 'codex') {
+    throw new Error('Only Codex share bundles are supported');
+  }
+  if (!bundle.hydraSession?.agentSessionId) {
+    throw new Error('Share bundle is missing agentSessionId');
+  }
+  if (bundle.agents?.codex?.adapter !== 'codex') {
+    throw new Error('Share bundle is missing Codex native session payload');
+  }
+}

--- a/src/share/codexAdapter.ts
+++ b/src/share/codexAdapter.ts
@@ -1,0 +1,126 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveAgentSessionFile } from '../core/path';
+import type { CodexNativeSessionPayload, NativeSessionFile } from './types';
+
+export interface ImportCodexSessionOptions {
+  force?: boolean;
+}
+
+export interface ImportCodexSessionResult {
+  written: string[];
+  skipped: string[];
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function toHomeRelativePath(filePath: string): string {
+  const home = path.resolve(os.homedir());
+  const absoluteFilePath = path.resolve(filePath);
+  const relative = path.relative(home, absoluteFilePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Codex session file is outside the current home directory: ${filePath}`);
+  }
+  return relative;
+}
+
+function resolveHomeRelativePath(relativePath: string): string {
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    throw new Error(`Invalid native session path in bundle: ${relativePath}`);
+  }
+
+  const home = path.resolve(os.homedir());
+  const absolutePath = path.resolve(home, relativePath);
+  const normalizedRelative = path.relative(home, absolutePath);
+  if (!normalizedRelative || normalizedRelative.startsWith('..') || path.isAbsolute(normalizedRelative)) {
+    throw new Error(`Native session path escapes the home directory: ${relativePath}`);
+  }
+  return absolutePath;
+}
+
+function readNativeSessionFile(filePath: string): NativeSessionFile {
+  const contents = fs.readFileSync(filePath);
+  const stat = fs.statSync(filePath);
+  return {
+    homeRelativePath: toHomeRelativePath(filePath),
+    mode: stat.mode & 0o777,
+    size: contents.length,
+    sha256: sha256(contents),
+    contentBase64: contents.toString('base64'),
+  };
+}
+
+export function exportCodexNativeSession(
+  workdir: string,
+  sessionId: string,
+): CodexNativeSessionPayload {
+  const sessionFile = resolveAgentSessionFile('codex', workdir, sessionId);
+  if (!sessionFile) {
+    throw new Error(`Codex session file not found for session ID "${sessionId}"`);
+  }
+
+  return {
+    adapter: 'codex',
+    adapterVersion: 1,
+    sessionId,
+    files: [readNativeSessionFile(sessionFile)],
+  };
+}
+
+export function importCodexNativeSession(
+  payload: CodexNativeSessionPayload,
+  options: ImportCodexSessionOptions = {},
+): ImportCodexSessionResult {
+  if (payload.adapter !== 'codex') {
+    throw new Error(`Unsupported native session adapter: ${payload.adapter}`);
+  }
+  if (payload.adapterVersion !== 1) {
+    throw new Error(`Unsupported Codex adapter version: ${payload.adapterVersion}`);
+  }
+  if (!payload.sessionId) {
+    throw new Error('Codex native session payload is missing sessionId');
+  }
+
+  const written: string[] = [];
+  const skipped: string[] = [];
+
+  for (const file of payload.files) {
+    const contents = Buffer.from(file.contentBase64, 'base64');
+    const actualHash = sha256(contents);
+    if (actualHash !== file.sha256) {
+      throw new Error(`Hash mismatch for native session file: ${file.homeRelativePath}`);
+    }
+    if (contents.length !== file.size) {
+      throw new Error(`Size mismatch for native session file: ${file.homeRelativePath}`);
+    }
+
+    const targetPath = resolveHomeRelativePath(file.homeRelativePath);
+    if (fs.existsSync(targetPath)) {
+      const existingHash = sha256(fs.readFileSync(targetPath));
+      if (existingHash === file.sha256) {
+        skipped.push(targetPath);
+        continue;
+      }
+      if (!options.force) {
+        throw new Error(
+          `Codex session file already exists with different contents: ${targetPath}. Use --force to overwrite it.`,
+        );
+      }
+    }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, contents, { mode: file.mode || 0o600 });
+    try {
+      fs.chmodSync(targetPath, file.mode || 0o600);
+    } catch {
+      // Best-effort: some filesystems ignore chmod.
+    }
+    written.push(targetPath);
+  }
+
+  return { written, skipped };
+}

--- a/src/share/gcpStorage.ts
+++ b/src/share/gcpStorage.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
+import * as path from 'path';
+import { exec, resolveCommandPath } from '../core/exec';
+import { shellQuote } from '../core/shell';
+
+export interface GcsLocationOptions {
+  bucket: string;
+  prefix?: string;
+  shareId: string;
+}
+
+function stripSlashes(value: string): string {
+  return value.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+export function buildGcsBundleUrl(options: GcsLocationOptions): string {
+  const bucket = options.bucket.replace(/^gs:\/\//, '').replace(/\/+$/, '');
+  if (!bucket) {
+    throw new Error('GCS bucket is required');
+  }
+  const prefix = stripSlashes(options.prefix || 'shares');
+  const key = [prefix, options.shareId, 'bundle.json'].filter(Boolean).join('/');
+  return `gs://${bucket}/${key}`;
+}
+
+export function resolveShareRef(
+  shareRef: string,
+  options: { bucket?: string; prefix?: string },
+): string {
+  const trimmed = shareRef.trim();
+  if (trimmed.startsWith('gs://')) {
+    return trimmed;
+  }
+  if (!options.bucket) {
+    throw new Error('A GCS bucket is required when share ref is not a gs:// URL');
+  }
+  return buildGcsBundleUrl({
+    bucket: options.bucket,
+    prefix: options.prefix,
+    shareId: trimmed,
+  });
+}
+
+async function getStorageCopyCommand(source: string, target: string): Promise<string> {
+  const gcloud = await resolveCommandPath('gcloud');
+  if (gcloud) {
+    return `${shellQuote(gcloud)} storage cp ${shellQuote(source)} ${shellQuote(target)}`;
+  }
+
+  const gsutil = await resolveCommandPath('gsutil');
+  if (gsutil) {
+    return `${shellQuote(gsutil)} cp ${shellQuote(source)} ${shellQuote(target)}`;
+  }
+
+  throw new Error('Neither gcloud nor gsutil was found on PATH. Install the Google Cloud CLI to use Hydra share.');
+}
+
+export async function uploadBundle(localBundlePath: string, gcsUrl: string): Promise<void> {
+  const command = await getStorageCopyCommand(localBundlePath, gcsUrl);
+  await exec(command, { cwd: path.dirname(localBundlePath) });
+}
+
+export async function downloadBundle(gcsUrl: string, localBundlePath: string): Promise<void> {
+  const command = await getStorageCopyCommand(gcsUrl, localBundlePath);
+  await exec(command, { cwd: path.dirname(localBundlePath) });
+}
+
+export function isHttpBundleUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value.trim());
+}
+
+export async function downloadHttpBundle(url: string, localBundlePath: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(localBundlePath), { recursive: true });
+  await downloadHttpBundleWithRedirects(url, localBundlePath, 0);
+}
+
+function downloadHttpBundleWithRedirects(
+  url: string,
+  localBundlePath: string,
+  redirects: number,
+): Promise<void> {
+  if (redirects > 5) {
+    return Promise.reject(new Error(`Too many redirects while downloading share bundle: ${url}`));
+  }
+
+  const parsed = new URL(url);
+  const client = parsed.protocol === 'https:' ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const request = client.get(parsed, (response) => {
+      const statusCode = response.statusCode || 0;
+      const location = response.headers.location;
+
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        response.resume();
+        const nextUrl = new URL(location, parsed).toString();
+        downloadHttpBundleWithRedirects(nextUrl, localBundlePath, redirects + 1)
+          .then(resolve, reject);
+        return;
+      }
+
+      if (statusCode < 200 || statusCode >= 300) {
+        response.resume();
+        reject(new Error(`Failed to download share bundle from ${url}: HTTP ${statusCode}`));
+        return;
+      }
+
+      const file = fs.createWriteStream(localBundlePath, { mode: 0o600 });
+      file.on('error', reject);
+      file.on('finish', () => {
+        file.close((error) => {
+          if (error) reject(error); else resolve();
+        });
+      });
+      response.pipe(file);
+    });
+
+    request.on('error', reject);
+    request.setTimeout(30000, () => {
+      request.destroy(new Error(`Timed out downloading share bundle from ${url}`));
+    });
+  });
+}

--- a/src/share/repo.ts
+++ b/src/share/repo.ts
@@ -1,0 +1,144 @@
+import { exec } from '../core/exec';
+import { getRepoName, getRepoRootFromPath, localBranchExists, validateBranchName } from '../core/git';
+import { shellQuote } from '../core/shell';
+import type { ShareRepoInfo } from './types';
+
+function emptyRepoInfo(): ShareRepoInfo {
+  return {
+    repoName: null,
+    repoRoot: null,
+    branch: null,
+    headCommit: null,
+    remotes: {},
+  };
+}
+
+async function execOrNull(command: string, cwd: string): Promise<string | null> {
+  try {
+    const output = await exec(command, { cwd });
+    return output || null;
+  } catch {
+    return null;
+  }
+}
+
+async function collectRemotes(repoRoot: string): Promise<Record<string, string>> {
+  const namesOutput = await execOrNull('git remote', repoRoot);
+  if (!namesOutput) {
+    return {};
+  }
+
+  const remotes: Record<string, string> = {};
+  for (const name of namesOutput.split(/\r?\n/).map(line => line.trim()).filter(Boolean)) {
+    const url = await execOrNull(`git remote get-url ${shellQuote(name)}`, repoRoot);
+    if (url) {
+      remotes[name] = url;
+    }
+  }
+  return remotes;
+}
+
+export async function collectRepoInfo(workdir: string): Promise<ShareRepoInfo> {
+  let repoRoot: string;
+  try {
+    repoRoot = await getRepoRootFromPath(workdir);
+  } catch {
+    return emptyRepoInfo();
+  }
+
+  const [branch, headCommit, remotes] = await Promise.all([
+    execOrNull('git branch --show-current', repoRoot),
+    execOrNull('git rev-parse HEAD', repoRoot),
+    collectRemotes(repoRoot),
+  ]);
+
+  return {
+    repoName: getRepoName(repoRoot),
+    repoRoot,
+    branch,
+    headCommit,
+    remotes,
+  };
+}
+
+function normalizeRemoteUrl(url: string): string {
+  let value = url.trim();
+  const sshMatch = value.match(/^git@([^:]+):(.+)$/);
+  if (sshMatch) {
+    value = `${sshMatch[1]}/${sshMatch[2]}`;
+  } else {
+    value = value.replace(/^https?:\/\//, '').replace(/^ssh:\/\//, '');
+    value = value.replace(/^[^@/]+@/, '');
+  }
+  value = value.replace(/\.git$/i, '');
+  return value.toLowerCase();
+}
+
+function hasCommonRemote(left: Record<string, string>, right: Record<string, string>): boolean {
+  const leftUrls = new Set(Object.values(left).map(normalizeRemoteUrl).filter(Boolean));
+  return Object.values(right).some(url => leftUrls.has(normalizeRemoteUrl(url)));
+}
+
+async function commitExists(repoRoot: string, commit: string): Promise<boolean> {
+  try {
+    await exec(`git cat-file -e ${shellQuote(`${commit}^{commit}`)}`, { cwd: repoRoot });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function validateRepoMatch(
+  bundleRepo: ShareRepoInfo,
+  targetRepoRoot: string,
+  allowMismatch = false,
+): Promise<ShareRepoInfo> {
+  const targetRepo = await collectRepoInfo(targetRepoRoot);
+  if (allowMismatch) {
+    return targetRepo;
+  }
+
+  if (!targetRepo.repoRoot) {
+    throw new Error(`Target repo path is not a git repository: ${targetRepoRoot}`);
+  }
+
+  if (bundleRepo.repoName && targetRepo.repoName && bundleRepo.repoName !== targetRepo.repoName) {
+    throw new Error(
+      `Repo name mismatch: share is for "${bundleRepo.repoName}", target is "${targetRepo.repoName}". Use --allow-mismatch to override.`,
+    );
+  }
+
+  const bundleRemoteCount = Object.keys(bundleRepo.remotes || {}).length;
+  const targetRemoteCount = Object.keys(targetRepo.remotes || {}).length;
+  if (bundleRemoteCount > 0 && targetRemoteCount > 0 && !hasCommonRemote(bundleRepo.remotes, targetRepo.remotes)) {
+    throw new Error('Repo remote mismatch. Use --allow-mismatch to override.');
+  }
+
+  if (bundleRepo.headCommit && !(await commitExists(targetRepo.repoRoot, bundleRepo.headCommit))) {
+    throw new Error(
+      `Target repo does not contain shared HEAD commit ${bundleRepo.headCommit}. Use --allow-mismatch to override.`,
+    );
+  }
+
+  return targetRepo;
+}
+
+export async function ensureLocalBranchFromRemote(repoRoot: string, branchName: string): Promise<void> {
+  const validationError = validateBranchName(branchName);
+  if (validationError) {
+    throw new Error(validationError);
+  }
+
+  if (await localBranchExists(repoRoot, branchName)) {
+    return;
+  }
+
+  const remoteRef = `origin/${branchName}`;
+  try {
+    await exec(`git rev-parse --verify ${shellQuote(remoteRef)}`, { cwd: repoRoot });
+  } catch {
+    throw new Error(`Shared worker branch "${branchName}" does not exist locally or at origin.`);
+  }
+
+  await exec(`git branch ${shellQuote(branchName)} ${shellQuote(remoteRef)}`, { cwd: repoRoot });
+}

--- a/src/share/types.ts
+++ b/src/share/types.ts
@@ -1,0 +1,61 @@
+export type ShareSessionType = 'copilot' | 'worker';
+
+export interface ShareEncryptionInfo {
+  enabled: false;
+  algorithm: null;
+  keyHint: null;
+}
+
+export interface ShareRepoInfo {
+  repoName: string | null;
+  repoRoot: string | null;
+  branch: string | null;
+  headCommit: string | null;
+  remotes: Record<string, string>;
+}
+
+export interface ShareHydraWorkerInfo {
+  workerId: number;
+  repo: string;
+  repoRoot: string;
+  branch: string;
+  slug: string;
+  copilotSessionName: string | null;
+}
+
+export interface ShareHydraSessionInfo {
+  type: ShareSessionType;
+  sessionName: string;
+  displayName: string;
+  agent: 'codex';
+  workdir: string;
+  agentSessionId: string;
+  worker?: ShareHydraWorkerInfo;
+}
+
+export interface NativeSessionFile {
+  homeRelativePath: string;
+  mode: number;
+  size: number;
+  sha256: string;
+  contentBase64: string;
+}
+
+export interface CodexNativeSessionPayload {
+  adapter: 'codex';
+  adapterVersion: 1;
+  sessionId: string;
+  files: NativeSessionFile[];
+}
+
+export interface HydraShareBundle {
+  schemaVersion: 1;
+  shareId: string;
+  createdAt: string;
+  encryption: ShareEncryptionInfo;
+  repo: ShareRepoInfo;
+  hydraSession: ShareHydraSessionInfo;
+  agents: {
+    codex: CodexNativeSessionPayload;
+  };
+}

--- a/src/smoke/codexBypassSmoke.ts
+++ b/src/smoke/codexBypassSmoke.ts
@@ -232,13 +232,15 @@ async function main(): Promise<void> {
       backend.sendKeysCalls[0]?.keys,
       `${smokeCodexCommand} ${BYPASS_FLAG}`,
     );
-    assert.ok(
+    assert.equal(
       backend.sendMessageCalls.some(call => call.sessionName === 'copilot-fresh' && call.message === '/status'),
+      false,
     );
     assert.equal(copilot.sessionId, '11111111-1111-4111-8111-111111111111');
   }
 
   {
+    const copilotRestoredWorkdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-copilot-restored-'));
     const archive = readJson<{ entries: Array<Record<string, unknown>> }>(archiveFile, { entries: [] });
     archive.entries.push({
       type: 'copilot',
@@ -251,7 +253,7 @@ async function main(): Promise<void> {
         status: 'stopped',
         attached: false,
         agent: 'codex',
-        workdir: fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-copilot-restored-')),
+        workdir: copilotRestoredWorkdir,
         tmuxSession: 'copilot-restored',
         createdAt: new Date().toISOString(),
         lastSeenAt: new Date().toISOString(),
@@ -270,7 +272,7 @@ async function main(): Promise<void> {
 
     assert.equal(
       command,
-      `${smokeCodexCommand} ${BYPASS_FLAG} resume '22222222-2222-4222-8222-222222222222'`,
+      `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${copilotRestoredWorkdir}' '22222222-2222-4222-8222-222222222222'`,
     );
     assert.ok(
       backend.capturePaneCalls.some(call => call.sessionName === 'copilot-restored'),
@@ -319,7 +321,7 @@ async function main(): Promise<void> {
     const command = lastSendKeysFor(backend, 'worker-start');
     assert.equal(
       command,
-      `${smokeCodexCommand} ${BYPASS_FLAG} resume '33333333-3333-4333-8333-333333333333'`,
+      `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${workerWorkdir}' '33333333-3333-4333-8333-333333333333'`,
     );
     assert.ok(
       backend.capturePaneCalls.some(call => call.sessionName === 'worker-start'),
@@ -382,7 +384,7 @@ async function main(): Promise<void> {
       const command = lastSendKeysFor(backend, 'worker-restored');
       assert.equal(
         command,
-        `${smokeCodexCommand} ${BYPASS_FLAG} resume '44444444-4444-4444-8444-444444444444'`,
+        `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${restoredWorktree}' '44444444-4444-4444-8444-444444444444'`,
       );
       assert.equal(result.workerInfo.sessionName, 'worker-restored');
       assert.equal(result.workerInfo.sessionId, '44444444-4444-4444-8444-444444444444');
@@ -477,7 +479,7 @@ async function main(): Promise<void> {
       assert.equal(result.workerInfo.workdir, fooSlashBarWorktree);
       assert.equal(
         lastSendKeysFor(backend, 'repo-ns_foo-bar-2'),
-        `${smokeCodexCommand} ${BYPASS_FLAG} resume 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'`,
+        `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${fooSlashBarWorktree}' 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'`,
       );
       assert.ok(
         backend.sendMessageCalls.some(call =>

--- a/src/smoke/shareBundleSmoke.ts
+++ b/src/smoke/shareBundleSmoke.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { WorkerInfo } from '../core/sessionManager';
+import { createShareBundle, readBundle, writeBundle } from '../share/bundle';
+import { importCodexNativeSession } from '../share/codexAdapter';
+import { downloadHttpBundle } from '../share/gcpStorage';
+
+const SESSION_ID = '019deccc-251c-7192-bf0d-e8ff36a0bb5e';
+
+function withHome<T>(home: string, fn: () => T): T {
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    return fn();
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+  }
+}
+
+async function withHomeAsync<T>(home: string, fn: () => Promise<T>): Promise<T> {
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    return await fn();
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevUserProfile;
+  }
+}
+
+function runGit(repoRoot: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8' }).trim();
+}
+
+function createRepo(parent: string): string {
+  const repoRoot = path.join(parent, 'repo');
+  fs.mkdirSync(repoRoot, { recursive: true });
+  runGit(repoRoot, ['init', '-b', 'main']);
+  runGit(repoRoot, ['config', 'user.email', 'hydra@example.com']);
+  runGit(repoRoot, ['config', 'user.name', 'Hydra Smoke']);
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), '# smoke\n', 'utf-8');
+  runGit(repoRoot, ['add', 'README.md']);
+  runGit(repoRoot, ['commit', '-m', 'initial']);
+  runGit(repoRoot, ['remote', 'add', 'origin', 'git@github.com:example/repo.git']);
+  return repoRoot;
+}
+
+function writeCodexSession(home: string, contents = '{"type":"session"}\n'): string {
+  const sessionFile = path.join(
+    home,
+    '.codex',
+    'sessions',
+    '2026',
+    '05',
+    '03',
+    `rollout-2026-05-03T00-44-55-${SESSION_ID}.jsonl`,
+  );
+  fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+  fs.writeFileSync(sessionFile, contents, 'utf-8');
+  return sessionFile;
+}
+
+function buildWorker(repoRoot: string): WorkerInfo {
+  return {
+    sessionName: 'repo-feat-share',
+    displayName: 'feat-share',
+    workerId: 7,
+    repo: 'repo',
+    repoRoot,
+    branch: 'main',
+    slug: 'feat-share',
+    status: 'running',
+    attached: false,
+    agent: 'codex',
+    workdir: repoRoot,
+    tmuxSession: 'repo-feat-share',
+    createdAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    sessionId: SESSION_ID,
+    copilotSessionName: null,
+  };
+}
+
+async function withBundleServer<T>(bundlePath: string, fn: (url: string) => Promise<T>): Promise<T> {
+  const server = http.createServer((request, response) => {
+    if (request.url !== '/bundle.json') {
+      response.writeHead(404);
+      response.end('not found');
+      return;
+    }
+
+    response.writeHead(200, { 'content-type': 'application/json' });
+    fs.createReadStream(bundlePath).pipe(response);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('HTTP smoke server did not expose a TCP address');
+    }
+    return await fn(`http://127.0.0.1:${address.port}/bundle.json`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error); else resolve();
+      });
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-share-smoke-'));
+  const sourceHome = path.join(tempDir, 'source-home');
+  const targetHome = path.join(tempDir, 'target-home');
+  fs.mkdirSync(sourceHome, { recursive: true });
+  fs.mkdirSync(targetHome, { recursive: true });
+
+  try {
+    const repoRoot = createRepo(tempDir);
+    const sourceSessionFile = writeCodexSession(sourceHome);
+
+    const bundle = await withHomeAsync(sourceHome, () => createShareBundle({
+      type: 'worker',
+      data: buildWorker(repoRoot),
+    }, 'share-smoke'));
+
+    assert.equal(bundle.schemaVersion, 1);
+    assert.equal(bundle.shareId, 'share-smoke');
+    assert.equal(bundle.encryption.enabled, false);
+    assert.equal(bundle.hydraSession.type, 'worker');
+    assert.equal(bundle.hydraSession.agentSessionId, SESSION_ID);
+    assert.equal(bundle.agents.codex.files.length, 1);
+    assert.equal(bundle.agents.codex.files[0]?.homeRelativePath, path.relative(sourceHome, sourceSessionFile));
+    assert.equal(bundle.repo.repoName, 'repo');
+    assert.equal(bundle.repo.branch, 'main');
+    assert.equal(bundle.repo.remotes.origin, 'git@github.com:example/repo.git');
+
+    const bundlePath = path.join(tempDir, 'bundle.json');
+    writeBundle(bundlePath, bundle);
+    assert.equal(readBundle(bundlePath).shareId, 'share-smoke');
+
+    const httpDownloadedBundlePath = path.join(tempDir, 'downloaded-bundle.json');
+    await withBundleServer(bundlePath, async (url) => {
+      await downloadHttpBundle(url, httpDownloadedBundlePath);
+    });
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(httpDownloadedBundlePath, 'utf-8')),
+      JSON.parse(fs.readFileSync(bundlePath, 'utf-8')),
+    );
+
+    const firstImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex));
+    assert.equal(firstImport.written.length, 1);
+    assert.equal(firstImport.skipped.length, 0);
+    assert.equal(fs.readFileSync(firstImport.written[0]!, 'utf-8'), fs.readFileSync(sourceSessionFile, 'utf-8'));
+
+    const secondImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex));
+    assert.equal(secondImport.written.length, 0);
+    assert.equal(secondImport.skipped.length, 1);
+
+    fs.writeFileSync(firstImport.written[0]!, 'conflict\n', 'utf-8');
+    assert.throws(
+      () => withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex)),
+      /already exists with different contents/,
+    );
+
+    const forcedImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex, { force: true }));
+    assert.equal(forcedImport.written.length, 1);
+    assert.equal(fs.readFileSync(forcedImport.written[0]!, 'utf-8'), fs.readFileSync(sourceSessionFile, 'utf-8'));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  console.log('shareBundleSmoke: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a native Codex session sharing MVP for Hydra copilots and workers.

The feature exports the Codex native JSONL transcript into an unencrypted share bundle, uploads it to GCS or writes it locally, then imports that bundle on another machine and resumes Codex using the native session id.

## Usage

Create a local bundle for testing:

```bash
hydra share create <session> --out ./bundle.json --stop --yes
```

Upload a bundle to GCS. This path requires local GCP write credentials because it uses `gcloud storage cp` or `gsutil cp`:

```bash
hydra share create <session> \
  --bucket <bucket> \
  --prefix shares \
  --stop \
  --yes
```

Accept a local bundle:

```bash
hydra share accept ./bundle.json --repo /path/to/repo
```

Accept from private GCS using a share id. This still requires the receiver to have `gcloud` or `gsutil` installed and authenticated with read access:

```bash
hydra share accept <share-id> \
  --bucket <bucket> \
  --prefix shares \
  --repo /path/to/repo
```

Accept from an explicit `gs://` object. This also uses `gcloud` or `gsutil`:

```bash
hydra share accept gs://<bucket>/shares/<share-id>/bundle.json \
  --repo /path/to/repo
```

Accept from a public HTTPS URL. This does not use `gcloud`, so the receiver does not need GCP login:

```bash
hydra share accept \
  https://storage.googleapis.com/<bucket>/shares/<share-id>/bundle.json \
  --repo /path/to/repo
```

## Implementation Notes

- Adds `hydra share create` and `hydra share accept` CLI commands.
- Supports Codex copilots and workers.
- Stores repo metadata, Hydra session metadata, and Codex native session file contents in the bundle.
- Adds GCS upload/download helpers with `gcloud storage cp` and `gsutil cp` fallback.
- Adds HTTPS bundle download for public object flows.
- Passes `-C <workdir>` to Codex resume to avoid cross-machine working-directory picker issues.
- Improves Codex readiness/session-id capture for modern Codex TUI output.

## Validation

Automated checks:

```bash
npm run compile
npm run lint
npm run smoke:share
node out/smoke/codexBypassSmoke.js
npm test
git diff --check
```

Manual end-to-end validation:

- Local bundle export/import with real Codex native resume.
- GCS upload/download with `gcloud` and real Codex native resume.
- Public HTTPS download without `gcloud` credentials and real Codex native resume.

## Known Limitations

- Bundles are intentionally unencrypted for this MVP. Anyone with bundle access can read the Codex transcript.
- Public bucket/object usage should be temporary. Long term we should use encryption, signed URLs, or a backend-mediated share flow.
- `--stop` exits the source Codex session so Codex flushes the JSONL before export.
- Share ids are currently short. Public share flows should move to a longer random token before production use.
