### PR TITLE
[codex] Add Claude native session sharing

### DIFF
--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -29,6 +29,7 @@ import {
   uploadBundle,
 } from '../../share/gcpStorage';
 import { importCodexNativeSession } from '../../share/codexAdapter';
+import { importClaudeNativeSession } from '../../share/claudeAdapter';
 import { ensureLocalBranchFromRemote, validateRepoMatch } from '../../share/repo';
 import type { HydraShareBundle, ShareHydraWorkerInfo } from '../../share/types';
 import { outputError, outputResult, type OutputOpts } from '../output';
@@ -57,6 +58,11 @@ interface ShareConfigOpts {
   public?: boolean;
   publicBaseUrl?: string;
   clear?: boolean;
+}
+
+interface NativeImportResult {
+  written: string[];
+  skipped: string[];
 }
 
 function expandPath(inputPath: string): string {
@@ -106,7 +112,7 @@ function findShareableSession(
 function warnUnencrypted(globalOpts: OutputOpts, yes?: boolean): void {
   if (!globalOpts.quiet && !yes) {
     console.error(
-      'Warning: Hydra share bundles are not encrypted yet. Anyone with access to this GCS object can read the Codex session contents.',
+      'Warning: Hydra share bundles are not encrypted yet. Anyone with access to this GCS object can read the agent session contents.',
     );
   }
 }
@@ -144,7 +150,7 @@ async function stopSessionForExport(
   const sessionFile = await waitForNativeSessionFile(session);
   if (!sessionFile) {
     throw new Error(
-      `Timed out waiting for Codex to flush native session data for "${session.data.sessionName}". ` +
+      `Timed out waiting for ${session.data.agent} to flush native session data for "${session.data.sessionName}". ` +
       'Try again after the agent has exited.',
     );
   }
@@ -286,7 +292,7 @@ function buildImportedWorkerInfo(
     slug,
     status: 'stopped',
     attached: false,
-    agent: 'codex',
+    agent: bundleSession.agent,
     workdir,
     tmuxSession: sessionName,
     createdAt: now,
@@ -296,22 +302,49 @@ function buildImportedWorkerInfo(
   };
 }
 
+function importNativeSession(
+  bundle: HydraShareBundle,
+  targetWorkdir: string,
+  opts: AcceptShareOpts,
+): NativeImportResult {
+  switch (bundle.hydraSession.agent) {
+    case 'codex': {
+      const payload = bundle.agents.codex;
+      if (!payload) {
+        throw new Error('Share bundle is missing Codex native session payload');
+      }
+      return importCodexNativeSession(payload, { force: opts.force });
+    }
+    case 'claude': {
+      const payload = bundle.agents.claude;
+      if (!payload) {
+        throw new Error('Share bundle is missing Claude native session payload');
+      }
+      return importClaudeNativeSession(payload, targetWorkdir, { force: opts.force });
+    }
+    default:
+      throw new Error(`Unsupported share bundle agent: ${bundle.hydraSession.agent}`);
+  }
+}
+
 async function acceptCopilot(
   sm: SessionManager,
   backend: TmuxBackendCore,
   bundle: HydraShareBundle,
   repoRoot: string,
   opts: AcceptShareOpts,
-): Promise<CopilotInfo> {
+): Promise<{ session: CopilotInfo; nativeImport: NativeImportResult }> {
   const sessionName = backend.sanitizeSessionName(opts.session || bundle.hydraSession.sessionName);
-  return sm.createCopilotAndFinalize({
+  const nativeImport = importNativeSession(bundle, repoRoot, opts);
+  const session = await sm.createCopilotAndFinalize({
     workdir: repoRoot,
-    agentType: 'codex',
+    agentType: bundle.hydraSession.agent,
     name: opts.session ? sessionName : bundle.hydraSession.displayName,
     sessionName,
     agentCommand: opts.agentCommand,
     resumeSessionId: bundle.hydraSession.agentSessionId,
   });
+  return { session, nativeImport };
 }
 
 async function acceptWorker(
@@ -320,7 +353,7 @@ async function acceptWorker(
   bundle: HydraShareBundle,
   repoRoot: string,
   opts: AcceptShareOpts,
-): Promise<WorkerInfo> {
+): Promise<{ session: WorkerInfo; nativeImport: NativeImportResult }> {
   const worker = bundle.hydraSession.worker;
   if (!worker) {
     throw new Error('Worker share bundle is missing worker metadata');
@@ -336,11 +369,12 @@ async function acceptWorker(
     slug,
     sessionName,
   );
+  const nativeImport = importNativeSession(bundle, workdir, opts);
 
   const { workerInfo, postCreatePromise } = await sm.createWorker({
     repoRoot,
     branchName: worker.branch,
-    agentType: 'codex',
+    agentType: bundle.hydraSession.agent,
     agentCommand: opts.agentCommand,
     resumeSessionId: bundle.hydraSession.agentSessionId,
     preservedWorkerInfo,
@@ -348,7 +382,7 @@ async function acceptWorker(
     fetchMode: 'best-effort',
   });
   await postCreatePromise;
-  return workerInfo;
+  return { session: workerInfo, nativeImport };
 }
 
 function formatShareConfigForOutput(): Record<string, string | null> {
@@ -440,11 +474,11 @@ export function registerShareCommands(program: Command): void {
 
   share
     .command('create <session>')
-    .description('Create a native Codex share bundle locally or upload it to GCS')
+    .description('Create a native agent share bundle locally or upload it to GCS')
     .option('--bucket <bucket>', 'GCS bucket for share bundles')
     .option('--prefix <prefix>', 'GCS object prefix', 'shares')
     .option('--out <path>', 'Write the share bundle to a local file instead of GCS')
-    .option('--stop', 'Send /quit before exporting so Codex flushes native session data')
+    .option('--stop', 'Send /quit before exporting so the agent flushes native session data')
     .option('--yes', 'Acknowledge that the bundle is not encrypted')
     .action(async (sessionName: string, opts: CreateShareOpts) => {
       const globalOpts = program.opts() as OutputOpts;
@@ -505,7 +539,7 @@ export function registerShareCommands(program: Command): void {
             destination,
             session: session.data.sessionName,
             type: session.type,
-            agent: 'codex',
+            agent: session.data.agent,
             agentSessionId: session.data.sessionId,
             encryption: bundle.encryption,
             publicUrl,
@@ -519,7 +553,7 @@ export function registerShareCommands(program: Command): void {
             }
             console.log(`  Session:    ${session.data.sessionName}`);
             console.log(`  Type:       ${session.type}`);
-            console.log(`  Agent:      codex`);
+            console.log(`  Agent:      ${session.data.agent}`);
             console.log(`  Session ID: ${session.data.sessionId}`);
           },
         );
@@ -530,13 +564,13 @@ export function registerShareCommands(program: Command): void {
 
   share
     .command('accept <share-ref>')
-    .description('Accept a local, GCS, or HTTPS native Codex share bundle and resume it locally')
+    .description('Accept a local, GCS, or HTTPS native agent share bundle and resume it locally')
     .requiredOption('--repo <path>', 'Path to the local copy of the shared repository')
     .option('--bucket <bucket>', 'GCS bucket when share-ref is a share ID')
     .option('--prefix <prefix>', 'GCS object prefix', 'shares')
     .option('--session <name>', 'Override the local Hydra session name')
-    .option('--agent-command <command>', 'Override the Codex command used to resume the shared session')
-    .option('--force', 'Overwrite an existing Codex session file if contents differ')
+    .option('--agent-command <command>', 'Override the agent command used to resume the shared session')
+    .option('--force', 'Overwrite an existing native session file if contents differ')
     .option('--allow-mismatch', 'Allow repo remote or commit mismatch')
     .action(async (shareRef: string, opts: AcceptShareOpts) => {
       const globalOpts = program.opts() as OutputOpts;
@@ -547,13 +581,13 @@ export function registerShareCommands(program: Command): void {
         const resolvedRepoInput = resolveRepoInput(opts.repo);
         const repoRoot = await getRepoRootFromPath(expandPath(resolvedRepoInput.path));
         await validateRepoMatch(bundle.repo, repoRoot, opts.allowMismatch);
-        const nativeImport = importCodexNativeSession(bundle.agents.codex, { force: opts.force });
 
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
         const result = bundle.hydraSession.type === 'copilot'
           ? await acceptCopilot(sm, backend, bundle, repoRoot, opts)
           : await acceptWorker(sm, backend, bundle, repoRoot, opts);
+        const session = result.session;
 
         outputResult(
           {
@@ -561,20 +595,20 @@ export function registerShareCommands(program: Command): void {
             shareId: bundle.shareId,
             source,
             type: bundle.hydraSession.type,
-            session: result.sessionName,
-            agent: 'codex',
+            session: session.sessionName,
+            agent: bundle.hydraSession.agent,
             agentSessionId: bundle.hydraSession.agentSessionId,
-            workdir: result.workdir,
-            nativeSessionFiles: nativeImport,
+            workdir: session.workdir,
+            nativeSessionFiles: result.nativeImport,
           },
           globalOpts,
           () => {
             console.log(`Accepted share: ${bundle.shareId}`);
             console.log(`  Source:     ${source}`);
-            console.log(`  Session:    ${result.sessionName}`);
+            console.log(`  Session:    ${session.sessionName}`);
             console.log(`  Type:       ${bundle.hydraSession.type}`);
-            console.log(`  Agent:      codex`);
-            console.log(`  Workdir:    ${result.workdir}`);
+            console.log(`  Agent:      ${bundle.hydraSession.agent}`);
+            console.log(`  Workdir:    ${session.workdir}`);
             console.log(`  Session ID: ${bundle.hydraSession.agentSessionId}`);
           },
         );

--- a/src/share/bundle.ts
+++ b/src/share/bundle.ts
@@ -3,9 +3,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { resolveAgentSessionFile } from '../core/path';
 import type { CopilotInfo, WorkerInfo } from '../core/sessionManager';
+import { exportClaudeNativeSession } from './claudeAdapter';
 import { exportCodexNativeSession } from './codexAdapter';
 import { collectRepoInfo } from './repo';
-import type { HydraShareBundle, ShareHydraSessionInfo } from './types';
+import type { HydraShareBundle, ShareAgent, ShareHydraSessionInfo } from './types';
 
 export type ShareableSession =
   | { type: 'copilot'; data: CopilotInfo }
@@ -15,27 +16,31 @@ export function generateShareId(): string {
   return crypto.randomBytes(8).toString('hex');
 }
 
-function assertCodexSession(session: ShareableSession): string {
-  if (session.data.agent !== 'codex') {
-    throw new Error(`Only Codex sessions can be shared natively. Session agent is "${session.data.agent}".`);
-  }
-  if (!session.data.sessionId) {
-    throw new Error(`Session "${session.data.sessionName}" does not have a captured Codex session ID yet.`);
-  }
-  const sessionFile = resolveAgentSessionFile('codex', session.data.workdir, session.data.sessionId);
-  if (!sessionFile) {
-    throw new Error(`Codex session file not found for session "${session.data.sessionName}".`);
-  }
-  return session.data.sessionId;
+function isShareAgent(agent: string): agent is ShareAgent {
+  return agent === 'codex' || agent === 'claude';
 }
 
-function buildHydraSessionInfo(session: ShareableSession, sessionId: string): ShareHydraSessionInfo {
+function assertShareableSession(session: ShareableSession): { agent: ShareAgent; sessionId: string } {
+  if (!isShareAgent(session.data.agent)) {
+    throw new Error(`Only Codex and Claude sessions can be shared natively. Session agent is "${session.data.agent}".`);
+  }
+  if (!session.data.sessionId) {
+    throw new Error(`Session "${session.data.sessionName}" does not have a captured ${session.data.agent} session ID yet.`);
+  }
+  const sessionFile = resolveAgentSessionFile(session.data.agent, session.data.workdir, session.data.sessionId);
+  if (!sessionFile) {
+    throw new Error(`${session.data.agent} session file not found for session "${session.data.sessionName}".`);
+  }
+  return { agent: session.data.agent, sessionId: session.data.sessionId };
+}
+
+function buildHydraSessionInfo(session: ShareableSession, agent: ShareAgent, sessionId: string): ShareHydraSessionInfo {
   if (session.type === 'copilot') {
     return {
       type: 'copilot',
       sessionName: session.data.sessionName,
       displayName: session.data.displayName || session.data.sessionName,
-      agent: 'codex',
+      agent,
       workdir: session.data.workdir,
       agentSessionId: sessionId,
     };
@@ -45,7 +50,7 @@ function buildHydraSessionInfo(session: ShareableSession, sessionId: string): Sh
     type: 'worker',
     sessionName: session.data.sessionName,
     displayName: session.data.displayName || session.data.slug || session.data.sessionName,
-    agent: 'codex',
+    agent,
     workdir: session.data.workdir,
     agentSessionId: sessionId,
     worker: {
@@ -63,8 +68,11 @@ export async function createShareBundle(
   session: ShareableSession,
   shareId = generateShareId(),
 ): Promise<HydraShareBundle> {
-  const sessionId = assertCodexSession(session);
+  const { agent, sessionId } = assertShareableSession(session);
   const repo = await collectRepoInfo(session.data.workdir);
+  const agents = agent === 'codex'
+    ? { codex: exportCodexNativeSession(session.data.workdir, sessionId) }
+    : { claude: exportClaudeNativeSession(session.data.workdir, sessionId) };
 
   return {
     schemaVersion: 1,
@@ -76,10 +84,8 @@ export async function createShareBundle(
       keyHint: null,
     },
     repo,
-    hydraSession: buildHydraSessionInfo(session, sessionId),
-    agents: {
-      codex: exportCodexNativeSession(session.data.workdir, sessionId),
-    },
+    hydraSession: buildHydraSessionInfo(session, agent, sessionId),
+    agents,
   };
 }
 
@@ -107,13 +113,15 @@ export function validateBundle(bundle: HydraShareBundle): void {
   if (!bundle.shareId) {
     throw new Error('Share bundle is missing shareId');
   }
-  if (bundle.hydraSession?.agent !== 'codex') {
-    throw new Error('Only Codex share bundles are supported');
+  const agent = bundle.hydraSession?.agent;
+  if (!agent || !isShareAgent(agent)) {
+    throw new Error(`Unsupported share bundle agent: ${agent || 'missing'}`);
   }
   if (!bundle.hydraSession?.agentSessionId) {
     throw new Error('Share bundle is missing agentSessionId');
   }
-  if (bundle.agents?.codex?.adapter !== 'codex') {
-    throw new Error('Share bundle is missing Codex native session payload');
+  const payload = bundle.agents?.[agent];
+  if (!payload || payload.adapter !== agent) {
+    throw new Error(`Share bundle is missing ${agent} native session payload`);
   }
 }

--- a/src/share/claudeAdapter.ts
+++ b/src/share/claudeAdapter.ts
@@ -1,0 +1,115 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { encodeClaudeWorkdir, resolveAgentSessionFile } from '../core/path';
+import type { ClaudeNativeSessionPayload, NativeSessionFile } from './types';
+
+export interface ImportClaudeSessionOptions {
+  force?: boolean;
+}
+
+export interface ImportClaudeSessionResult {
+  written: string[];
+  skipped: string[];
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function toHomeRelativePath(filePath: string): string {
+  const home = path.resolve(os.homedir());
+  const absoluteFilePath = path.resolve(filePath);
+  const relative = path.relative(home, absoluteFilePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Claude session file is outside the current home directory: ${filePath}`);
+  }
+  return relative;
+}
+
+function readNativeSessionFile(filePath: string): NativeSessionFile {
+  const contents = fs.readFileSync(filePath);
+  const stat = fs.statSync(filePath);
+  return {
+    homeRelativePath: toHomeRelativePath(filePath),
+    mode: stat.mode & 0o777,
+    size: contents.length,
+    sha256: sha256(contents),
+    contentBase64: contents.toString('base64'),
+  };
+}
+
+function resolveClaudeTargetSessionFile(workdir: string, sessionId: string): string {
+  const encoded = encodeClaudeWorkdir(path.resolve(workdir));
+  return path.join(os.homedir(), '.claude', 'projects', encoded, `${sessionId}.jsonl`);
+}
+
+export function exportClaudeNativeSession(
+  workdir: string,
+  sessionId: string,
+): ClaudeNativeSessionPayload {
+  const sessionFile = resolveAgentSessionFile('claude', workdir, sessionId);
+  if (!sessionFile) {
+    throw new Error(`Claude session file not found for session ID "${sessionId}"`);
+  }
+
+  return {
+    adapter: 'claude',
+    adapterVersion: 1,
+    sessionId,
+    sourceWorkdir: workdir,
+    files: [readNativeSessionFile(sessionFile)],
+  };
+}
+
+export function importClaudeNativeSession(
+  payload: ClaudeNativeSessionPayload,
+  targetWorkdir: string,
+  options: ImportClaudeSessionOptions = {},
+): ImportClaudeSessionResult {
+  if (payload.adapter !== 'claude') {
+    throw new Error(`Unsupported native session adapter: ${payload.adapter}`);
+  }
+  if (payload.adapterVersion !== 1) {
+    throw new Error(`Unsupported Claude adapter version: ${payload.adapterVersion}`);
+  }
+  if (!payload.sessionId) {
+    throw new Error('Claude native session payload is missing sessionId');
+  }
+  if (payload.files.length !== 1) {
+    throw new Error(`Claude native session payload must contain exactly one file, got ${payload.files.length}`);
+  }
+
+  const file = payload.files[0]!;
+  const contents = Buffer.from(file.contentBase64, 'base64');
+  const actualHash = sha256(contents);
+  if (actualHash !== file.sha256) {
+    throw new Error(`Hash mismatch for native session file: ${file.homeRelativePath}`);
+  }
+  if (contents.length !== file.size) {
+    throw new Error(`Size mismatch for native session file: ${file.homeRelativePath}`);
+  }
+
+  const targetPath = resolveClaudeTargetSessionFile(targetWorkdir, payload.sessionId);
+  if (fs.existsSync(targetPath)) {
+    const existingHash = sha256(fs.readFileSync(targetPath));
+    if (existingHash === file.sha256) {
+      return { written: [], skipped: [targetPath] };
+    }
+    if (!options.force) {
+      throw new Error(
+        `Claude session file already exists with different contents: ${targetPath}. Use --force to overwrite it.`,
+      );
+    }
+  }
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, contents, { mode: file.mode || 0o600 });
+  try {
+    fs.chmodSync(targetPath, file.mode || 0o600);
+  } catch {
+    // Best-effort: some filesystems ignore chmod.
+  }
+  return { written: [targetPath], skipped: [] };
+}

--- a/src/share/types.ts
+++ b/src/share/types.ts
@@ -1,4 +1,5 @@
 export type ShareSessionType = 'copilot' | 'worker';
+export type ShareAgent = 'codex' | 'claude';
 
 export interface ShareEncryptionInfo {
   enabled: false;
@@ -27,7 +28,7 @@ export interface ShareHydraSessionInfo {
   type: ShareSessionType;
   sessionName: string;
   displayName: string;
-  agent: 'codex';
+  agent: ShareAgent;
   workdir: string;
   agentSessionId: string;
   worker?: ShareHydraWorkerInfo;
@@ -48,6 +49,14 @@ export interface CodexNativeSessionPayload {
   files: NativeSessionFile[];
 }
 
+export interface ClaudeNativeSessionPayload {
+  adapter: 'claude';
+  adapterVersion: 1;
+  sessionId: string;
+  sourceWorkdir: string;
+  files: NativeSessionFile[];
+}
+
 export interface HydraShareBundle {
   schemaVersion: 1;
   shareId: string;
@@ -56,6 +65,7 @@ export interface HydraShareBundle {
   repo: ShareRepoInfo;
   hydraSession: ShareHydraSessionInfo;
   agents: {
-    codex: CodexNativeSessionPayload;
+    codex?: CodexNativeSessionPayload;
+    claude?: ClaudeNativeSessionPayload;
   };
 }

--- a/src/smoke/shareBundleSmoke.ts
+++ b/src/smoke/shareBundleSmoke.ts
@@ -4,8 +4,10 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { encodeClaudeWorkdir } from '../core/path';
 import type { WorkerInfo } from '../core/sessionManager';
 import { createShareBundle, readBundle, writeBundle } from '../share/bundle';
+import { importClaudeNativeSession } from '../share/claudeAdapter';
 import { importCodexNativeSession } from '../share/codexAdapter';
 import { buildDefaultPublicBaseUrl, buildPublicHttpBundleUrl, downloadHttpBundle } from '../share/gcpStorage';
 import { collectRepoInfo, validateRepoMatch } from '../share/repo';
@@ -70,7 +72,20 @@ function writeCodexSession(home: string, contents = '{"type":"session"}\n'): str
   return sessionFile;
 }
 
-function buildWorker(repoRoot: string): WorkerInfo {
+function writeClaudeSession(home: string, workdir: string, contents = `{"type":"user","sessionId":"${SESSION_ID}"}\n`): string {
+  const sessionFile = path.join(
+    home,
+    '.claude',
+    'projects',
+    encodeClaudeWorkdir(workdir),
+    `${SESSION_ID}.jsonl`,
+  );
+  fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+  fs.writeFileSync(sessionFile, contents, 'utf-8');
+  return sessionFile;
+}
+
+function buildWorker(repoRoot: string, agent = 'codex'): WorkerInfo {
   return {
     sessionName: 'repo-feat-share',
     displayName: 'feat-share',
@@ -81,7 +96,7 @@ function buildWorker(repoRoot: string): WorkerInfo {
     slug: 'feat-share',
     status: 'running',
     attached: false,
-    agent: 'codex',
+    agent,
     workdir: repoRoot,
     tmuxSession: 'repo-feat-share',
     createdAt: '2026-05-12T00:00:00.000Z',
@@ -156,9 +171,10 @@ async function main(): Promise<void> {
     assert.equal(bundle.shareId, 'share-smoke');
     assert.equal(bundle.encryption.enabled, false);
     assert.equal(bundle.hydraSession.type, 'worker');
+    assert.equal(bundle.hydraSession.agent, 'codex');
     assert.equal(bundle.hydraSession.agentSessionId, SESSION_ID);
-    assert.equal(bundle.agents.codex.files.length, 1);
-    assert.equal(bundle.agents.codex.files[0]?.homeRelativePath, path.relative(sourceHome, sourceSessionFile));
+    assert.equal(bundle.agents.codex?.files.length, 1);
+    assert.equal(bundle.agents.codex?.files[0]?.homeRelativePath, path.relative(sourceHome, sourceSessionFile));
     assert.equal(bundle.repo.repoName, 'repo');
     assert.equal(bundle.repo.branch, 'main');
     assert.equal(bundle.repo.remotes.origin, 'git@github.com:example/repo.git');
@@ -188,24 +204,59 @@ async function main(): Promise<void> {
       JSON.parse(fs.readFileSync(bundlePath, 'utf-8')),
     );
 
-    const firstImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex));
+    const firstImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex!));
     assert.equal(firstImport.written.length, 1);
     assert.equal(firstImport.skipped.length, 0);
     assert.equal(fs.readFileSync(firstImport.written[0]!, 'utf-8'), fs.readFileSync(sourceSessionFile, 'utf-8'));
 
-    const secondImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex));
+    const secondImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex!));
     assert.equal(secondImport.written.length, 0);
     assert.equal(secondImport.skipped.length, 1);
 
     fs.writeFileSync(firstImport.written[0]!, 'conflict\n', 'utf-8');
     assert.throws(
-      () => withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex)),
+      () => withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex!)),
       /already exists with different contents/,
     );
 
-    const forcedImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex, { force: true }));
+    const forcedImport = withHome(targetHome, () => importCodexNativeSession(bundle.agents.codex!, { force: true }));
     assert.equal(forcedImport.written.length, 1);
     assert.equal(fs.readFileSync(forcedImport.written[0]!, 'utf-8'), fs.readFileSync(sourceSessionFile, 'utf-8'));
+
+    const sourceClaudeSessionFile = writeClaudeSession(sourceHome, repoRoot);
+    const claudeBundle = await withHomeAsync(sourceHome, () => createShareBundle({
+      type: 'worker',
+      data: buildWorker(repoRoot, 'claude'),
+    }, 'claude-share-smoke'));
+    assert.equal(claudeBundle.hydraSession.agent, 'claude');
+    assert.equal(claudeBundle.agents.claude?.adapter, 'claude');
+    assert.equal(claudeBundle.agents.claude?.files[0]?.homeRelativePath, path.relative(sourceHome, sourceClaudeSessionFile));
+
+    const claudeBundlePath = path.join(tempDir, 'claude-bundle.json');
+    writeBundle(claudeBundlePath, claudeBundle);
+    assert.equal(readBundle(claudeBundlePath).agents.claude?.adapter, 'claude');
+
+    const targetClaudeWorkdir = path.join(tempDir, 'receiver-repo');
+    fs.mkdirSync(targetClaudeWorkdir, { recursive: true });
+    const claudeImport = withHome(targetHome, () => importClaudeNativeSession(
+      claudeBundle.agents.claude!,
+      targetClaudeWorkdir,
+    ));
+    const expectedClaudeSessionFile = path.join(
+      targetHome,
+      '.claude',
+      'projects',
+      encodeClaudeWorkdir(path.resolve(targetClaudeWorkdir)),
+      `${SESSION_ID}.jsonl`,
+    );
+    assert.deepEqual(claudeImport.written, [expectedClaudeSessionFile]);
+    assert.equal(fs.readFileSync(expectedClaudeSessionFile, 'utf-8'), fs.readFileSync(sourceClaudeSessionFile, 'utf-8'));
+
+    const secondClaudeImport = withHome(targetHome, () => importClaudeNativeSession(
+      claudeBundle.agents.claude!,
+      targetClaudeWorkdir,
+    ));
+    assert.deepEqual(secondClaudeImport.skipped, [expectedClaudeSessionFile]);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Extend Hydra share bundles from Codex-only to agent-aware native session payloads.
- Add a Claude native session adapter that exports Claude JSONL transcripts and imports them into the receiver workdir's `~/.claude/projects/<encoded-workdir>/<sessionId>.jsonl` path.
- Update `hydra share create` / `hydra share accept` so Claude copilots and workers follow the same CLI flow as Codex.
- Keep Codex behavior compatible while making CLI copy agent-neutral.

## Current State

This is a draft PR and should not be merged yet.

Implemented and locally verified:

- Claude copilot share bundle creation works with the local compiled CLI.
- Claude copilot accept works and creates a new Hydra copilot session using `claude --resume <session-id>`.
- The imported Claude JSONL is written to the receiver repo's Claude project directory, not the sender path.
- The resumed Claude session shows the original conversation history in `hydra copilot logs`.
- Codex share smoke coverage still passes.

Manual Claude copilot test performed:

```bash
node out/cli/index.js share create hydra-copilot-claude --out /tmp/...json --yes --json
node out/cli/index.js share accept /tmp/...json --repo /Users/hanlu/Desktop/ai/hydra --session hydra-claude-share-received-011826 --json
```

Observed import target:

```text
/Users/hanlu/.claude/projects/-Users-hanlu-Desktop-ai-hydra/1e5608eb-d959-44ec-b0e5-75d48b80a418.jsonl
```

The test session was deleted afterward.

## Validation

- `npm run compile`
- `npm run smoke:share`
- `npm run lint`
- `npm test`
- `git diff --check`
- Local Claude bundle create/accept smoke with a real existing Claude copilot session

## Missing / Pending Tests

- A successful post-resume Claude model response. The resumed session accepted the prompt and started generation, but Claude returned `503 No available accounts`. A direct `claude -p "只回复 CLAUDE_DIRECT_OK"` failed with the same 503, so this appears to be current Claude account/service availability rather than a Hydra resume failure.
- Real Claude worker end-to-end share/accept with a pushed worker branch. The code path is implemented, but I have not manually exercised a live Claude worker share yet.
- GCS/public URL Claude share flow. Storage is shared with the existing Codex implementation, but I have only tested local bundle create/accept for Claude.
- Cross-machine Claude accept. Current tests simulate receiver workdir path behavior locally; a second physical machine has not been used.
- Encryption remains out of scope, same as the current Codex share implementation.

## Notes

Claude differs from Codex because `claude --resume` only finds transcripts under the current workdir's encoded Claude project path. This PR intentionally imports Claude JSONL files relative to the receiver workdir before starting the resumed Hydra session.