### PR TITLE
chore: release v0.3.2026051301

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026051301] - 2026-05-13
+
+### Changed
+- Improve native session sharing ergonomics with default share storage config, shorter public share commands, and clearer received copilot names
+
 ## [0.3.2026051300] - 2026-05-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026051300",
+  "version": "0.3.2026051301",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026051300",
+      "version": "0.3.2026051301",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026051300",
+  "version": "0.3.2026051301",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026051301.

## Changes

### Changed
- Improve native session sharing ergonomics with default share storage config, shorter public share commands, and clearer received copilot names

## Validation

```bash
npm test
npm run lint
git diff --check
```

## Release Notes

After this PR is merged, `auto-tag-release.yml` should create the `v0.3.2026051301` tag from the package version bump. The tag should then trigger the publish workflow for VSIX packaging, Marketplace/Open VSX publishing, and GitHub Release creation.
