### PR TITLE
[codex] Fix worker share repo validation

### DIFF
--- a/src/share/repo.ts
+++ b/src/share/repo.ts
@@ -38,6 +38,28 @@ async function collectRemotes(repoRoot: string): Promise<Record<string, string>>
   return remotes;
 }
 
+function repoNameFromRemoteUrl(url: string): string | null {
+  const normalized = normalizeRemoteUrl(url);
+  const repoName = normalized.split('/').filter(Boolean).pop();
+  return repoName || null;
+}
+
+function getRepoNameFromRemotes(remotes: Record<string, string>, repoRoot: string): string {
+  const originRepoName = remotes.origin ? repoNameFromRemoteUrl(remotes.origin) : null;
+  if (originRepoName) {
+    return originRepoName;
+  }
+
+  for (const remoteUrl of Object.values(remotes)) {
+    const repoName = repoNameFromRemoteUrl(remoteUrl);
+    if (repoName) {
+      return repoName;
+    }
+  }
+
+  return getRepoName(repoRoot);
+}
+
 export async function collectRepoInfo(workdir: string): Promise<ShareRepoInfo> {
   let repoRoot: string;
   try {
@@ -53,7 +75,7 @@ export async function collectRepoInfo(workdir: string): Promise<ShareRepoInfo> {
   ]);
 
   return {
-    repoName: getRepoName(repoRoot),
+    repoName: getRepoNameFromRemotes(remotes, repoRoot),
     repoRoot,
     branch,
     headCommit,
@@ -102,16 +124,18 @@ export async function validateRepoMatch(
     throw new Error(`Target repo path is not a git repository: ${targetRepoRoot}`);
   }
 
-  if (bundleRepo.repoName && targetRepo.repoName && bundleRepo.repoName !== targetRepo.repoName) {
+  const bundleRemoteCount = Object.keys(bundleRepo.remotes || {}).length;
+  const targetRemoteCount = Object.keys(targetRepo.remotes || {}).length;
+  const canCompareRemotes = bundleRemoteCount > 0 && targetRemoteCount > 0;
+  const hasSharedRemote = canCompareRemotes && hasCommonRemote(bundleRepo.remotes, targetRepo.remotes);
+  if (canCompareRemotes && !hasSharedRemote) {
+    throw new Error('Repo remote mismatch. Use --allow-mismatch to override.');
+  }
+
+  if (!hasSharedRemote && bundleRepo.repoName && targetRepo.repoName && bundleRepo.repoName !== targetRepo.repoName) {
     throw new Error(
       `Repo name mismatch: share is for "${bundleRepo.repoName}", target is "${targetRepo.repoName}". Use --allow-mismatch to override.`,
     );
-  }
-
-  const bundleRemoteCount = Object.keys(bundleRepo.remotes || {}).length;
-  const targetRemoteCount = Object.keys(targetRepo.remotes || {}).length;
-  if (bundleRemoteCount > 0 && targetRemoteCount > 0 && !hasCommonRemote(bundleRepo.remotes, targetRepo.remotes)) {
-    throw new Error('Repo remote mismatch. Use --allow-mismatch to override.');
   }
 
   if (bundleRepo.headCommit && !(await commitExists(targetRepo.repoRoot, bundleRepo.headCommit))) {

--- a/src/smoke/shareBundleSmoke.ts
+++ b/src/smoke/shareBundleSmoke.ts
@@ -8,6 +8,7 @@ import type { WorkerInfo } from '../core/sessionManager';
 import { createShareBundle, readBundle, writeBundle } from '../share/bundle';
 import { importCodexNativeSession } from '../share/codexAdapter';
 import { buildDefaultPublicBaseUrl, buildPublicHttpBundleUrl, downloadHttpBundle } from '../share/gcpStorage';
+import { collectRepoInfo, validateRepoMatch } from '../share/repo';
 
 const SESSION_ID = '019deccc-251c-7192-bf0d-e8ff36a0bb5e';
 
@@ -131,6 +132,19 @@ async function main(): Promise<void> {
 
   try {
     const repoRoot = createRepo(tempDir);
+    const workerWorktree = path.join(tempDir, 'worker-worktree');
+    runGit(repoRoot, ['branch', 'worker-branch']);
+    runGit(repoRoot, ['worktree', 'add', workerWorktree, 'worker-branch']);
+
+    const worktreeRepoInfo = await collectRepoInfo(workerWorktree);
+    assert.equal(worktreeRepoInfo.repoName, 'repo');
+    assert.equal(worktreeRepoInfo.branch, 'worker-branch');
+
+    await validateRepoMatch({
+      ...worktreeRepoInfo,
+      repoName: 'worker-worktree',
+    }, repoRoot);
+
     const sourceSessionFile = writeCodexSession(sourceHome);
 
     const bundle = await withHomeAsync(sourceHome, () => createShareBundle({


### PR DESCRIPTION
## Summary

- Derive shared repo names from git remotes when available, so worker worktree folder names do not become the canonical repo identity.
- Let share accept pass repo-name validation when source and target remotes match.
- Add share smoke coverage for accepting a worker share into a normal clone whose folder name differs from the source worktree.

## Validation

- npm run compile
- npm run smoke:share
- npm run lint
- git diff --check

## Notes

Worker branch availability is still required on the receiving repo; this PR fixes the repo/worktree identity mismatch only.