### PR TITLE
[codex] Improve share CLI ergonomics

### DIFF
--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -13,15 +13,19 @@ import {
 } from '../../core/git';
 import { exec } from '../../core/exec';
 import { shellQuote } from '../../core/shell';
-import { resolveAgentSessionFile, toCanonicalPath } from '../../core/path';
+import { getHydraConfig, resolveAgentSessionFile, toCanonicalPath, writeHydraConfig } from '../../core/path';
 import { resolveRepoInput } from '../../core/repoRegistry';
 import { createShareBundle, readBundle, writeBundle, type ShareableSession } from '../../share/bundle';
 import {
+  buildDefaultPublicBaseUrl,
   buildGcsBundleUrl,
+  buildPublicHttpBundleUrl,
   downloadBundle,
   downloadHttpBundle,
   isHttpBundleUrl,
+  normalizeGcsBucket,
   resolveShareRef,
+  stripSlashes,
   uploadBundle,
 } from '../../share/gcpStorage';
 import { importCodexNativeSession } from '../../share/codexAdapter';
@@ -47,8 +51,39 @@ interface AcceptShareOpts {
   allowMismatch?: boolean;
 }
 
+interface ShareConfigOpts {
+  bucket?: string;
+  prefix?: string;
+  public?: boolean;
+  publicBaseUrl?: string;
+  clear?: boolean;
+}
+
 function expandPath(inputPath: string): string {
   return toCanonicalPath(inputPath) || path.resolve(inputPath);
+}
+
+function getConfiguredSharePrefix(override?: string): string {
+  return stripSlashes(override || getHydraConfig().share?.prefix || 'shares');
+}
+
+function getConfiguredShareBucket(override?: string): string | undefined {
+  const bucket = override || getHydraConfig().share?.bucket;
+  return bucket ? normalizeGcsBucket(bucket) : undefined;
+}
+
+function getConfiguredPublicBaseUrl(): string | undefined {
+  const publicBaseUrl = getHydraConfig().share?.publicBaseUrl?.trim();
+  return publicBaseUrl ? publicBaseUrl.replace(/\/+$/, '') : undefined;
+}
+
+function isPathLikeShareRef(shareRef: string): boolean {
+  const trimmed = shareRef.trim();
+  return path.isAbsolute(trimmed)
+    || trimmed.startsWith('.')
+    || trimmed.startsWith('~')
+    || trimmed.includes('/')
+    || trimmed.includes('\\');
 }
 
 function findShareableSession(
@@ -141,17 +176,19 @@ async function downloadTempHttpBundle(url: string): Promise<string> {
 }
 
 async function resolveBundleInput(shareRef: string, opts: AcceptShareOpts): Promise<{ bundlePath: string; source: string }> {
-  if (isHttpBundleUrl(shareRef)) {
+  const trimmedShareRef = shareRef.trim();
+
+  if (isHttpBundleUrl(trimmedShareRef)) {
     return {
-      bundlePath: await downloadTempHttpBundle(shareRef.trim()),
-      source: shareRef.trim(),
+      bundlePath: await downloadTempHttpBundle(trimmedShareRef),
+      source: trimmedShareRef,
     };
   }
 
-  if (shareRef.trim().startsWith('gs://') || opts.bucket) {
-    const gcsUrl = resolveShareRef(shareRef, {
+  if (trimmedShareRef.startsWith('gs://') || opts.bucket) {
+    const gcsUrl = resolveShareRef(trimmedShareRef, {
       bucket: opts.bucket,
-      prefix: opts.prefix,
+      prefix: getConfiguredSharePrefix(opts.prefix),
     });
     return {
       bundlePath: await downloadTempBundle(gcsUrl),
@@ -159,9 +196,45 @@ async function resolveBundleInput(shareRef: string, opts: AcceptShareOpts): Prom
     };
   }
 
-  const bundlePath = expandPath(shareRef);
+  if (isPathLikeShareRef(trimmedShareRef)) {
+    const bundlePath = expandPath(trimmedShareRef);
+    if (!fs.existsSync(bundlePath)) {
+      throw new Error(`Share bundle file not found: ${bundlePath}`);
+    }
+    return { bundlePath, source: bundlePath };
+  }
+
+  const publicBaseUrl = getConfiguredPublicBaseUrl();
+  if (publicBaseUrl) {
+    const publicUrl = buildPublicHttpBundleUrl({
+      publicBaseUrl,
+      prefix: getConfiguredSharePrefix(opts.prefix),
+      shareId: trimmedShareRef,
+    });
+    return {
+      bundlePath: await downloadTempHttpBundle(publicUrl),
+      source: publicUrl,
+    };
+  }
+
+  const configuredBucket = getConfiguredShareBucket();
+  if (configuredBucket) {
+    const gcsUrl = resolveShareRef(trimmedShareRef, {
+      bucket: configuredBucket,
+      prefix: getConfiguredSharePrefix(opts.prefix),
+    });
+    return {
+      bundlePath: await downloadTempBundle(gcsUrl),
+      source: gcsUrl,
+    };
+  }
+
+  const bundlePath = expandPath(trimmedShareRef);
   if (!fs.existsSync(bundlePath)) {
-    throw new Error(`Share bundle file not found: ${bundlePath}`);
+    throw new Error(
+      `Share bundle file not found: ${bundlePath}. ` +
+      'Pass --bucket <bucket>, use an https:// URL, or run `hydra share config --bucket <bucket>` first.',
+    );
   }
   return { bundlePath, source: bundlePath };
 }
@@ -234,7 +307,7 @@ async function acceptCopilot(
   return sm.createCopilotAndFinalize({
     workdir: repoRoot,
     agentType: 'codex',
-    name: bundle.hydraSession.displayName,
+    name: opts.session ? sessionName : bundle.hydraSession.displayName,
     sessionName,
     agentCommand: opts.agentCommand,
     resumeSessionId: bundle.hydraSession.agentSessionId,
@@ -278,10 +351,92 @@ async function acceptWorker(
   return workerInfo;
 }
 
+function formatShareConfigForOutput(): Record<string, string | null> {
+  const config = getHydraConfig().share || {};
+  return {
+    bucket: config.bucket || null,
+    prefix: config.prefix || 'shares',
+    publicBaseUrl: config.publicBaseUrl || null,
+  };
+}
+
+function updateShareConfig(opts: ShareConfigOpts): Record<string, string | null> {
+  const currentConfig = getHydraConfig();
+  if (opts.clear) {
+    const nextConfig = { ...currentConfig };
+    delete nextConfig.share;
+    writeHydraConfig(nextConfig);
+    return formatShareConfigForOutput();
+  }
+
+  const shareConfig = { ...(currentConfig.share || {}) };
+  if (opts.bucket !== undefined) {
+    shareConfig.bucket = normalizeGcsBucket(opts.bucket);
+  }
+  if (opts.prefix !== undefined) {
+    shareConfig.prefix = stripSlashes(opts.prefix) || 'shares';
+  }
+  if (opts.publicBaseUrl !== undefined) {
+    shareConfig.publicBaseUrl = opts.publicBaseUrl.replace(/\/+$/, '').trim();
+  }
+  if (opts.public === true) {
+    if (!shareConfig.bucket) {
+      throw new Error('Configure --bucket before enabling --public');
+    }
+    shareConfig.publicBaseUrl = buildDefaultPublicBaseUrl(shareConfig.bucket);
+  } else if (opts.public === false) {
+    delete shareConfig.publicBaseUrl;
+  }
+
+  writeHydraConfig({
+    ...currentConfig,
+    share: shareConfig,
+  });
+  return formatShareConfigForOutput();
+}
+
+function hasShareConfigMutation(opts: ShareConfigOpts): boolean {
+  return opts.clear
+    || opts.bucket !== undefined
+    || opts.prefix !== undefined
+    || opts.public !== undefined
+    || opts.publicBaseUrl !== undefined;
+}
+
 export function registerShareCommands(program: Command): void {
   const share = program
     .command('share')
     .description('Share Hydra sessions through native agent resume data');
+
+  share
+    .command('config')
+    .description('Show or update default share storage settings')
+    .option('--bucket <bucket>', 'Default GCS bucket for share create/accept')
+    .option('--prefix <prefix>', 'Default GCS object prefix')
+    .option('--public', 'Use public HTTPS URLs for share-id accept')
+    .option('--no-public', 'Use gcloud/gsutil for share-id accept')
+    .option('--public-base-url <url>', 'Public base URL for share-id accept')
+    .option('--clear', 'Clear default share storage settings')
+    .action((opts: ShareConfigOpts) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const changed = hasShareConfigMutation(opts);
+        const config = changed ? updateShareConfig(opts) : formatShareConfigForOutput();
+
+        outputResult(
+          { status: changed ? 'updated' : 'ok', share: config },
+          globalOpts,
+          () => {
+            console.log('Share config:');
+            console.log(`  Bucket:          ${config.bucket || 'none'}`);
+            console.log(`  Prefix:          ${config.prefix || 'shares'}`);
+            console.log(`  Public base URL: ${config.publicBaseUrl || 'none'}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
 
   share
     .command('create <session>')
@@ -294,8 +449,15 @@ export function registerShareCommands(program: Command): void {
     .action(async (sessionName: string, opts: CreateShareOpts) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
-        if (!!opts.bucket === !!opts.out) {
-          throw new Error('Specify exactly one destination: --out <path> for local testing or --bucket <bucket> for GCS.');
+        if (opts.out && opts.bucket) {
+          throw new Error('Specify only one destination: --out <path> or --bucket <bucket>.');
+        }
+        const bucket = opts.out ? undefined : getConfiguredShareBucket(opts.bucket);
+        if (!opts.out && !bucket) {
+          throw new Error(
+            'Specify a destination: --out <path> for local testing or --bucket <bucket> for GCS. ' +
+            'You can also run `hydra share config --bucket <bucket>` once and omit --bucket.',
+          );
         }
         warnUnencrypted(globalOpts, opts.yes);
 
@@ -316,13 +478,24 @@ export function registerShareCommands(program: Command): void {
         writeBundle(localBundlePath, bundle);
 
         let destination = localBundlePath;
-        if (opts.bucket) {
+        let publicUrl: string | null = null;
+        if (bucket) {
+          const prefix = getConfiguredSharePrefix(opts.prefix);
           destination = buildGcsBundleUrl({
-            bucket: opts.bucket,
-            prefix: opts.prefix,
+            bucket,
+            prefix,
             shareId: bundle.shareId,
           });
           await uploadBundle(localBundlePath, destination);
+
+          const publicBaseUrl = getConfiguredPublicBaseUrl();
+          if (publicBaseUrl) {
+            publicUrl = buildPublicHttpBundleUrl({
+              publicBaseUrl,
+              prefix,
+              shareId: bundle.shareId,
+            });
+          }
         }
 
         outputResult(
@@ -335,11 +508,15 @@ export function registerShareCommands(program: Command): void {
             agent: 'codex',
             agentSessionId: session.data.sessionId,
             encryption: bundle.encryption,
+            publicUrl,
           },
           globalOpts,
           () => {
             console.log(`Created share: ${bundle.shareId}`);
             console.log(`  Location:   ${destination}`);
+            if (publicUrl) {
+              console.log(`  Public URL: ${publicUrl}`);
+            }
             console.log(`  Session:    ${session.data.sessionName}`);
             console.log(`  Type:       ${session.type}`);
             console.log(`  Agent:      codex`);

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -181,12 +181,19 @@ export interface HydraCliConfig {
   version?: string;
 }
 
+export interface HydraShareConfig {
+  bucket?: string;
+  prefix?: string;
+  publicBaseUrl?: string;
+}
+
 export interface HydraGlobalConfig {
   hydraHome?: string;
   hydraConfigPath?: string;
   HYDRA_HOME?: string;
   HYDRA_CONFIG_PATH?: string;
   cli?: HydraCliConfig;
+  share?: HydraShareConfig;
 }
 
 export interface HydraResolvedPaths {

--- a/src/share/gcpStorage.ts
+++ b/src/share/gcpStorage.ts
@@ -11,18 +11,46 @@ export interface GcsLocationOptions {
   shareId: string;
 }
 
-function stripSlashes(value: string): string {
+export interface PublicHttpLocationOptions {
+  publicBaseUrl: string;
+  prefix?: string;
+  shareId: string;
+}
+
+export function stripSlashes(value: string): string {
   return value.replace(/^\/+/, '').replace(/\/+$/, '');
 }
 
+export function normalizeGcsBucket(bucket: string): string {
+  return bucket.replace(/^gs:\/\//, '').replace(/\/+$/, '').trim();
+}
+
 export function buildGcsBundleUrl(options: GcsLocationOptions): string {
-  const bucket = options.bucket.replace(/^gs:\/\//, '').replace(/\/+$/, '');
+  const bucket = normalizeGcsBucket(options.bucket);
   if (!bucket) {
     throw new Error('GCS bucket is required');
   }
   const prefix = stripSlashes(options.prefix || 'shares');
   const key = [prefix, options.shareId, 'bundle.json'].filter(Boolean).join('/');
   return `gs://${bucket}/${key}`;
+}
+
+export function buildPublicHttpBundleUrl(options: PublicHttpLocationOptions): string {
+  const baseUrl = options.publicBaseUrl.replace(/\/+$/, '').trim();
+  if (!baseUrl) {
+    throw new Error('Public base URL is required');
+  }
+  const prefix = stripSlashes(options.prefix || 'shares');
+  const key = [prefix, options.shareId, 'bundle.json'].filter(Boolean).join('/');
+  return `${baseUrl}/${key}`;
+}
+
+export function buildDefaultPublicBaseUrl(bucket: string): string {
+  const normalizedBucket = normalizeGcsBucket(bucket);
+  if (!normalizedBucket) {
+    throw new Error('GCS bucket is required');
+  }
+  return `https://storage.googleapis.com/${normalizedBucket}`;
 }
 
 export function resolveShareRef(

--- a/src/smoke/shareBundleSmoke.ts
+++ b/src/smoke/shareBundleSmoke.ts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import type { WorkerInfo } from '../core/sessionManager';
 import { createShareBundle, readBundle, writeBundle } from '../share/bundle';
 import { importCodexNativeSession } from '../share/codexAdapter';
-import { downloadHttpBundle } from '../share/gcpStorage';
+import { buildDefaultPublicBaseUrl, buildPublicHttpBundleUrl, downloadHttpBundle } from '../share/gcpStorage';
 
 const SESSION_ID = '019deccc-251c-7192-bf0d-e8ff36a0bb5e';
 
@@ -152,6 +152,18 @@ async function main(): Promise<void> {
     const bundlePath = path.join(tempDir, 'bundle.json');
     writeBundle(bundlePath, bundle);
     assert.equal(readBundle(bundlePath).shareId, 'share-smoke');
+    assert.equal(
+      buildDefaultPublicBaseUrl('gs://hydra-share-smoke'),
+      'https://storage.googleapis.com/hydra-share-smoke',
+    );
+    assert.equal(
+      buildPublicHttpBundleUrl({
+        publicBaseUrl: 'https://storage.googleapis.com/hydra-share-smoke/',
+        prefix: '/shares/',
+        shareId: 'share-smoke',
+      }),
+      'https://storage.googleapis.com/hydra-share-smoke/shares/share-smoke/bundle.json',
+    );
 
     const httpDownloadedBundlePath = path.join(tempDir, 'downloaded-bundle.json');
     await withBundleServer(bundlePath, async (url) => {


### PR DESCRIPTION
## Summary

Improves the native session sharing UX after the initial release.

- Fixes accepted copilot display names when `--session` is used, so the sidebar shows the local received session name instead of duplicating the source display name.
- Adds `hydra share config` for default share storage settings.
- Allows short create/accept commands once a default public GCS bucket is configured.

## New Short Flow

Configure once:

```bash
hydra share config \
  --bucket hydra-session-share-test-mystic-cable-447417-s0-20260513093455 \
  --prefix shares \
  --public
```

Create a GCS share using configured defaults:

```bash
hydra share create hydra-copilot-codex-2 --stop --yes
```

Accept a public share by id using configured defaults:

```bash
hydra share accept f1df697e75e0cc96 \
  --repo . \
  --session hydra-copilot-codex-2-received
```

Existing explicit forms still work:

```bash
hydra share create <session> --bucket <bucket> --prefix shares --stop --yes
hydra share accept <share-id> --bucket <bucket> --prefix shares --repo .
hydra share accept https://storage.googleapis.com/<bucket>/shares/<share-id>/bundle.json --repo .
```

## Validation

```bash
npm run compile
npm run lint
npm run smoke:share
npm test
git diff --check
```
