### PR TITLE
[codex] Add Sudo Code agent support

### DIFF
--- a/docs/sudocode-agent-support-v1.md
+++ b/docs/sudocode-agent-support-v1.md
@@ -1,0 +1,580 @@
+# Sudo Code Agent Support v1
+
+Status: v1 implementation plan for issue #162.
+
+This document describes the first production-ready integration of Sudo Code
+(`scode`) into Hydra's existing tmux-based agent model. It intentionally uses
+Sudo Code's ordinary interactive REPL mode, not ACP, so the change fits the
+current Claude/Codex/Gemini architecture.
+
+## Background
+
+Hydra currently treats agents as long-lived terminal processes inside tmux. A
+worker or copilot is launched, Hydra waits for the agent's idle prompt, captures
+the agent session identifier, and then sends prompts into the terminal.
+
+Sudo Code fits this model when launched as plain `scode`:
+
+- `scode` with no prompt starts an interactive REPL.
+- The idle prompt is `❯`.
+- The startup banner prints both:
+  - `Session          session-<millis>-<counter>`
+  - `Auto-save        .scode/sessions/<workspace-hash>/<session-id>.jsonl`
+- Session files are stored under the current worktree:
+  - `<worktree>/.scode/sessions/<workspace-hash>/<session-id>.jsonl`
+- `/resume <session-ref>` inside the REPL switches the live REPL to an existing
+  session.
+
+The main incompatibility is resume. `scode --resume <id>` is not a long-lived
+terminal resume command. It restores the session, prints information or runs
+resume-supported slash commands, and exits. Hydra must therefore resume Sudo
+Code by starting a fresh REPL and then sending `/resume <session-ref>` into it.
+
+## Goals
+
+- Add `sudocode` as a first-class Hydra agent type.
+- Launch Sudo Code in ordinary interactive REPL mode.
+- Capture Sudo Code session ids and session files.
+- Support fresh copilot and worker creation.
+- Support `stop` / `start` for stopped workers.
+- Support archive restore for deleted workers when the restored worktree path is
+  the same as the original path.
+- Keep model, auth, and proxy behavior owned by the user's local Sudo Code
+  configuration.
+- Avoid changing Hydra's tmux backend or introducing ACP in v1.
+
+## Non-Goals
+
+- No ACP transport integration.
+- No one-shot `scode "prompt"` or `scode --print` integration.
+- No hard-coded Sudo Code model, auth mode, endpoint, proxy, or token behavior.
+- No automatic worker-completion notification for Sudo Code in v1.
+- No cross-machine or arbitrary-cross-path Sudo Code session migration.
+- No changes to Sudo Code itself.
+
+## Prior PR Assessment
+
+PR #139 has useful low-risk scaffolding:
+
+- `sudocode` agent type.
+- Default command `scode`.
+- Auto-approve flag `--dangerously-skip-permissions`.
+- Ready pattern `❯`.
+- Basic session capture from `Session session-...`.
+- VS Code command and setting contributions.
+- CLI help and doctor updates.
+
+It should not be applied directly because:
+
+- It uses `scode --resume <session-id>` as a long-lived resume command, which is
+  incompatible with Sudo Code's actual behavior.
+- It adds `.sudocode/skills`, which Sudo Code does not currently scan. Sudo Code
+  scans `.nexus/sudocode/skills`, `.agents/skills`, `.codex/skills`, and
+  `.claude/skills`, so Hydra's existing `.codex/skills` and `.claude/skills`
+  links already give it skill visibility.
+- It does not preserve `.scode/sessions` before deleting worker worktrees.
+- It does not account for Sudo Code's lack of a turn-completion hook.
+- It was built against an older Hydra main and misses later Codex/session/share
+  changes.
+
+## Agent Configuration
+
+Add `sudocode` everywhere Hydra enumerates built-in agents:
+
+- `src/core/types.ts`
+  - `AgentType = 'claude' | 'codex' | 'gemini' | 'sudocode' | 'custom'`
+- `src/core/agentConfig.ts`
+  - `AGENT_LABELS.sudocode = 'Sudo Code'`
+  - `DEFAULT_AGENT_COMMANDS.sudocode = 'scode'`
+  - `AGENT_YOLO_FLAGS.sudocode = '--dangerously-skip-permissions'`
+  - `AGENT_READY_PATTERNS.sudocode = /❯/`
+  - `AGENT_SESSION_CAPTURE.sudocode = { statusCommand: '/status', ... }`
+- VS Code extension activation and `package.json`
+  - Start Copilot command.
+  - Explicit `onCommand:*` activation events for contributed Hydra commands.
+  - `hydra.sudocodeAvailable` context key.
+  - `hydra.defaultAgent` enum.
+  - `hydra.agentCommands` default.
+- Hydra global config
+  - VS Code syncs `hydra.agentCommands` into `HYDRA_CONFIG_PATH`.
+  - CLI-created workers use the same configured agent command as the
+    extension-created copilot.
+- CLI help text for worker/copilot creation.
+- Doctor agent discovery.
+- Telemetry allowlist.
+
+The default launch command must remain `scode` plus Hydra's permission flag.
+Hydra must not bake in `--model`, `--auth`, proxy env vars, or user-specific
+credentials. Users who need a proxy can configure it through their shell or
+through `hydra.agentCommands.sudocode`, for example:
+
+```json
+{
+  "sudocode": "env HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 NO_PROXY=localhost,127.0.0.1,::1 scode"
+}
+```
+
+## Launch Semantics
+
+Hydra should always launch Sudo Code as a persistent REPL:
+
+```text
+scode --dangerously-skip-permissions
+```
+
+Initial worker tasks are sent after readiness and session capture via
+`backend.sendMessage()`. Hydra must not pass a worker task as argv to `scode`,
+because `scode "task"` is one-shot and exits.
+
+Implementation detail:
+
+- Existing `buildAgentLaunchCommand()` can keep supporting current agents.
+- Either add a persistent launch helper or ensure Sudo Code call sites never pass
+  a `task` argument into `buildAgentLaunchCommand()`.
+- Add a smoke test that fails if the Sudo Code worker creation flow launches
+  `scode '<task>'`.
+
+## Resume Strategy
+
+Replace the single-command resume assumption with an explicit strategy.
+
+Suggested shape:
+
+```ts
+type AgentResumeStrategy =
+  | {
+      kind: 'command';
+      command: string;
+    }
+  | {
+      kind: 'replSlashCommand';
+      launchCommand: string;
+      slashCommand: string;
+    };
+```
+
+Agent behavior:
+
+| Agent | Resume strategy |
+| --- | --- |
+| Claude | `command`: `claude --resume <id>` |
+| Codex | `command`: `codex ... resume -C <workdir> <id>` |
+| Gemini | `command`: `gemini --resume <id>` |
+| Sudo Code | `replSlashCommand`: launch `scode ...`, wait ready, send `/resume <ref>`, wait for resume completion and the next prompt |
+
+The Sudo Code resume sequence:
+
+1. Create the tmux session.
+2. Send `scode --dangerously-skip-permissions`.
+3. Wait for `❯`.
+4. Send `/resume <session-ref>`.
+5. Wait for a new `Session resumed` report and then a following `❯`.
+6. For worker restore with a task, send the task only after the second ready
+   wait.
+
+Never use `scode --resume <id>` for a long-lived Hydra session.
+Sudo Code parses `/resume` by taking the full remainder after the command name,
+so file paths with spaces should be sent raw rather than shell-quoted.
+
+## Session Capture
+
+Hydra should capture two values for Sudo Code:
+
+- `sessionId`: `session-<millis>-<counter>`
+- `agentSessionFile`: absolute path to the `.jsonl` session file, when known
+
+The existing `sessionId` field remains the public identifier. Add a new optional
+field instead of overloading `sessionId`:
+
+```ts
+interface WorkerInfo {
+  sessionId: string | null;
+  agentSessionFile?: string | null;
+}
+
+interface CopilotInfo {
+  sessionId: string | null;
+  agentSessionFile?: string | null;
+}
+
+interface ArchivedSessionInfo {
+  agentSessionId: string | null;
+  agentSessionFile?: string | null;
+}
+```
+
+Capture algorithm:
+
+1. Wait for `❯`.
+2. Capture existing pane output.
+3. Try to parse the startup banner:
+   - `Session          session-1778832876869-0`
+   - `Auto-save        .scode/sessions/.../session-1778832876869-0.jsonl`
+4. If the banner was missed, send `/status` and parse the session from the
+   `Session` path line.
+5. Resolve relative `Auto-save` paths against the worker/copilot workdir.
+6. Persist `sessionId` and `agentSessionFile`.
+
+Suggested parser behavior:
+
+```ts
+const sessionIdPattern = /\b(session-\d+-\d+)\b/;
+const autoSavePattern = /Auto-save\s+(.+?\.jsonl)\b/;
+const statusSessionPathPattern = /Session\s+(.+?session-\d+-\d+\.jsonl)\b/;
+```
+
+For non-Sudo agents, keep the existing id-only capture behavior.
+
+## Session File Resolution
+
+Extend `resolveAgentSessionFile(agent, workdir, sessionId)`:
+
+- For `sudocode`, scan:
+  - `<workdir>/.scode/sessions/*/<sessionId>.jsonl`
+- Return `null` when the workdir or session file is missing.
+
+Prefer the persisted `agentSessionFile` when present and still exists. Fall back
+to resolver scanning by id.
+
+## Archive and Restore
+
+Sudo Code stores sessions inside the worker worktree. `deleteWorker()` removes
+the worktree, so the session file would otherwise be lost.
+
+Before removing a Sudo Code worker worktree:
+
+1. Resolve the current session file from `worker.agentSessionFile` or
+   `resolveAgentSessionFile('sudocode', worker.workdir, worker.sessionId)`.
+2. Copy it into Hydra-owned storage:
+
+   ```text
+   ~/.hydra/agent-sessions/sudocode/<session-name>/<session-id>.jsonl
+   ```
+
+3. Store the copied path on the archive entry as `agentSessionFile`.
+4. Continue with worktree and branch cleanup.
+
+Restore behavior:
+
+- Use `entry.agentSessionFile` as the preferred Sudo Code session ref.
+- Fall back to `entry.agentSessionId` if there is no copied file.
+- Launch REPL and send `/resume <ref>`.
+
+Important limitation:
+
+Sudo Code validates the session's `workspace_root`. Archive restore is expected
+to work when Hydra recreates the worker at the same deterministic worktree path.
+If the repo or worktree path changes, Sudo Code may reject the restored session.
+That is acceptable for v1.
+
+## Completion Notification
+
+Hydra's parent-copilot notification currently depends on agent lifecycle hooks:
+
+- Claude: `Stop`
+- Codex: `Stop`
+- Gemini: `AfterAgent`
+
+Sudo Code currently supports only tool-level hooks:
+
+- `PreToolUse`
+- `PostToolUse`
+- `PostToolUseFailure`
+
+These hooks are not equivalent to "the agent completed the user's task". Using
+`PostToolUse` would notify too early and may notify multiple times.
+
+Add a capability check:
+
+```ts
+function supportsCompletionNotification(agentType: string): boolean {
+  return agentType === 'claude' || agentType === 'codex' || agentType === 'gemini';
+}
+```
+
+For Sudo Code:
+
+- Do not inject hook config.
+- Do not arm the pending notification file.
+- Worker creation should still succeed when
+  `hydra.notifyCopilotOnWorkerComplete` is enabled.
+
+If Sudo Code later adds a turn/session completion hook, support can be added
+without changing worker launch or resume semantics.
+
+## CLI and VS Code Behavior
+
+User-visible additions:
+
+- `hydra worker create --agent sudocode ...`
+- `hydra copilot create --agent sudocode ...`
+- VS Code welcome action: `Hydra: Start Copilot (Sudo Code)`
+- `hydra doctor` recognizes `scode`
+- `hydra list --json` and logs commands include `agent: "sudocode"`
+- `sessionFile` output resolves to the Sudo Code `.jsonl` file when available
+- A copilot launched from the VS Code extension and a worker launched by that
+  copilot through the `hydra` CLI use the same `hydra.agentCommands.sudocode`
+  value.
+
+No user-facing command should imply ACP support in v1.
+
+## Implementation Plan
+
+1. Add agent enum/config/UI/CLI scaffolding.
+2. Add Sudo Code launch and capture config.
+3. Refactor resume from `buildAgentResumeCommand()` into a resume strategy.
+4. Update worker and copilot lifecycle flows to handle `replSlashCommand`.
+5. Capture and persist `agentSessionFile`.
+6. Add Sudo Code support to `resolveAgentSessionFile()`.
+7. Copy Sudo Code session files during worker archive.
+8. Use copied archive session files during restore.
+9. Gate completion notification by agent capability.
+10. Sync VS Code agent command settings to Hydra global config for nested CLI
+    worker creation.
+11. Add command activation events so command-palette entrypoints activate the
+    extension without requiring the Hydra view to open first.
+12. Add smoke tests.
+13. Update README/AGENTS references to list Sudo Code as supported.
+
+## Test Plan
+
+### Static Validation
+
+Run before opening a PR:
+
+```bash
+npm run compile
+npm run lint
+```
+
+Run before marking the PR ready:
+
+```bash
+npm test
+```
+
+### Unit and Smoke Tests
+
+Add or extend smoke tests for the following cases.
+
+#### Agent Config
+
+- `DEFAULT_AGENT_COMMANDS.sudocode` is `scode`.
+- Sudo Code launch includes `--dangerously-skip-permissions`.
+- Sudo Code ready pattern matches `❯`.
+- Sudo Code capture regex parses:
+  - startup banner `Session          session-...`
+  - startup banner `Auto-save        .scode/sessions/...jsonl`
+  - status output path `Session          .../session-...jsonl`
+- Sudo Code resume strategy is `replSlashCommand`.
+- No helper returns `scode --resume <id>` for Sudo Code.
+
+#### Session File Resolution
+
+Fixture:
+
+```text
+<tmp-workdir>/.scode/sessions/abc123/session-1000-0.jsonl
+```
+
+Assertions:
+
+- `resolveAgentSessionFile('sudocode', workdir, 'session-1000-0')` returns the
+  fixture path.
+- Missing session id returns `null`.
+- Missing workdir returns `null`.
+- Unknown agent behavior remains unchanged.
+
+#### Fresh Worker Create
+
+Use a fake `scode` script in a temp directory. The fake script should:
+
+- Print a Sudo Code-like banner with session id and auto-save path.
+- Print `❯`.
+- Record stdin lines to a file.
+- When it receives a normal task prompt, print a response and `❯`.
+
+Assertions:
+
+- Hydra sends the persistent launch command, not `scode '<task>'`.
+- Hydra captures `sessionId`.
+- Hydra captures `agentSessionFile`.
+- Hydra sends the worker task after capture.
+- `sessions.json` records `agent: "sudocode"`.
+
+#### Stop and Start Worker
+
+Using the same fake agent:
+
+- Create a worker.
+- Stop it.
+- Start it again.
+
+Assertions:
+
+- Restart launches `scode ...`.
+- Restart then sends `/resume <session-ref>`.
+- Restart waits for the new resume report and prompt after `/resume`, not any
+  stale prompt already present in the pane.
+- It does not send `scode --resume`.
+
+#### Archive Restore
+
+Using a fake session file:
+
+- Create a Sudo Code worker.
+- Ensure its session file exists.
+- Delete the worker.
+- Restore from archive.
+
+Assertions:
+
+- Delete copies the session file under
+  `~/.hydra/agent-sessions/sudocode/<session-name>/`.
+- Archive entry includes `agentSessionFile`.
+- Restore sends `/resume <copied-session-file>`.
+- Restore recreates the worker using agent `sudocode`.
+
+#### Completion Notification Gating
+
+With `notifyCopilotOnWorkerComplete` enabled:
+
+- Create a Sudo Code worker with a parent copilot.
+
+Assertions:
+
+- No Sudo Code hook config is written.
+- No pending notification file is armed for Sudo Code.
+- Worker creation still succeeds.
+- Existing Claude/Codex/Gemini hook tests continue to pass.
+
+#### CLI JSON Fields
+
+Seed a Sudo Code worker in `sessions.json` and create a fixture session file.
+
+Assertions:
+
+- `hydra list --json` returns `agentSessionId` and `sessionId`.
+- `hydra list --json` resolves `sessionFile`.
+- `hydra worker logs --json` includes the same session fields.
+
+### Manual Tests
+
+Run these with a real locally configured `scode`.
+
+#### Fresh Copilot
+
+```bash
+hydra copilot create --agent sudocode --workdir /Users/hanlu/Desktop/ai/hydra --name sudocode-smoke
+hydra copilot logs sudocode-smoke --lines 80
+```
+
+Expected:
+
+- Sudo Code banner appears.
+- Model/auth/proxy reflect the user's local `scode` configuration.
+- Hydra captures session id.
+- `hydra list --json` shows the copilot as running with agent `sudocode`.
+
+#### Extension-Created Copilot And Worker
+
+Use the `/test-hydra` skill to launch an Extension Development Host.
+
+Expected:
+
+- `Hydra: Start Copilot (Sudo Code)` activates the extension from the command
+  palette.
+- Sudo Code launches as a copilot and auto-confirms its broad-directory prompt.
+- `HYDRA_CONFIG_PATH` contains synced `agentCommands.sudocode`.
+- A prompt to the copilot that runs `hydra worker create --agent sudocode`
+  creates a worker whose pane also launches through the configured command.
+- The worker can answer, stop/start, resume through `/resume <jsonl>`, answer
+  again, and archive its copied Sudo Code session file on delete.
+
+#### Fresh Worker
+
+```bash
+hydra worker create \
+  --repo /Users/hanlu/Desktop/ai/hydra \
+  --branch test/sudocode-v1-smoke \
+  --agent sudocode \
+  --task "Inspect package.json and reply with one sentence. Do not edit files."
+```
+
+Expected:
+
+- Worker starts in a new worktree.
+- Prompt is delivered after Sudo Code reaches `❯`.
+- Agent responds.
+- `hydra worker logs <session> --json` includes session id and session file.
+
+#### Stop and Start
+
+```bash
+hydra worker stop <session>
+hydra worker start <session>
+hydra worker send <session> "Reply with the active session id from /status."
+```
+
+Expected:
+
+- The restarted process is a fresh `scode` REPL.
+- Hydra sends `/resume ...` inside the REPL.
+- Conversation context is preserved.
+
+#### Delete and Restore
+
+```bash
+hydra worker delete <session>
+hydra archive restore <session>
+hydra worker send <session> "Confirm whether this is the restored Sudo Code session."
+```
+
+Expected:
+
+- The archive entry has a copied Sudo Code session file.
+- Restore uses `/resume <copied-jsonl>`.
+- The restored worker responds with prior context when the worktree path is
+  recreated at the same location.
+
+#### Notification Behavior
+
+Create a Sudo Code worker from a copilot while
+`hydra.notifyCopilotOnWorkerComplete` is true.
+
+Expected:
+
+- No automatic completion notification is sent.
+- No error is shown.
+- Worker logs and review flow still work.
+
+## Acceptance Criteria
+
+The v1 implementation is complete when:
+
+- Sudo Code appears in VS Code and CLI agent choices.
+- `hydra worker create --agent sudocode` starts a real long-lived Sudo Code
+  REPL.
+- Hydra captures Sudo Code session id and session file.
+- `hydra worker stop/start` resumes by sending `/resume` inside a new REPL.
+- `hydra worker delete` preserves the Sudo Code session file before worktree
+  removal.
+- `hydra archive restore` resumes from the copied Sudo Code session file when
+  the worktree path is unchanged.
+- Completion notifications are explicitly skipped for Sudo Code without
+  breaking worker creation.
+- Compile, lint, smoke tests, and real local manual tests pass.
+
+## Known Risks
+
+- If a user's proxy is only defined as an interactive shell function, Hydra
+  cannot resolve that function as an executable. The user should set
+  `hydra.agentCommands.sudocode` to an explicit command such as
+  `env HTTPS_PROXY=... scode`.
+- Sudo Code may reject restored sessions when the restored worktree path differs
+  from the original `workspace_root`.
+- Session file copying preserves the last persisted Sudo Code state. If Sudo
+  Code is killed mid-turn before persisting, the latest partial output may be
+  absent.
+- The one-shot Sudo Code path can have different config behavior from REPL mode;
+  Hydra v1 must not depend on one-shot mode.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,12 @@
       },
       {
         "view": "hydraCopilots",
-        "contents": "No supported agents found on PATH.\nInstall [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), or [Gemini CLI](https://github.com/google-gemini/gemini-cli).",
+        "contents": "[Start Copilot (Sudo Code)](command:hydra.startCopilotSudoCode)",
+        "when": "hydra.sudocodeAvailable"
+      },
+      {
+        "view": "hydraCopilots",
+        "contents": "No supported agents found on PATH.\nInstall [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or Sudo Code.",
         "when": "hydra.noAgentsAvailable"
       }
     ],
@@ -179,6 +184,10 @@
       {
         "command": "hydra.startCopilotGemini",
         "title": "Hydra: Start Copilot (Gemini)"
+      },
+      {
+        "command": "hydra.startCopilotSudoCode",
+        "title": "Hydra: Start Copilot (Sudo Code)"
       }
     ],
     "keybindings": [
@@ -217,6 +226,7 @@
             "claude",
             "codex",
             "gemini",
+            "sudocode",
             "custom"
           ],
           "default": "claude",
@@ -227,7 +237,8 @@
           "default": {
             "claude": "claude",
             "codex": "codex",
-            "gemini": "gemini"
+            "gemini": "gemini",
+            "sudocode": "scode"
           },
           "markdownDescription": "Map of agent type to shell command used to launch the agent."
         },
@@ -281,7 +292,27 @@
     }
   },
   "activationEvents": [
-    "onView:hydraCopilots"
+    "onView:hydraCopilots",
+    "onCommand:tmux.attachCreate",
+    "onCommand:hydra.createWorker",
+    "onCommand:tmux.removeTask",
+    "onCommand:tmux.refresh",
+    "onCommand:tmux.attach",
+    "onCommand:tmux.attachInEditor",
+    "onCommand:tmux.openWorktree",
+    "onCommand:tmux.reviewChanges",
+    "onCommand:tmux.copyPath",
+    "onCommand:tmux.newPane",
+    "onCommand:tmux.newWindow",
+    "onCommand:tmux.terminalPaste",
+    "onCommand:tmux.pasteImage",
+    "onCommand:tmux.createWorktreeFromBranch",
+    "onCommand:hydra.openPR",
+    "onCommand:hydra.createCopilot",
+    "onCommand:hydra.startCopilotClaude",
+    "onCommand:hydra.startCopilotCodex",
+    "onCommand:hydra.startCopilotGemini",
+    "onCommand:hydra.startCopilotSudoCode"
   ],
   "scripts": {
     "compile": "tsc -p ./ && node scripts/postcompile.js",
@@ -299,10 +330,11 @@
     "smoke:telemetry-e2e": "node out/smoke/telemetryE2eSmoke.js",
     "smoke:telemetry-posthog-real": "node out/smoke/telemetryPostHogRealSmoke.js",
     "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
+    "smoke:sudocode-agent": "node out/smoke/sudocodeAgentSmoke.js",
     "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:cli-session-fields && npm run smoke:share && npm run smoke:repo-registry"
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:share && npm run smoke:repo-registry"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -8,6 +8,7 @@ function formatEntry(entry: ArchivedSessionInfo): Record<string, unknown> {
     sessionName: entry.sessionName,
     type: entry.type,
     agentSessionId: entry.agentSessionId,
+    agentSessionFile: entry.agentSessionFile || null,
     archivedAt: entry.archivedAt,
     agent: entry.data.agent,
     branch: entry.type === 'worker' ? (entry.data as { branch?: string }).branch || null : null,
@@ -21,6 +22,7 @@ function printEntry(entry: ArchivedSessionInfo): void {
   console.log(`  [${entry.type}] ${entry.sessionName}${branch}`);
   console.log(`    Agent:      ${entry.data.agent}`);
   console.log(`    Session ID: ${entry.agentSessionId || 'none'}`);
+  if (entry.agentSessionFile) console.log(`    Session file: ${entry.agentSessionFile}`);
   console.log(`    Archived:   ${entry.archivedAt}`);
 }
 

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -40,7 +40,7 @@ export function registerCopilotCommands(program: Command): void {
     .description('Create a new copilot')
     .option('--workdir <path>', 'Working directory for the copilot', process.cwd())
     .option('--repo <identifier>', 'Run inside a registered repo: <owner/name> or absolute path (overrides --workdir)')
-    .option('--agent <type>', 'Agent type (claude, codex, gemini)', 'claude')
+    .option('--agent <type>', 'Agent type (claude, codex, gemini, sudocode)', 'claude')
     .option('--name <name>', 'Display name for the copilot session')
     .option('--session <name>', 'Explicit tmux session name')
     .action(async (opts: { workdir: string; repo?: string; agent: string; name?: string; session?: string }) => {
@@ -189,7 +189,7 @@ export function registerCopilotCommands(program: Command): void {
           sm.getCopilot(sessionName),
         ]);
         const sessionFile = copilot
-          ? resolveAgentSessionFile(copilot.agent, copilot.workdir, copilot.sessionId)
+          ? resolveAgentSessionFile(copilot.agent, copilot.workdir, copilot.sessionId, copilot.agentSessionFile)
           : null;
 
         outputResult(

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -125,12 +125,12 @@ export function registerDoctorCommand(program: Command): void {
       }
 
       // 10. AI agent CLIs
-      const agents = ['claude', 'codex', 'gemini'];
+      const agents = ['claude', 'codex', 'gemini', 'scode'];
       const foundAgents = agents.filter(a => checkOnPath(a));
       if (foundAgents.length > 0) {
         checks.push({ name: 'ai-agent', status: 'pass', message: `Found: ${foundAgents.join(', ')}` });
       } else {
-        checks.push({ name: 'ai-agent', status: 'fail', message: 'No AI agent CLI found — install at least one of: claude, codex, gemini' });
+        checks.push({ name: 'ai-agent', status: 'fail', message: 'No AI agent CLI found — install at least one of: claude, codex, gemini, scode' });
       }
 
       // Compute summary

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -29,7 +29,7 @@ export function registerListCommand(program: Command): void {
             attached: c.attached,
             workdir: c.workdir || null,
             sessionId: c.sessionId,
-            sessionFile: resolveAgentSessionFile(c.agent, c.workdir, c.sessionId),
+            sessionFile: resolveAgentSessionFile(c.agent, c.workdir, c.sessionId, c.agentSessionFile),
             agentSessionId: c.sessionId,
           })),
           workers: workers.map(w => ({
@@ -44,7 +44,7 @@ export function registerListCommand(program: Command): void {
             workdir: w.workdir || null,
             copilotSessionName: w.copilotSessionName || null,
             sessionId: w.sessionId,
-            sessionFile: resolveAgentSessionFile(w.agent, w.workdir, w.sessionId),
+            sessionFile: resolveAgentSessionFile(w.agent, w.workdir, w.sessionId, w.agentSessionFile),
             agentSessionId: w.sessionId,
           })),
           count: copilots.length + workers.length,

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -7,6 +7,7 @@ import { resolveRepoInput } from '../../core/repoRegistry';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { detectCurrentTmuxIdentity, detectIdentity, getWorkerCreationBlockedMessage } from '../identity';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
+import { agentSupportsCompletionNotification } from '../../core/agentConfig';
 
 export function registerWorkerCommands(program: Command): void {
   const worker = program
@@ -18,7 +19,7 @@ export function registerWorkerCommands(program: Command): void {
     .description('Create a new worker')
     .requiredOption('--repo <path>', 'Path to the repository')
     .requiredOption('--branch <name>', 'Branch name')
-    .option('--agent <type>', 'Agent type (claude, codex, gemini)', 'claude')
+    .option('--agent <type>', 'Agent type (claude, codex, gemini, sudocode)', 'claude')
     .option('--base <branch>', 'Base branch override')
     .option('--task <prompt>', 'Task prompt for the agent')
     .option('--task-file <path>', 'Path to a file containing the task description')
@@ -232,7 +233,7 @@ export function registerWorkerCommands(program: Command): void {
           sm.getWorker(sessionName),
         ]);
         const sessionFile = worker
-          ? resolveAgentSessionFile(worker.agent, worker.workdir, worker.sessionId)
+          ? resolveAgentSessionFile(worker.agent, worker.workdir, worker.sessionId, worker.agentSessionFile)
           : null;
 
         outputResult(
@@ -268,7 +269,11 @@ export function registerWorkerCommands(program: Command): void {
 
           const sent: string[] = [];
           for (const worker of running) {
-            if (identity?.role === 'copilot' && worker.copilotSessionName === identity.sessionName) {
+            if (
+              identity?.role === 'copilot' &&
+              worker.copilotSessionName === identity.sessionName &&
+              agentSupportsCompletionNotification(worker.agent)
+            ) {
               sm.armCompletionNotification(worker.sessionName);
             }
             await backend.sendMessage(worker.sessionName, message);
@@ -290,7 +295,11 @@ export function registerWorkerCommands(program: Command): void {
           const message = messageOrUndefined;
           const sm = new SessionManager(backend);
           const worker = await sm.getWorker(session);
-          if (identity?.role === 'copilot' && worker?.copilotSessionName === identity.sessionName) {
+          if (
+            identity?.role === 'copilot' &&
+            worker?.copilotSessionName === identity.sessionName &&
+            agentSupportsCompletionNotification(worker.agent)
+          ) {
             sm.armCompletionNotification(session);
           }
           await backend.sendMessage(session, message);

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -1,11 +1,11 @@
 import { AgentType } from './types';
 
 export const AGENT_LABELS: Record<AgentType, string> = {
-  claude: 'Claude', codex: 'Codex', gemini: 'Gemini', custom: 'Custom',
+  claude: 'Claude', codex: 'Codex', gemini: 'Gemini', sudocode: 'Sudo Code', custom: 'Custom',
 };
 
 export const DEFAULT_AGENT_COMMANDS: Record<string, string> = {
-  claude: 'claude', codex: 'codex', gemini: 'gemini',
+  claude: 'claude', codex: 'codex', gemini: 'gemini', sudocode: 'scode',
 };
 
 /** Per-agent flag to enable full auto-approve (skip all permission prompts) */
@@ -13,6 +13,7 @@ export const AGENT_YOLO_FLAGS: Record<string, string> = {
   claude: '--dangerously-skip-permissions',
   codex: '--dangerously-bypass-approvals-and-sandbox',
   gemini: '--yolo',
+  sudocode: '--dangerously-skip-permissions',
 };
 
 /**
@@ -27,6 +28,8 @@ export interface SessionCaptureConfig {
   statusCommand: string;
   /** Regex to extract session ID from captured pane output (first capture group) */
   sessionIdPattern: RegExp;
+  /** Optional regex to extract the agent transcript file path (first capture group) */
+  sessionFilePattern?: RegExp;
   /** Delay (ms) before sending status command, to wait for agent readiness */
   readyDelayMs: number;
   /** Delay (ms) after sending status command, before capturing pane output */
@@ -46,6 +49,13 @@ export const AGENT_SESSION_CAPTURE: Partial<Record<string, SessionCaptureConfig>
     readyDelayMs: 15000,
     captureDelayMs: 2000,
   },
+  sudocode: {
+    statusCommand: '/status',
+    sessionIdPattern: /Session\s+(session-\d+-\d+)\b/,
+    sessionFilePattern: /Auto-save\s+(.+?\.jsonl)/,
+    readyDelayMs: 8000,
+    captureDelayMs: 1000,
+  },
 };
 
 /** Delay (ms) for Claude before sending task (agent needs time to start) — used as fallback timeout */
@@ -63,7 +73,57 @@ export const AGENT_READY_PATTERNS: Record<string, RegExp> = {
   claude: /⏵/,
   codex: /⏵|(?:^|\n)\s*›\s*/m,
   gemini: /⏵/,
+  sudocode: /(?:^|\n)\s*❯\s*/m,
 };
+
+export const AGENT_COMPLETION_NOTIFICATIONS: Record<string, boolean> = {
+  claude: true,
+  codex: true,
+  gemini: true,
+  sudocode: false,
+  custom: false,
+};
+
+export function agentSupportsCompletionNotification(agentType: string): boolean {
+  return AGENT_COMPLETION_NOTIFICATIONS[agentType] === true;
+}
+
+export function extractAgentCommandExecutable(command: string): string {
+  const tokens = tokenizeCommand(command);
+  if (tokens.length === 0) {
+    return '';
+  }
+
+  if (!isEnvExecutable(tokens[0])) {
+    return tokens[0];
+  }
+
+  for (let index = 1; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (token === '-S') {
+      return extractAgentCommandExecutable(tokens[index + 1] ?? '');
+    }
+    if (token === '-u' || token === '--unset') {
+      index += 1;
+      continue;
+    }
+    if (token === '-i' || token === '-' || token === '--ignore-environment') {
+      continue;
+    }
+    if (token.startsWith('-u') && token.length > 2) {
+      continue;
+    }
+    if (token.startsWith('-')) {
+      continue;
+    }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      continue;
+    }
+    return token;
+  }
+
+  return tokens[0];
+}
 
 /**
  * Pattern to detect the Claude trust prompt ("Do you trust this folder?").
@@ -77,6 +137,9 @@ export const CLAUDE_TRUST_PROMPT_PATTERN = /trust this folder/;
  * as a fallback for older/newer Codex picker flows.
  */
 export const CODEX_RESUME_CWD_PROMPT_PATTERN = /Choose working directory to resume this session/i;
+
+/** Sudo Code asks for explicit confirmation when launched from a broad directory. */
+export const SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN = /Continue anyway\?\s+\[y\/N\]:/i;
 
 /** Maximum time (ms) to wait for agent readiness before giving up */
 export const AGENT_READY_TIMEOUT_MS = 30000;
@@ -106,18 +169,49 @@ export function buildAgentResumeCommand(
   sessionId: string,
   workdir?: string,
 ): string | null {
+  const plan = buildAgentResumePlan(agentType, agentBinary, sessionId, workdir);
+  return plan?.strategy === 'command' ? plan.command : null;
+}
+
+export type AgentResumePlan =
+  | { strategy: 'command'; command: string }
+  | { strategy: 'replSlashCommand'; command: string; slashCommand: string };
+
+/**
+ * Build the shell command and optional in-REPL slash command needed to resume
+ * an existing agent session.
+ */
+export function buildAgentResumePlan(
+  agentType: string,
+  agentBinary: string,
+  sessionId: string,
+  workdir?: string,
+  sessionFile?: string | null,
+): AgentResumePlan | null {
   const quotedSessionId = shellQuoteForDisplay(sessionId);
   switch (agentType) {
     case 'claude': {
-      return appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`);
+      return { strategy: 'command', command: appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`) };
     }
     case 'codex': {
       const command = ensureCommandFlag(agentBinary, AGENT_YOLO_FLAGS.codex);
       const cdArgs = workdir ? ['-C', shellQuoteForDisplay(workdir)] : [];
-      return appendCommandArgs(command, 'resume', ...cdArgs, quotedSessionId);
+      return { strategy: 'command', command: appendCommandArgs(command, 'resume', ...cdArgs, quotedSessionId) };
     }
     case 'gemini':
-      return appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`);
+      return { strategy: 'command', command: appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`) };
+    case 'sudocode': {
+      const command = ensureCommandFlag(agentBinary, AGENT_YOLO_FLAGS.sudocode);
+      const resumeRef = sessionFile?.trim() || sessionId;
+      return {
+        strategy: 'replSlashCommand',
+        command,
+        // Sudo Code parses /resume by taking the full remainder after the
+        // command name, so paths with spaces must be sent raw. Shell-style
+        // quotes would become part of the path.
+        slashCommand: `/resume ${resumeRef}`,
+      };
+    }
     default:
       return null;
   }
@@ -152,6 +246,8 @@ export function buildAgentLaunchCommand(
       return task
         ? appendCommandArgs(command, shellQuoteForDisplay(task))
         : command;
+    case 'sudocode':
+      return command;
     default:
       return agentBinary;
   }
@@ -163,4 +259,56 @@ function shellQuoteForDisplay(s: string): string {
     return `"${s.replace(/[`"$]/g, '`$&')}"`;
   }
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function isEnvExecutable(token: string): boolean {
+  return /(^|[/\\])env(?:\.exe)?$/.test(token);
+}
+
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+
+  for (const char of command.trim()) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaping) {
+    current += '\\';
+  }
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
 }

--- a/src/core/hydraGlobalConfig.ts
+++ b/src/core/hydraGlobalConfig.ts
@@ -2,6 +2,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getHydraConfigPath, getHydraHome } from './path';
 
+export interface HydraGlobalConfig {
+  cli?: {
+    extensionPath?: string;
+    version?: string;
+  };
+  agentCommands?: Record<string, string>;
+}
+
 /** Ensure Hydra data/config directories exist. */
 export function ensureHydraGlobalConfig(): void {
   const hydraHome = getHydraHome();
@@ -13,4 +21,40 @@ export function ensureHydraGlobalConfig(): void {
   if (!fs.existsSync(hydraConfigDir)) {
     fs.mkdirSync(hydraConfigDir, { recursive: true });
   }
+}
+
+export function readHydraGlobalConfig(): HydraGlobalConfig {
+  ensureHydraGlobalConfig();
+  const configPath = getHydraConfigPath();
+  try {
+    if (!fs.existsSync(configPath)) {
+      return {};
+    }
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as HydraGlobalConfig
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeHydraGlobalConfig(config: HydraGlobalConfig): void {
+  ensureHydraGlobalConfig();
+  fs.writeFileSync(getHydraConfigPath(), `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}
+
+export function updateHydraGlobalAgentCommands(commands: Record<string, string>): void {
+  const config = readHydraGlobalConfig();
+  writeHydraGlobalConfig({
+    ...config,
+    agentCommands: {
+      ...(config.agentCommands ?? {}),
+      ...commands,
+    },
+  });
+}
+
+export function getHydraGlobalAgentCommand(agentType: string): string | undefined {
+  return readHydraGlobalConfig().agentCommands?.[agentType];
 }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -30,10 +30,23 @@ export function toCanonicalPath(targetPath?: string): string | undefined {
  *   - gemini:  ~/.gemini/tmp/<projectName>/logs.json
  *              (projectName looked up by workdir in ~/.gemini/projects.json;
  *              the file is per-project and may contain multiple sessions)
+ *   - sudocode:
+ *              <workdir>/.scode/sessions/<workspace-hash>/<sessionId>.jsonl
  * Returns null when the agent is unknown, required inputs are missing, or the
  * file does not exist.
  */
-export function resolveAgentSessionFile(agent: string, workdir: string, sessionId: string | null): string | null {
+export function resolveAgentSessionFile(
+  agent: string,
+  workdir: string,
+  sessionId: string | null,
+  persistedSessionFile?: string | null,
+): string | null {
+  if (persistedSessionFile && fs.existsSync(persistedSessionFile)) {
+    if (agent !== 'sudocode' || sudoCodeSessionMatchesWorkdir(persistedSessionFile, workdir)) {
+      return persistedSessionFile;
+    }
+  }
+
   switch (agent) {
     case 'claude':
       return resolveClaudeSessionFile(workdir, sessionId);
@@ -41,6 +54,8 @@ export function resolveAgentSessionFile(agent: string, workdir: string, sessionI
       return resolveCodexSessionFile(sessionId);
     case 'gemini':
       return resolveGeminiSessionFile(workdir);
+    case 'sudocode':
+      return resolveSudoCodeSessionFile(workdir, sessionId);
     default:
       return null;
   }
@@ -174,6 +189,77 @@ function resolveGeminiSessionFile(workdir: string): string | null {
 
   const logsFile = path.join(os.homedir(), '.gemini', 'tmp', projectName, 'logs.json');
   return fs.existsSync(logsFile) ? logsFile : null;
+}
+
+function resolveSudoCodeSessionFile(workdir: string, sessionId: string | null): string | null {
+  if (!workdir || !sessionId) return null;
+  const root = path.join(workdir, '.scode', 'sessions');
+  if (!fs.existsSync(root)) return null;
+
+  const filename = `${sessionId}.jsonl`;
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (
+        entry.isFile() &&
+        entry.name === filename &&
+        sudoCodeSessionMatchesWorkdir(entryPath, workdir)
+      ) {
+        return entryPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function sudoCodeSessionMatchesWorkdir(sessionFile: string, workdir: string): boolean {
+  const workspaceRoot = readSudoCodeWorkspaceRoot(sessionFile);
+  if (!workspaceRoot || !workdir) {
+    return true;
+  }
+
+  const sessionRoot = toCanonicalPath(workspaceRoot);
+  const targetRoot = toCanonicalPath(workdir);
+  if (!sessionRoot || !targetRoot) {
+    return true;
+  }
+  if (sessionRoot === targetRoot) {
+    return true;
+  }
+
+  try {
+    return fs.realpathSync.native(sessionRoot) === fs.realpathSync.native(targetRoot);
+  } catch {
+    return false;
+  }
+}
+
+function readSudoCodeWorkspaceRoot(sessionFile: string): string | null {
+  try {
+    const raw = fs.readFileSync(sessionFile, 'utf-8');
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      const parsed = JSON.parse(line);
+      if (parsed?.type === 'session_meta') {
+        return typeof parsed.workspace_root === 'string' ? parsed.workspace_root : null;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 export interface HydraCliConfig {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -3,10 +3,10 @@ import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
-import { ensureHydraGlobalConfig } from './hydraGlobalConfig';
-import { buildAgentLaunchCommand, buildAgentResumeCommand, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN } from './agentConfig';
+import { ensureHydraGlobalConfig, getHydraGlobalAgentCommand } from './hydraGlobalConfig';
+import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification } from './agentConfig';
 import { exec, resolveCommandPath } from './exec';
-import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, toCanonicalPath } from './path';
+import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, resolveAgentSessionFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 75000;
@@ -56,6 +56,36 @@ function fixWindowsSymlinks(worktreeDir: string): void {
   }
 }
 
+function countOccurrences(text: string, needle: string): number {
+  if (!needle) {
+    return 0;
+  }
+  let count = 0;
+  let index = 0;
+  while (true) {
+    const next = text.indexOf(needle, index);
+    if (next < 0) {
+      return count;
+    }
+    count += 1;
+    index = next + needle.length;
+  }
+}
+
+function rebasePathUnderDirectory(filePath: string | null | undefined, oldDir: string, newDir: string): string | null {
+  if (!filePath || !oldDir || !newDir) {
+    return null;
+  }
+
+  const normalizedFile = path.normalize(path.resolve(filePath));
+  const normalizedOldDir = path.normalize(path.resolve(oldDir));
+  if (normalizedFile !== normalizedOldDir && !normalizedFile.startsWith(`${normalizedOldDir}${path.sep}`)) {
+    return null;
+  }
+
+  return path.join(newDir, path.relative(normalizedOldDir, normalizedFile));
+}
+
 /**
  * Look up a worker's numeric ID from sessions.json.
  * Lightweight standalone function — no SessionManager instance needed.
@@ -92,6 +122,8 @@ export interface WorkerInfo {
   createdAt: string;
   lastSeenAt: string;
   sessionId: string | null;
+  /** Absolute path to the agent's native session/transcript file, when captured. */
+  agentSessionFile?: string | null;
   /** Session name of the copilot that spawned this worker, if any. */
   copilotSessionName: string | null;
 }
@@ -108,6 +140,8 @@ export interface CopilotInfo {
   createdAt: string;
   lastSeenAt: string;
   sessionId: string | null;
+  /** Absolute path to the agent's native session/transcript file, when captured. */
+  agentSessionFile?: string | null;
 }
 
 export interface SessionState {
@@ -121,6 +155,7 @@ export interface ArchivedSessionInfo {
   type: 'worker' | 'copilot';
   sessionName: string;
   agentSessionId: string | null;
+  agentSessionFile?: string | null;
   archivedAt: string;
   data: WorkerInfo | CopilotInfo;
 }
@@ -144,6 +179,8 @@ export interface CreateWorkerOpts {
   agentCommand?: string;
   /** When set, launch the agent with --resume instead of a fresh session. */
   resumeSessionId?: string;
+  /** Native session file to use for agents whose resume command accepts paths. */
+  resumeSessionFile?: string | null;
   /** Session name of the copilot that spawned this worker. */
   copilotSessionName?: string;
   /** Whether to notify the parent copilot when the worker completes (default: true). */
@@ -167,6 +204,8 @@ export interface CreateCopilotOpts {
   agentCommand?: string;
   /** When set, launch the agent with --resume instead of a fresh session. */
   resumeSessionId?: string;
+  /** Native session file to use for agents whose resume command accepts paths. */
+  resumeSessionFile?: string | null;
 }
 
 export interface CreateWorkerResult {
@@ -283,6 +322,7 @@ export class SessionManager {
             createdAt: now,
             lastSeenAt: now,
             sessionId: null,
+            agentSessionFile: null,
             copilotSessionName: null,
           };
         } else {
@@ -297,6 +337,7 @@ export class SessionManager {
             createdAt: now,
             lastSeenAt: now,
             sessionId: null,
+            agentSessionFile: null,
           };
         }
       }
@@ -346,7 +387,7 @@ export class SessionManager {
     const { repoRoot, branchName } = opts;
     let { task, taskFile } = opts;
     const agentType = opts.agentType || 'claude';
-    let agentCommand = await this.resolveAgentCommand(opts.agentCommand || DEFAULT_AGENT_COMMANDS[agentType] || agentType);
+    let agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
 
     const validationError = coreGit.validateBranchName(branchName);
     if (validationError) {
@@ -374,6 +415,7 @@ export class SessionManager {
         savedWorker,
         opts.copilotSessionName,
         opts.notifyCopilot !== false,
+        opts.resumeSessionFile,
       );
     }
 
@@ -442,7 +484,10 @@ export class SessionManager {
       ? preservedWorker.worker.sessionName
       : this.backend.buildSessionName(repoSessionNamespace, finalSlug);
     const copilotSessionName = opts.copilotSessionName;
-    const shouldNotifyCopilot = opts.notifyCopilot !== false && !!copilotSessionName && !!(task || taskFile);
+    const shouldNotifyCopilot = agentSupportsCompletionNotification(agentType) &&
+      opts.notifyCopilot !== false &&
+      !!copilotSessionName &&
+      !!(task || taskFile);
     if (shouldNotifyCopilot) {
       const peekState = this.readSessionState();
       const workerId = peekState.workers[sessionName]?.workerId ??
@@ -471,23 +516,22 @@ export class SessionManager {
     // Two distinct paths — resume (from archive) vs fresh create:
     //
     // Resume: session ID already known, launch with --resume, skip Phase 1.
-    // Fresh:  all 3 agents converge to sessionId stored in sessions.json:
+    // Fresh: supported agents converge to sessionId stored in sessions.json:
     //   - Claude: pre-assigned via --session-id flag (known immediately)
     //   - Codex:  launch → wait for ready → send /status → parse session ID
     //   - Gemini: launch → wait for ready → send /stats → parse session ID
+    //   - Sudo Code: launch → wait for ready → parse startup banner or /status
     const isResume = !!opts.resumeSessionId;
     let sessionId: string | null;
+    let launchStartedAt: number | undefined;
 
     if (isResume) {
       sessionId = opts.resumeSessionId!;
-      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId, worktreePath);
-      if (!resumeCmd) {
-        throw new Error(`Agent "${agentType}" does not support session resume`);
-      }
-      await this.backend.sendKeys(sessionName, resumeCmd);
+      await this.launchAgentResume(sessionName, agentType, agentCommand, sessionId, worktreePath, opts.resumeSessionFile);
     } else {
       sessionId = agentType === 'claude' ? randomUUID() : null;
       const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined);
+      launchStartedAt = Date.now();
       await this.backend.sendKeys(sessionName, launchCmd);
     }
 
@@ -518,6 +562,7 @@ export class SessionManager {
         createdAt: existingWorker?.createdAt ?? now,
         lastSeenAt: now,
         sessionId: sessionId ?? existingWorker?.sessionId ?? null,
+        agentSessionFile: opts.resumeSessionFile ?? existingWorker?.agentSessionFile ?? null,
         copilotSessionName: opts.copilotSessionName ?? existingWorker?.copilotSessionName ?? null,
       };
 
@@ -533,7 +578,7 @@ export class SessionManager {
         await this.waitForAgentReady(sessionName, agentType);
       } else {
         // Phase 1: Wait for readiness & capture session ID into sessions.json
-        await this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId);
+        await this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId, worktreePath, launchStartedAt);
       }
       // Phase 2: Send task prompt (only after sessions.json is up to date)
       await this.sendInitialPrompt(sessionName, task, shouldNotifyCopilot);
@@ -546,6 +591,7 @@ export class SessionManager {
     await this.killSessionOrConfirmAbsent(sessionName);
 
     const worker = this.readSessionState().workers[sessionName];
+    const archivedWorker = worker ? this.prepareArchivedSessionData(worker) as WorkerInfo : undefined;
 
     if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
       try {
@@ -569,8 +615,8 @@ export class SessionManager {
     }
 
     // Archive only after destructive cleanup has succeeded, so failed deletes remain retryable.
-    if (worker) {
-      this.archiveEntry('worker', worker.sessionName, worker.sessionId, worker);
+    if (archivedWorker) {
+      this.archiveEntry('worker', archivedWorker.sessionName, archivedWorker.sessionId, archivedWorker);
     }
 
     await this.updateSessionState((state) => {
@@ -606,7 +652,7 @@ export class SessionManager {
     }
 
     const agent = agentType || existingWorker.agent || 'claude';
-    const command = await this.resolveAgentCommand(agentCommand || DEFAULT_AGENT_COMMANDS[agent] || agent);
+    const command = await this.resolveAgentCommand(agentCommand || this.getDefaultAgentCommand(agent));
 
     await this.backend.createSession(sessionName, existingWorker.workdir);
     await this.backend.setSessionWorkdir(sessionName, existingWorker.workdir);
@@ -615,17 +661,33 @@ export class SessionManager {
 
     // Resume from stored session ID if available; otherwise fresh start
     const storedSessionId = existingWorker.sessionId;
-    const resumeCmd = storedSessionId
-      ? buildAgentResumeCommand(agent, command, storedSessionId, existingWorker.workdir)
+    const resolvedResumeSessionFile = storedSessionId
+      ? resolveAgentSessionFile(agent, existingWorker.workdir, storedSessionId, existingWorker.agentSessionFile)
       : null;
+    const canResume = !!storedSessionId &&
+      (agent !== 'sudocode' || !!resolvedResumeSessionFile) &&
+      !!buildAgentResumePlan(
+        agent,
+        command,
+        storedSessionId,
+        existingWorker.workdir,
+        resolvedResumeSessionFile,
+      );
 
     let workerInfo: WorkerInfo;
     let postCreatePromise: Promise<void>;
 
-    if (resumeCmd) {
-      // ── Resume flow: launch with --resume, no session ID capture needed ──
+    if (canResume && storedSessionId) {
+      // ── Resume flow: launch agent resume, no session ID capture needed ──
       // The agent already has its conversation context; just restart it.
-      await this.backend.sendKeys(sessionName, resumeCmd);
+      await this.launchAgentResume(
+        sessionName,
+        agent,
+        command,
+        storedSessionId,
+        existingWorker.workdir,
+        resolvedResumeSessionFile,
+      );
       workerInfo = await this.updateSessionState((currentState) => {
         const currentWorker = currentState.workers[sessionName];
         if (!currentWorker) {
@@ -635,6 +697,7 @@ export class SessionManager {
         currentWorker.status = 'running';
         currentWorker.attached = false;
         currentWorker.agent = agent;
+        currentWorker.agentSessionFile = resolvedResumeSessionFile ?? existingWorker.agentSessionFile ?? currentWorker.agentSessionFile ?? null;
         currentWorker.lastSeenAt = new Date().toISOString();
         currentState.updatedAt = currentWorker.lastSeenAt;
         return { ...currentWorker };
@@ -647,6 +710,7 @@ export class SessionManager {
       // No stored session ID — launch fresh agent and capture new session ID.
       const preAssignedSessionId = agent === 'claude' ? randomUUID() : null;
       const launchCmd = buildAgentLaunchCommand(agent, command, undefined, preAssignedSessionId ?? undefined);
+      const launchStartedAt = Date.now();
       await this.backend.sendKeys(sessionName, launchCmd);
 
       workerInfo = await this.updateSessionState((currentState) => {
@@ -659,13 +723,20 @@ export class SessionManager {
         currentWorker.attached = false;
         currentWorker.agent = agent;
         currentWorker.sessionId = preAssignedSessionId;
+        currentWorker.agentSessionFile = null;
         currentWorker.lastSeenAt = new Date().toISOString();
         currentState.updatedAt = currentWorker.lastSeenAt;
         return { ...currentWorker };
       });
 
       // Phase 1 only — startWorker is a restart, no task to send (Phase 2 skipped)
-      postCreatePromise = this.waitForReadyAndCaptureSessionId(sessionName, agent, preAssignedSessionId);
+      postCreatePromise = this.waitForReadyAndCaptureSessionId(
+        sessionName,
+        agent,
+        preAssignedSessionId,
+        existingWorker.workdir,
+        launchStartedAt,
+      );
     }
 
     return {
@@ -680,7 +751,7 @@ export class SessionManager {
     ensureHydraGlobalConfig();
 
     const agentType = opts.agentType || 'claude';
-    const agentCommand = await this.resolveAgentCommand(opts.agentCommand || DEFAULT_AGENT_COMMANDS[agentType] || agentType);
+    const agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
     const displayName = opts.name || opts.sessionName || `hydra-copilot-${agentType}`;
     const sessionName = opts.sessionName || this.backend.sanitizeSessionName(`hydra-copilot-${agentType}`);
 
@@ -698,19 +769,17 @@ export class SessionManager {
     // Same two paths as createWorker: resume vs fresh.
     const isResume = !!opts.resumeSessionId;
     let sessionId: string | null;
+    let launchStartedAt: number | undefined;
 
     let postCreatePromise = Promise.resolve();
 
     if (isResume) {
       sessionId = opts.resumeSessionId!;
-      const resumeCmd = buildAgentResumeCommand(agentType, agentCommand, sessionId, opts.workdir);
-      if (!resumeCmd) {
-        throw new Error(`Agent "${agentType}" does not support session resume`);
-      }
-      await this.backend.sendKeys(sessionName, resumeCmd);
+      await this.launchAgentResume(sessionName, agentType, agentCommand, sessionId, opts.workdir, opts.resumeSessionFile);
     } else {
       sessionId = agentType === 'claude' ? randomUUID() : null;
       const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined);
+      launchStartedAt = Date.now();
       await this.backend.sendKeys(sessionName, launchCmd);
     }
 
@@ -727,6 +796,7 @@ export class SessionManager {
       createdAt: now,
       lastSeenAt: now,
       sessionId,
+      agentSessionFile: opts.resumeSessionFile ?? null,
     };
 
     const persistedCopilotInfo = await this.updateSessionState((state) => {
@@ -735,6 +805,7 @@ export class SessionManager {
         ...copilotInfo,
         createdAt: existingCopilot?.createdAt ?? now,
         sessionId: sessionId ?? existingCopilot?.sessionId ?? null,
+        agentSessionFile: opts.resumeSessionFile ?? existingCopilot?.agentSessionFile ?? null,
       };
 
       state.copilots[sessionName] = nextCopilot;
@@ -745,7 +816,7 @@ export class SessionManager {
     // Match worker lifecycle semantics: wait for readiness and persist any deferred
     // session ID capture before the CLI treats creation as complete.
     postCreatePromise = this.withPostCreateTimeout(
-      this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId),
+      this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId, opts.workdir, launchStartedAt),
       sessionName,
       'copilot startup',
     );
@@ -852,6 +923,8 @@ export class SessionManager {
         throw new Error(`Worker "${oldSessionName}" not found`);
       }
 
+      const oldWorkdir = currentWorker.workdir;
+      const oldAgentSessionFile = currentWorker.agentSessionFile ?? null;
       const worktreeMoved = newSlug !== currentWorker.slug && fs.existsSync(newWorktreePath);
       delete currentState.workers[oldSessionName];
       currentWorker.sessionName = newSessionName;
@@ -861,6 +934,15 @@ export class SessionManager {
       currentWorker.slug = newSlug;
       if (worktreeMoved) {
         currentWorker.workdir = newWorktreePath;
+        if (currentWorker.agent === 'sudocode') {
+          currentWorker.sessionId = null;
+          currentWorker.agentSessionFile = null;
+        } else {
+          const rebasedSessionFile = rebasePathUnderDirectory(oldAgentSessionFile, oldWorkdir, newWorktreePath);
+          currentWorker.agentSessionFile = (rebasedSessionFile && fs.existsSync(rebasedSessionFile))
+            ? rebasedSessionFile
+            : resolveAgentSessionFile(currentWorker.agent, newWorktreePath, currentWorker.sessionId, null) ?? oldAgentSessionFile;
+        }
       }
       currentState.workers[newSessionName] = currentWorker;
       currentState.updatedAt = new Date().toISOString();
@@ -903,6 +985,11 @@ export class SessionManager {
       currentCopilot.displayName = newSessionName;
       currentCopilot.tmuxSession = newSessionName;
       currentState.copilots[newSessionName] = currentCopilot;
+      for (const worker of Object.values(currentState.workers)) {
+        if (worker.copilotSessionName === oldSessionName) {
+          worker.copilotSessionName = newSessionName;
+        }
+      }
       currentState.updatedAt = new Date().toISOString();
       return { ...currentCopilot };
     });
@@ -914,10 +1001,11 @@ export class SessionManager {
     } catch { /* Already dead */ }
 
     const copilot = this.readSessionState().copilots[sessionName];
+    const archivedCopilot = copilot ? this.prepareArchivedSessionData(copilot) as CopilotInfo : undefined;
 
     // Archive before removing
-    if (copilot) {
-      this.archiveEntry('copilot', copilot.sessionName, copilot.sessionId, copilot);
+    if (archivedCopilot) {
+      this.archiveEntry('copilot', archivedCopilot.sessionName, archivedCopilot.sessionId, archivedCopilot);
     }
 
     await this.updateSessionState((state) => {
@@ -955,6 +1043,7 @@ export class SessionManager {
         createdAt: existingCopilot?.createdAt ?? now,
         lastSeenAt: now,
         sessionId: sessionId ?? existingCopilot?.sessionId ?? null,
+        agentSessionFile: existingCopilot?.agentSessionFile ?? null,
       };
       state.updatedAt = now;
     });
@@ -965,8 +1054,11 @@ export class SessionManager {
    * Used by VS Code extension for Codex/Gemini copilots.
    */
   async captureAndPersistSessionId(sessionName: string, agentType: string): Promise<void> {
-    const sessionId = await this.captureAgentSessionId(sessionName, agentType);
-    await this.updateSessionId(sessionName, sessionId);
+    const state = this.readSessionState();
+    const saved = state.workers[sessionName] || state.copilots[sessionName];
+    const workdir = saved?.workdir || await this.backend.getSessionWorkdir(sessionName) || '';
+    const session = await this.captureAgentSessionInfo(sessionName, agentType, workdir);
+    await this.updateAgentSessionInfo(sessionName, session.sessionId, session.agentSessionFile);
   }
 
   // ── Archive ──
@@ -1008,6 +1100,7 @@ export class SessionManager {
       branchName: worker.branch,
       agentType: worker.agent,
       resumeSessionId: entry.agentSessionId || undefined,
+      resumeSessionFile: entry.agentSessionFile || worker.agentSessionFile || undefined,
       preservedWorkerInfo: worker,
     });
   }
@@ -1028,6 +1121,7 @@ export class SessionManager {
       name: copilot.displayName,
       sessionName: copilot.sessionName,
       resumeSessionId: entry.agentSessionId || undefined,
+      resumeSessionFile: entry.agentSessionFile || copilot.agentSessionFile || undefined,
     });
   }
 
@@ -1093,10 +1187,37 @@ export class SessionManager {
       type,
       sessionName,
       agentSessionId,
+      agentSessionFile: data.agentSessionFile ?? null,
       archivedAt: new Date().toISOString(),
       data: { ...data },
     });
     this.writeArchiveState(archive);
+  }
+
+  private prepareArchivedSessionData(data: WorkerInfo | CopilotInfo): WorkerInfo | CopilotInfo {
+    if (data.agent !== 'sudocode') {
+      return { ...data };
+    }
+
+    const sessionFile = resolveAgentSessionFile(
+      data.agent,
+      data.workdir,
+      data.sessionId,
+      data.agentSessionFile ?? null,
+    );
+    if (!sessionFile) {
+      return { ...data, agentSessionFile: data.agentSessionFile ?? null };
+    }
+
+    try {
+      const archiveDir = path.join(getHydraHome(), 'agent-sessions', 'sudocode', data.sessionName);
+      fs.mkdirSync(archiveDir, { recursive: true });
+      const archivedFile = path.join(archiveDir, path.basename(sessionFile));
+      fs.copyFileSync(sessionFile, archivedFile);
+      return { ...data, agentSessionFile: archivedFile };
+    } catch {
+      return { ...data, agentSessionFile: sessionFile };
+    }
   }
 
   private readArchiveState(): ArchiveState {
@@ -1133,10 +1254,12 @@ export class SessionManager {
         // Backward compat: ensure sessionId and displayName fields exist for legacy entries
         for (const w of Object.values(state.workers)) {
           w.sessionId ??= null;
+          w.agentSessionFile ??= null;
           w.displayName ??= w.slug || this.extractSlugFromSessionName(w.sessionName);
         }
         for (const c of Object.values(state.copilots)) {
           c.sessionId ??= null;
+          c.agentSessionFile ??= null;
           c.displayName ??= c.sessionName;
         }
         return state;
@@ -1313,14 +1436,16 @@ export class SessionManager {
     sessionName: string,
     agentType: string,
     preAssignedSessionId: string | null,
+    workdir: string,
+    launchStartedAt?: number,
   ): Promise<void> {
     if (preAssignedSessionId) {
       // Claude (or resume): sessionId already known — just wait for TUI readiness
       await this.waitForAgentReady(sessionName, agentType);
     } else {
-      // Codex/Gemini: capture sessionId via slash command (includes readiness wait)
-      const sessionId = await this.captureAgentSessionId(sessionName, agentType);
-      await this.updateSessionId(sessionName, sessionId);
+      // Codex/Gemini/Sudo Code: capture sessionId via slash command or startup banner
+      const session = await this.captureAgentSessionInfo(sessionName, agentType, workdir, launchStartedAt);
+      await this.updateAgentSessionInfo(sessionName, session.sessionId, session.agentSessionFile);
     }
   }
 
@@ -1362,6 +1487,10 @@ export class SessionManager {
       branch: string;
     },
   ): void {
+    if (!agentSupportsCompletionNotification(agentType)) {
+      return;
+    }
+
     try {
       // 1. Write the notification shell script
       const hooksDir = path.join(getHydraHome(), 'hooks');
@@ -1588,6 +1717,83 @@ export class SessionManager {
     return path.join(getHydraHome(), 'hooks', `notify-${sessionName}.pending`);
   }
 
+  private async launchAgentResume(
+    sessionName: string,
+    agentType: string,
+    agentCommand: string,
+    sessionId: string,
+    workdir: string,
+    agentSessionFile?: string | null,
+  ): Promise<void> {
+    const resumePlan = buildAgentResumePlan(agentType, agentCommand, sessionId, workdir, agentSessionFile);
+    if (!resumePlan) {
+      throw new Error(`Agent "${agentType}" does not support session resume`);
+    }
+
+    await this.backend.sendKeys(sessionName, resumePlan.command);
+    if (resumePlan.strategy === 'replSlashCommand') {
+      await this.waitForAgentReady(sessionName, agentType);
+      const beforeResume = await this.captureCleanPane(sessionName, 400);
+      await this.backend.sendMessage(sessionName, resumePlan.slashCommand);
+      await this.waitForReplSlashCommandReady(
+        sessionName,
+        agentType,
+        resumePlan.slashCommand,
+        beforeResume,
+      );
+    }
+  }
+
+  private async waitForReplSlashCommandReady(
+    sessionName: string,
+    agentType: string,
+    slashCommand: string,
+    beforeCommandOutput: string,
+  ): Promise<void> {
+    if (agentType === 'sudocode' && slashCommand.trim().startsWith('/resume')) {
+      await this.waitForSudoCodeResumeReady(sessionName, beforeCommandOutput);
+      return;
+    }
+
+    await this.waitForAgentReady(sessionName, agentType);
+  }
+
+  private async waitForSudoCodeResumeReady(
+    sessionName: string,
+    beforeResumeOutput: string,
+  ): Promise<void> {
+    const pattern = AGENT_READY_PATTERNS.sudocode;
+    const deadline = Date.now() + AGENT_READY_TIMEOUT_MS;
+    const marker = 'Session resumed';
+    const beforeMarkerCount = countOccurrences(beforeResumeOutput, marker);
+
+    await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+
+    while (Date.now() < deadline) {
+      try {
+        const output = await this.captureCleanPane(sessionName, 400);
+        let newOutput = '';
+        if (output.startsWith(beforeResumeOutput)) {
+          newOutput = output.slice(beforeResumeOutput.length);
+        } else if (countOccurrences(output, marker) > beforeMarkerCount) {
+          newOutput = output.slice(output.lastIndexOf(marker));
+        }
+
+        const markerIndex = newOutput.lastIndexOf(marker);
+        if (markerIndex >= 0) {
+          const afterMarker = newOutput.slice(markerIndex + marker.length);
+          if (pattern.test(afterMarker)) {
+            await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+            return;
+          }
+        }
+      } catch {
+        // Session may still be repainting after the slash command.
+      }
+      await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+    }
+  }
+
   /**
    * Poll the tmux pane output until the agent's ready indicator appears,
    * or fall back to the fixed delay on timeout.
@@ -1606,6 +1812,7 @@ export class SessionManager {
     const deadline = Date.now() + AGENT_READY_TIMEOUT_MS;
     let trustPromptHandled = false;
     let codexResumeCwdPromptHandled = false;
+    let sudoCodeBroadDirectoryPromptHandled = false;
 
     // Initial delay before first poll (agent needs time to start the process)
     await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
@@ -1635,6 +1842,17 @@ export class SessionManager {
           continue;
         }
 
+        if (
+          agentType === 'sudocode' &&
+          !sudoCodeBroadDirectoryPromptHandled &&
+          SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN.test(output)
+        ) {
+          await this.backend.sendKeys(sessionName, 'y');
+          sudoCodeBroadDirectoryPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
         if (pattern.test(output)) {
           // Brief settle delay — TUI input handler may not be fully interactive yet
           await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
@@ -1650,33 +1868,42 @@ export class SessionManager {
   }
 
   /**
-   * Capture session ID by sending a slash command (/status or /stats) to the agent,
-   * waiting for output, and parsing the result from the terminal pane.
+   * Capture native agent session metadata by sending a slash command
+   * (/status or /stats) to the agent, waiting for output, and parsing the
+   * terminal pane.
    *
-   * Used for Codex and Gemini. Claude uses --session-id flag instead.
-   * Returns null on failure (graceful fallback).
+   * Used for Codex, Gemini, and Sudo Code. Claude uses --session-id instead.
+   * Returns null fields on failure (graceful fallback).
    */
-  private async captureAgentSessionId(
+  private async captureAgentSessionInfo(
     sessionName: string,
     agentType: string,
-  ): Promise<string | null> {
+    workdir: string,
+    launchStartedAt?: number,
+  ): Promise<{ sessionId: string | null; agentSessionFile: string | null }> {
     const config = AGENT_SESSION_CAPTURE[agentType];
-    if (!config) return null;
+    if (!config) return { sessionId: null, agentSessionFile: null };
 
     try {
-      // For Codex, wait for the TUI prompt before sending /status. Starting
+      // For REPL TUIs, wait for the prompt before sending status. Starting
       // with Codex 0.129, the trust prompt and first paint can take long enough
       // that fixed sleeps race the input handler and lose the status command.
-      if (agentType === 'codex') {
+      if (agentType === 'codex' || agentType === 'sudocode') {
         await this.waitForAgentReady(sessionName, agentType);
       } else {
         await this.sleep(config.readyDelayMs);
       }
 
       const existingOutput = await this.backend.capturePane(sessionName, 400);
-      const existingMatch = existingOutput.match(config.sessionIdPattern);
-      if (existingMatch?.[1]) {
-        return existingMatch[1];
+      const existing = this.parseAgentSessionInfo(agentType, workdir, existingOutput);
+      if (existing.sessionId) {
+        return existing;
+      }
+      if (agentType === 'sudocode') {
+        const latest = this.findLatestSudoCodeSessionInfo(workdir, launchStartedAt);
+        if (latest.sessionId) {
+          return latest;
+        }
       }
 
       // Send status slash command (use sendMessage for reliable Enter delivery to TUIs)
@@ -1688,29 +1915,143 @@ export class SessionManager {
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         await this.sleep(pollInterval);
         const output = await this.backend.capturePane(sessionName, 400);
-        const match = output.match(config.sessionIdPattern);
-        if (match?.[1]) {
-          return match[1];
+        const parsed = this.parseAgentSessionInfo(agentType, workdir, output);
+        if (parsed.sessionId) {
+          return parsed;
+        }
+        if (agentType === 'sudocode') {
+          const latest = this.findLatestSudoCodeSessionInfo(workdir, launchStartedAt);
+          if (latest.sessionId) {
+            return latest;
+          }
         }
       }
 
       console.warn(
         `[hydra] Could not parse session ID for ${agentType} in ${sessionName}`,
       );
-      return null;
+      return { sessionId: null, agentSessionFile: null };
     } catch (error) {
       console.warn(`[hydra] Session ID capture failed for ${sessionName}:`, error);
-      return null;
+      return { sessionId: null, agentSessionFile: null };
     }
   }
 
-  private async updateSessionId(sessionName: string, sessionId: string | null): Promise<void> {
+  private parseAgentSessionInfo(
+    agentType: string,
+    workdir: string,
+    output: string,
+  ): { sessionId: string | null; agentSessionFile: string | null } {
+    const config = AGENT_SESSION_CAPTURE[agentType];
+    if (!config) return { sessionId: null, agentSessionFile: null };
+
+    const cleanOutput = this.stripAnsi(output);
+    const sessionId = cleanOutput.match(config.sessionIdPattern)?.[1] ?? null;
+    const capturedFile = config.sessionFilePattern
+      ? cleanOutput.match(config.sessionFilePattern)?.[1]?.trim() ?? null
+      : null;
+    const resolvedFile = capturedFile ? this.resolveCapturedSessionFile(workdir, capturedFile) : null;
+    const agentSessionFile = resolvedFile || resolveAgentSessionFile(agentType, workdir, sessionId);
+
+    return { sessionId, agentSessionFile };
+  }
+
+  private findLatestSudoCodeSessionInfo(
+    workdir: string,
+    minMtimeMs?: number,
+  ): { sessionId: string | null; agentSessionFile: string | null } {
+    if (!workdir) return { sessionId: null, agentSessionFile: null };
+    const root = path.join(workdir, '.scode', 'sessions');
+    if (!fs.existsSync(root)) return { sessionId: null, agentSessionFile: null };
+
+    let latestFile: string | null = null;
+    let latestMtime = -1;
+    const stack = [root];
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        const entryPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(entryPath);
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith('.jsonl')) {
+          continue;
+        }
+
+        try {
+          const mtime = fs.statSync(entryPath).mtimeMs;
+          if (minMtimeMs !== undefined && mtime < minMtimeMs - 1000) {
+            continue;
+          }
+          if (mtime > latestMtime) {
+            latestMtime = mtime;
+            latestFile = entryPath;
+          }
+        } catch {
+          // Best-effort scan; ignore files that disappear mid-walk.
+        }
+      }
+    }
+
+    if (!latestFile) return { sessionId: null, agentSessionFile: null };
+    const basenameMatch = path.basename(latestFile).match(/^(session-\d+-\d+)\.jsonl$/);
+    const sessionId = this.readSudoCodeSessionId(latestFile) || basenameMatch?.[1] || null;
+    return { sessionId, agentSessionFile: latestFile };
+  }
+
+  private readSudoCodeSessionId(sessionFile: string): string | null {
+    try {
+      const raw = fs.readFileSync(sessionFile, 'utf-8');
+      for (const line of raw.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        const parsed = JSON.parse(line);
+        if (parsed?.type === 'session_meta' && typeof parsed.session_id === 'string') {
+          return parsed.session_id;
+        }
+      }
+    } catch {
+      // Fall back to the filename.
+    }
+    return null;
+  }
+
+  private resolveCapturedSessionFile(workdir: string, sessionFile: string): string | null {
+    const cleaned = sessionFile.trim();
+    if (!cleaned) return null;
+    const unquoted = cleaned.replace(/^['"]|['"]$/g, '');
+    return path.normalize(path.isAbsolute(unquoted) ? unquoted : path.resolve(workdir, unquoted));
+  }
+
+  private stripAnsi(text: string): string {
+    const escape = String.fromCharCode(27);
+    return text.replace(new RegExp(`${escape}\\[[0-?]*[ -/]*[@-~]`, 'g'), '');
+  }
+
+  private async captureCleanPane(sessionName: string, lines: number): Promise<string> {
+    return this.stripAnsi(await this.backend.capturePane(sessionName, lines));
+  }
+
+  private async updateAgentSessionInfo(
+    sessionName: string,
+    sessionId: string | null,
+    agentSessionFile: string | null,
+  ): Promise<void> {
     await this.updateSessionState((state) => {
       if (state.workers[sessionName]) {
         state.workers[sessionName].sessionId = sessionId;
+        state.workers[sessionName].agentSessionFile = agentSessionFile;
         state.updatedAt = new Date().toISOString();
       } else if (state.copilots[sessionName]) {
         state.copilots[sessionName].sessionId = sessionId;
+        state.copilots[sessionName].agentSessionFile = agentSessionFile;
         state.updatedAt = new Date().toISOString();
       }
     });
@@ -1726,6 +2067,10 @@ export class SessionManager {
       return sessionName.substring(underscoreIdx + 1);
     }
     return sessionName;
+  }
+
+  private getDefaultAgentCommand(agentType: string): string {
+    return getHydraGlobalAgentCommand(agentType) || DEFAULT_AGENT_COMMANDS[agentType] || agentType;
   }
 
   private async resolveAgentCommand(agentCommand: string): Promise<string> {
@@ -1866,12 +2211,14 @@ export class SessionManager {
     savedWorkerMatch?: SavedWorkerMatch,
     copilotSessionName?: string,
     notifyCopilot = false,
+    resumeSessionFile?: string | null,
   ): Promise<CreateWorkerResult> {
     const savedWorker = savedWorkerMatch?.worker;
     const slug = savedWorker?.slug || coreGit.branchNameToSlug(branchName, this.backend);
     const sessionName = savedWorker?.sessionName || this.backend.buildSessionName(repoSessionNamespace, slug);
     const existingWorkerState = this.readSessionState().workers[sessionName] || savedWorker;
-    const shouldNotifyCopilot = notifyCopilot &&
+    const shouldNotifyCopilot = agentSupportsCompletionNotification(agentType) &&
+      notifyCopilot &&
       !!copilotSessionName &&
       !!task &&
       existingWorkerState?.copilotSessionName === copilotSessionName;
@@ -1923,6 +2270,7 @@ export class SessionManager {
           createdAt: existingWorker?.createdAt ?? now,
           lastSeenAt: now,
           sessionId: existingWorker?.sessionId ?? null,
+          agentSessionFile: resumeSessionFile ?? existingWorker?.agentSessionFile ?? null,
           copilotSessionName: existingWorker?.copilotSessionName ?? null,
         };
 
@@ -1955,19 +2303,36 @@ export class SessionManager {
       const now = new Date().toISOString();
       const existingWorker = this.readSessionState().workers[sessionName] || savedWorker;
       const storedSessionId = existingWorker?.sessionId;
+      const requestedResumeSessionFile = resumeSessionFile ?? existingWorker?.agentSessionFile ?? null;
+      const resolvedResumeSessionFile = storedSessionId
+        ? resolveAgentSessionFile(agentType, worktreePath, storedSessionId, requestedResumeSessionFile)
+        : null;
 
       // Resume or fresh start
-      const resumeCmd = storedSessionId
-        ? buildAgentResumeCommand(agentType, agentCommand, storedSessionId, worktreePath)
-        : null;
+      const canResume = !!storedSessionId &&
+        (agentType !== 'sudocode' || !!resolvedResumeSessionFile) &&
+        !!buildAgentResumePlan(
+          agentType,
+          agentCommand,
+          storedSessionId,
+          worktreePath,
+          resolvedResumeSessionFile,
+        );
 
       let postCreatePromise: Promise<void>;
       let sessionId: string | null;
 
-      if (resumeCmd) {
-        // ── Resume flow: launch with --resume, no session ID capture needed ──
+      if (canResume && storedSessionId) {
+        // ── Resume flow: launch agent resume, no session ID capture needed ──
         // The agent already has its conversation context from the previous session.
-        await this.backend.sendKeys(sessionName, resumeCmd);
+        await this.launchAgentResume(
+          sessionName,
+          agentType,
+          agentCommand,
+          storedSessionId,
+          worktreePath,
+          resolvedResumeSessionFile,
+        );
         sessionId = storedSessionId;
         // Skip Phase 1 (sessionId already known). Phase 2 only: send task if provided.
         postCreatePromise = (async () => {
@@ -1978,10 +2343,17 @@ export class SessionManager {
         // ── Fresh start: Phase 1 (capture sessionId) → Phase 2 (send task) ──
         const preAssignedSessionId = agentType === 'claude' ? randomUUID() : null;
         const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, preAssignedSessionId ?? undefined);
+        const launchStartedAt = Date.now();
         await this.backend.sendKeys(sessionName, launchCmd);
         sessionId = preAssignedSessionId;
         postCreatePromise = (async () => {
-          await this.waitForReadyAndCaptureSessionId(sessionName, agentType, preAssignedSessionId);
+          await this.waitForReadyAndCaptureSessionId(
+            sessionName,
+            agentType,
+            preAssignedSessionId,
+            worktreePath,
+            launchStartedAt,
+          );
           await this.sendInitialPrompt(sessionName, task, shouldNotifyCopilot);
         })();
       }
@@ -2009,6 +2381,7 @@ export class SessionManager {
           createdAt: currentWorker?.createdAt ?? now,
           lastSeenAt: now,
           sessionId,
+          agentSessionFile: canResume ? resolvedResumeSessionFile ?? requestedResumeSessionFile : null,
           copilotSessionName: currentWorker?.copilotSessionName ?? null,
         };
 

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -35,7 +35,7 @@ const FIRST_RUN_NOTICE =
 // UUIDv4 only: position 14 must be `4`, position 19 must be 8/9/a/b.
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini']);
+const KNOWN_AGENTS = new Set(['claude', 'codex', 'gemini', 'sudocode']);
 
 export function normalizeAgentForTelemetry(agent: string | undefined | null): string {
   if (typeof agent !== 'string' || !agent.trim()) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export type MultiplexerType = 'tmux';
 export type HydraRole = 'copilot' | 'worker';
-export type AgentType = 'claude' | 'codex' | 'gemini' | 'custom';
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'sudocode' | 'custom';
 
 export interface MultiplexerSession {
   name: string;

--- a/src/e2e/runner.ts
+++ b/src/e2e/runner.ts
@@ -135,24 +135,30 @@ async function sleep(ms: number): Promise<void> {
 
 async function detectAgent(preferredAgent?: string): Promise<string> {
   if (preferredAgent) {
+    const command = preferredAgent === 'sudocode' ? 'scode' : preferredAgent;
     try {
-      await exec(`which ${preferredAgent}`);
+      await exec(`which ${command}`);
       return preferredAgent;
     } catch {
       throw new Error(`Requested agent "${preferredAgent}" is not installed or not on PATH`);
     }
   }
 
-  for (const agent of ['claude', 'codex', 'gemini']) {
+  for (const candidate of [
+    { type: 'claude', command: 'claude' },
+    { type: 'codex', command: 'codex' },
+    { type: 'gemini', command: 'gemini' },
+    { type: 'sudocode', command: 'scode' },
+  ]) {
     try {
-      await exec(`which ${agent}`);
-      return agent;
+      await exec(`which ${candidate.command}`);
+      return candidate.type;
     } catch {
       // Try the next agent.
     }
   }
 
-  throw new Error('No agent CLI found. Install one of: claude, codex, gemini');
+  throw new Error('No agent CLI found. Install one of: claude, codex, gemini, scode');
 }
 
 async function checkPrerequisites(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
 import { createCopilot, createCopilotWithAgent } from './commands/createCopilot';
 import { ensureHydraGlobalConfig } from './utils/hydraGlobalConfig';
 import { installCli, ensurePathInShellProfile } from './core/cliInstaller';
-import { detectAvailableAgents } from './utils/agentConfig';
+import { detectAvailableAgents, syncAgentCommandsToHydraConfig } from './utils/agentConfig';
 import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } from './utils/hydraEditorGroup';
 import { lookupWorkerId } from './core/sessionManager';
 import { getHydraSessionsFile } from './core/path';
@@ -57,10 +57,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('hydra.startCopilotClaude', () => createCopilotWithAgent('claude')),
     vscode.commands.registerCommand('hydra.startCopilotCodex', () => createCopilotWithAgent('codex')),
     vscode.commands.registerCommand('hydra.startCopilotGemini', () => createCopilotWithAgent('gemini')),
+    vscode.commands.registerCommand('hydra.startCopilotSudoCode', () => createCopilotWithAgent('sudocode')),
   );
 
   ensureHydraGlobalConfig();
   silentInstallCli(context);
+  syncAgentCommandsToHydraConfig();
   autoAttachOnStartup();
   detectAndSetAgentContext();
 
@@ -70,6 +72,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('hydra.agentCommands')) {
+        syncAgentCommandsToHydraConfig();
         detectAndSetAgentContext();
       }
     })
@@ -179,6 +182,7 @@ async function detectAndSetAgentContext(): Promise<void> {
     vscode.commands.executeCommand('setContext', 'hydra.claudeAvailable', available.includes('claude'));
     vscode.commands.executeCommand('setContext', 'hydra.codexAvailable', available.includes('codex'));
     vscode.commands.executeCommand('setContext', 'hydra.geminiAvailable', available.includes('gemini'));
+    vscode.commands.executeCommand('setContext', 'hydra.sudocodeAvailable', available.includes('sudocode'));
     vscode.commands.executeCommand('setContext', 'hydra.noAgentsAvailable', available.length === 0);
   } catch {
     // Best-effort — don't block activation

--- a/src/smoke/sessionFileResolveSmoke.ts
+++ b/src/smoke/sessionFileResolveSmoke.ts
@@ -1,6 +1,7 @@
 /**
  * Smoke test: resolveAgentSessionFile resolves transcript paths for claude,
- * codex, and gemini against fixture homes laid out under a temp directory.
+ * codex, gemini, and sudocode against fixture homes laid out under a temp
+ * directory.
  *
  * Run:  node out/smoke/sessionFileResolveSmoke.js
  */
@@ -130,6 +131,53 @@ function testGeminiMissingLogs(): void {
   });
 }
 
+function testSudoCode(): void {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-resolve-'));
+  try {
+    const workdir = path.join(tmp, 'worktree');
+    const sessionId = 'session-1778831515919-0';
+    const expected = path.join(workdir, '.scode', 'sessions', 'ea44ee3d072f6b6a', `${sessionId}.jsonl`);
+    writeFile(expected, '{}\n');
+
+    assert.equal(resolveAgentSessionFile('sudocode', workdir, sessionId), expected);
+    assert.equal(resolveAgentSessionFile('sudocode', workdir, 'session-000-0'), null);
+    assert.equal(resolveAgentSessionFile('sudocode', workdir, null), null);
+    assert.equal(resolveAgentSessionFile('sudocode', '', sessionId), null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function testSudoCodeWorkspaceMismatch(): void {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-mismatch-'));
+  try {
+    const oldWorkdir = path.join(tmp, 'old-worktree');
+    const newWorkdir = path.join(tmp, 'new-worktree');
+    const sessionId = 'session-1778843662908-0';
+    const movedSessionFile = path.join(newWorkdir, '.scode', 'sessions', 'hash', `${sessionId}.jsonl`);
+    writeFile(
+      movedSessionFile,
+      `${JSON.stringify({ type: 'session_meta', session_id: sessionId, workspace_root: oldWorkdir })}\n`,
+    );
+
+    assert.equal(resolveAgentSessionFile('sudocode', newWorkdir, sessionId), null);
+    assert.equal(resolveAgentSessionFile('sudocode', newWorkdir, sessionId, movedSessionFile), null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function testPersistedSessionFileFallback(): void {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-persisted-session-'));
+  try {
+    const persisted = path.join(tmp, 'archived.jsonl');
+    writeFile(persisted, '{}\n');
+    assert.equal(resolveAgentSessionFile('sudocode', '/missing/workdir', 'session-1-0', persisted), persisted);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 function testUnknownAgent(): void {
   withFakeHome(() => {
     assert.equal(resolveAgentSessionFile('unknown', '/x', 'y'), null);
@@ -178,6 +226,9 @@ function main(): void {
   testGemini();
   testGeminiPathNormalization();
   testGeminiMissingLogs();
+  testSudoCode();
+  testSudoCodeWorkspaceMismatch();
+  testPersistedSessionFileFallback();
   testUnknownAgent();
   console.log('sessionFileResolveSmoke: ok');
 }

--- a/src/smoke/sudocodeAgentSmoke.ts
+++ b/src/smoke/sudocodeAgentSmoke.ts
@@ -1,0 +1,379 @@
+/**
+ * Smoke test for Sudo Code agent support.
+ *
+ * Run: node out/smoke/sudocodeAgentSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  agentSupportsCompletionNotification,
+  buildAgentLaunchCommand,
+  buildAgentResumeCommand,
+  buildAgentResumePlan,
+  extractAgentCommandExecutable,
+} from '../core/agentConfig';
+import { SessionManager } from '../core/sessionManager';
+import type {
+  HydraRole,
+  MultiplexerBackendCore,
+  MultiplexerSession,
+  SessionStatusInfo,
+} from '../core/types';
+
+class FakeBackend implements MultiplexerBackendCore {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'fake';
+  readonly installHint = 'fake';
+  readonly sentKeys: string[] = [];
+  readonly messages: string[] = [];
+  private pendingPaneOutput: string | null = null;
+  private pendingCaptureCount = 0;
+
+  constructor(private paneOutput: string) {}
+
+  setPaneOutput(output: string): void {
+    this.paneOutput = output;
+  }
+
+  async isInstalled(): Promise<boolean> { return true; }
+  async listSessions(): Promise<MultiplexerSession[]> { return []; }
+  async createSession(): Promise<void> {}
+  async killSession(): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async hasSession(): Promise<boolean> { return false; }
+  async getSessionWorkdir(): Promise<string | undefined> { return undefined; }
+  async setSessionWorkdir(): Promise<void> {}
+  async getSessionRole(): Promise<HydraRole | undefined> { return undefined; }
+  async setSessionRole(): Promise<void> {}
+  async getSessionAgent(): Promise<string | undefined> { return undefined; }
+  async setSessionAgent(): Promise<void> {}
+  async sendKeys(_sessionName: string, keys: string): Promise<void> {
+    this.sentKeys.push(keys);
+    if (keys === 'y') {
+      this.setPaneOutput('❯');
+    }
+  }
+  async capturePane(): Promise<string> {
+    if (this.pendingPaneOutput) {
+      if (this.pendingCaptureCount <= 0) {
+        this.paneOutput = this.pendingPaneOutput;
+        this.pendingPaneOutput = null;
+      } else {
+        this.pendingCaptureCount -= 1;
+      }
+    }
+    return this.paneOutput;
+  }
+  async sendMessage(_sessionName: string, message: string): Promise<void> {
+    this.messages.push(message);
+    if (message.startsWith('/resume ')) {
+      this.setPaneOutput(`${this.paneOutput}\n${message}`);
+      this.pendingPaneOutput = `${this.paneOutput}\nSession resumed\n  Messages         2\n❯`;
+      this.pendingCaptureCount = 1;
+    }
+  }
+  async getSessionInfo(): Promise<SessionStatusInfo> { return { attached: false, lastActive: 0 }; }
+  async getSessionPaneCount(): Promise<number> { return 1; }
+  async getSessionPanePids(): Promise<string[]> { return []; }
+  async splitPane(): Promise<void> {}
+  async newWindow(): Promise<void> {}
+  buildSessionName(repoName: string, slug: string): string { return `${repoName}_${slug}`; }
+  sanitizeSessionName(name: string): string { return name; }
+}
+
+interface UnsafeSessionManager {
+  captureAgentSessionInfo(
+    sessionName: string,
+    agentType: string,
+    workdir: string,
+    launchStartedAt?: number,
+  ): Promise<{ sessionId: string | null; agentSessionFile: string | null }>;
+  findLatestSudoCodeSessionInfo(
+    workdir: string,
+    minMtimeMs?: number,
+  ): { sessionId: string | null; agentSessionFile: string | null };
+  launchAgentResume(
+    sessionName: string,
+    agentType: string,
+    agentCommand: string,
+    sessionId: string,
+    workdir: string,
+    agentSessionFile?: string | null,
+  ): Promise<void>;
+  getDefaultAgentCommand(agentType: string): string;
+  waitForAgentReady(sessionName: string, agentType: string): Promise<void>;
+}
+
+function testAgentConfig(): void {
+  assert.equal(
+    buildAgentLaunchCommand('sudocode', 'scode', 'Implement the task'),
+    'scode --dangerously-skip-permissions',
+  );
+  assert.equal(
+    buildAgentLaunchCommand('sudocode', 'scode --dangerously-skip-permissions', 'Implement the task'),
+    'scode --dangerously-skip-permissions',
+  );
+  assert.equal(buildAgentResumeCommand('sudocode', 'scode', 'session-1-0'), null);
+
+  const plan = buildAgentResumePlan(
+    'sudocode',
+    'scode',
+    'session-1-0',
+    '/workspace',
+    '/tmp/session-1-0.jsonl',
+  );
+  assert.deepEqual(plan, {
+    strategy: 'replSlashCommand',
+    command: 'scode --dangerously-skip-permissions',
+    slashCommand: '/resume /tmp/session-1-0.jsonl',
+  });
+
+  const spacedPathPlan = buildAgentResumePlan(
+    'sudocode',
+    'scode',
+    'session-1-0',
+    '/workspace',
+    '/tmp/hydra sessions/session-1-0.jsonl',
+  );
+  assert.equal(
+    spacedPathPlan?.strategy === 'replSlashCommand' ? spacedPathPlan.slashCommand : null,
+    '/resume /tmp/hydra sessions/session-1-0.jsonl',
+    'Sudo Code /resume consumes the full remainder, so paths with spaces stay raw',
+  );
+
+  assert.equal(extractAgentCommandExecutable('env HTTPS_PROXY=http://127.0.0.1:7897 scode'), 'scode');
+  assert.equal(
+    extractAgentCommandExecutable('/usr/bin/env HTTPS_PROXY=http://127.0.0.1:7897 scode'),
+    'scode',
+  );
+  assert.equal(extractAgentCommandExecutable('env -u FOO BAR=1 /opt/bin/scode'), '/opt/bin/scode');
+  assert.equal(extractAgentCommandExecutable('scode --dangerously-skip-permissions'), 'scode');
+
+  assert.equal(agentSupportsCompletionNotification('claude'), true);
+  assert.equal(agentSupportsCompletionNotification('codex'), true);
+  assert.equal(agentSupportsCompletionNotification('gemini'), true);
+  assert.equal(agentSupportsCompletionNotification('sudocode'), false);
+}
+
+async function testSudoCodeSessionCapture(): Promise<void> {
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-capture-'));
+  try {
+    const output = [
+      'Sudo Code',
+      '│   Session          session-1778831515919-0                                        │',
+      '│   Auto-save        .scode/sessions/ea44ee3d072f6b6a/session-1778831515919-0.jsonl │',
+      '',
+      '❯',
+    ].join('\n');
+    const backend = new FakeBackend(output);
+    const sm = new SessionManager(backend) as unknown as UnsafeSessionManager;
+    const captured = await sm.captureAgentSessionInfo('s', 'sudocode', workdir);
+
+    assert.equal(captured.sessionId, 'session-1778831515919-0');
+    assert.equal(
+      captured.agentSessionFile,
+      path.join(workdir, '.scode', 'sessions', 'ea44ee3d072f6b6a', 'session-1778831515919-0.jsonl'),
+    );
+    assert.deepEqual(backend.messages, [], 'startup banner should avoid an extra /status round trip');
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+function testSudoCodeSessionFileFallback(): void {
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-file-fallback-'));
+  try {
+    const sessionId = 'session-1778836161133-0';
+    const sessionFile = path.join(workdir, '.scode', 'sessions', 'd42d407d9f3027ab', `${sessionId}.jsonl`);
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(
+      sessionFile,
+      `${JSON.stringify({ type: 'session_meta', session_id: sessionId })}\n`,
+      'utf-8',
+    );
+
+    const backend = new FakeBackend('❯');
+    const sm = new SessionManager(backend) as unknown as UnsafeSessionManager;
+    assert.deepEqual(sm.findLatestSudoCodeSessionInfo(workdir), {
+      sessionId,
+      agentSessionFile: sessionFile,
+    });
+    assert.deepEqual(sm.findLatestSudoCodeSessionInfo(workdir, Date.now() + 60_000), {
+      sessionId: null,
+      agentSessionFile: null,
+    });
+  } finally {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+function testHydraGlobalAgentCommandFallback(): void {
+  const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-global-config-'));
+  const oldConfigPath = process.env.HYDRA_CONFIG_PATH;
+  const oldHome = process.env.HYDRA_HOME;
+  try {
+    process.env.HYDRA_HOME = path.join(configRoot, 'home');
+    process.env.HYDRA_CONFIG_PATH = path.join(configRoot, 'config.json');
+    fs.writeFileSync(
+      process.env.HYDRA_CONFIG_PATH,
+      JSON.stringify({
+        cli: { extensionPath: '/extension', version: 'test' },
+        agentCommands: { sudocode: 'env HTTPS_PROXY=http://127.0.0.1:7897 scode' },
+      }),
+      'utf-8',
+    );
+
+    const sm = new SessionManager(new FakeBackend('')) as unknown as UnsafeSessionManager;
+    assert.equal(sm.getDefaultAgentCommand('sudocode'), 'env HTTPS_PROXY=http://127.0.0.1:7897 scode');
+    assert.equal(sm.getDefaultAgentCommand('unknown-agent'), 'unknown-agent');
+  } finally {
+    if (oldConfigPath === undefined) {
+      delete process.env.HYDRA_CONFIG_PATH;
+    } else {
+      process.env.HYDRA_CONFIG_PATH = oldConfigPath;
+    }
+    if (oldHome === undefined) {
+      delete process.env.HYDRA_HOME;
+    } else {
+      process.env.HYDRA_HOME = oldHome;
+    }
+    fs.rmSync(configRoot, { recursive: true, force: true });
+  }
+}
+
+async function testSudoCodeResumeLaunch(): Promise<void> {
+  const backend = new FakeBackend('❯');
+  const sm = new SessionManager(backend) as unknown as UnsafeSessionManager;
+
+  await sm.launchAgentResume(
+    's',
+    'sudocode',
+    'scode',
+    'session-1778831515919-0',
+    '/workspace',
+    '/tmp/session-1778831515919-0.jsonl',
+  );
+
+  assert.deepEqual(backend.sentKeys, ['scode --dangerously-skip-permissions']);
+  assert.deepEqual(backend.messages, ['/resume /tmp/session-1778831515919-0.jsonl']);
+  assert.match(await backend.capturePane(), /Session resumed[\s\S]*❯/);
+}
+
+async function testSudoCodeStartSkipsMismatchedWorkspaceSessionFile(): Promise<void> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-sudocode-start-resolve-'));
+  const oldHome = process.env.HYDRA_HOME;
+  const oldConfigPath = process.env.HYDRA_CONFIG_PATH;
+
+  try {
+    const hydraHome = path.join(root, 'home');
+    const workdir = path.join(root, 'worktree-renamed');
+    const oldWorkdir = path.join(root, 'worktree-old');
+    const sessionName = 'repo_worker';
+    const sessionId = 'session-1778843662908-0';
+    const newSessionId = 'session-1778844056844-0';
+    const oldSessionFile = path.join(oldWorkdir, '.scode', 'sessions', 'hash', `${sessionId}.jsonl`);
+    const movedSessionFile = path.join(workdir, '.scode', 'sessions', 'hash', `${sessionId}.jsonl`);
+    const newSessionFile = path.join(workdir, '.scode', 'sessions', 'newhash', `${newSessionId}.jsonl`);
+
+    process.env.HYDRA_HOME = hydraHome;
+    process.env.HYDRA_CONFIG_PATH = path.join(root, 'config.json');
+    fs.mkdirSync(path.dirname(movedSessionFile), { recursive: true });
+    fs.writeFileSync(
+      movedSessionFile,
+      `${JSON.stringify({ type: 'session_meta', session_id: sessionId, workspace_root: oldWorkdir })}\n`,
+      'utf-8',
+    );
+    fs.mkdirSync(hydraHome, { recursive: true });
+
+    const now = new Date().toISOString();
+    fs.writeFileSync(
+      path.join(hydraHome, 'sessions.json'),
+      JSON.stringify({
+        copilots: {},
+        workers: {
+          [sessionName]: {
+            sessionName,
+            displayName: 'worker',
+            workerId: 1,
+            repo: 'repo',
+            repoRoot: workdir,
+            branch: 'branch',
+            slug: 'worker',
+            status: 'stopped',
+            attached: false,
+            agent: 'sudocode',
+            workdir,
+            tmuxSession: sessionName,
+            createdAt: now,
+            lastSeenAt: now,
+            sessionId,
+            agentSessionFile: oldSessionFile,
+            copilotSessionName: null,
+          },
+        },
+        nextWorkerId: 2,
+        updatedAt: now,
+      }, null, 2),
+      'utf-8',
+    );
+
+    const backend = new FakeBackend([
+      'Sudo Code',
+      `│   Session          ${newSessionId}                                        │`,
+      `│   Auto-save        .scode/sessions/newhash/${newSessionId}.jsonl │`,
+      '',
+      '❯',
+    ].join('\n'));
+    const sm = new SessionManager(backend);
+    const result = await sm.startWorker(sessionName);
+    await result.postCreatePromise;
+
+    assert.deepEqual(backend.messages, []);
+    assert.equal(backend.sentKeys.length, 1);
+    assert.match(backend.sentKeys[0], /scode'?\s+--dangerously-skip-permissions$/);
+
+    const updated = JSON.parse(fs.readFileSync(path.join(hydraHome, 'sessions.json'), 'utf-8'));
+    assert.equal(updated.workers[sessionName].sessionId, newSessionId);
+    assert.equal(updated.workers[sessionName].agentSessionFile, newSessionFile);
+  } finally {
+    if (oldHome === undefined) {
+      delete process.env.HYDRA_HOME;
+    } else {
+      process.env.HYDRA_HOME = oldHome;
+    }
+    if (oldConfigPath === undefined) {
+      delete process.env.HYDRA_CONFIG_PATH;
+    } else {
+      process.env.HYDRA_CONFIG_PATH = oldConfigPath;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function testSudoCodeBroadDirectoryPrompt(): Promise<void> {
+  const backend = new FakeBackend('Continue anyway? [y/N]:');
+  const sm = new SessionManager(backend) as unknown as UnsafeSessionManager;
+
+  await sm.waitForAgentReady('s', 'sudocode');
+
+  assert.deepEqual(backend.sentKeys, ['y']);
+}
+
+async function main(): Promise<void> {
+  testAgentConfig();
+  await testSudoCodeSessionCapture();
+  testSudoCodeSessionFileFallback();
+  testHydraGlobalAgentCommandFallback();
+  await testSudoCodeResumeLaunch();
+  await testSudoCodeStartSkipsMismatchedWorkspaceSessionFile();
+  await testSudoCodeBroadDirectoryPrompt();
+  console.log('sudocodeAgentSmoke: ok');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/utils/agentConfig.ts
+++ b/src/utils/agentConfig.ts
@@ -1,16 +1,17 @@
 import * as vscode from 'vscode';
 import { AgentType } from '../core/types';
-import { AGENT_LABELS } from '../core/agentConfig';
+import { AGENT_LABELS, extractAgentCommandExecutable } from '../core/agentConfig';
 import { resolveCommandPath } from '../core/exec';
+import { updateHydraGlobalAgentCommands } from '../core/hydraGlobalConfig';
 
 export type { AgentType } from '../core/types';
 export { AGENT_LABELS, DEFAULT_AGENT_COMMANDS, buildAgentLaunchCommand } from '../core/agentConfig';
 
 export async function detectAvailableAgents(): Promise<AgentType[]> {
-  const agents: AgentType[] = ['claude', 'codex', 'gemini'];
+  const agents: AgentType[] = ['claude', 'codex', 'gemini', 'sudocode'];
   const results = await Promise.all(agents.map(async (agent) => {
     const cmd = getAgentCommand(agent);
-    const binary = cmd.split(/\s+/)[0];
+    const binary = extractAgentCommandExecutable(cmd);
     return await resolveCommandPath(binary) ? agent : null;
   }));
   return results.filter((a): a is AgentType => a !== null);
@@ -23,14 +24,23 @@ export function getDefaultAgent(): AgentType {
 }
 
 export function getAgentCommand(agentType: string): string {
-  const commands = vscode.workspace
+  const commands = getAgentCommands();
+  return commands[agentType] || agentType;
+}
+
+export function getAgentCommands(): Record<string, string> {
+  return vscode.workspace
     .getConfiguration('hydra')
     .get<Record<string, string>>('agentCommands', {
       claude: 'claude',
       codex: 'codex',
       gemini: 'gemini',
+      sudocode: 'scode',
     });
-  return commands[agentType] || agentType;
+}
+
+export function syncAgentCommandsToHydraConfig(): void {
+  updateHydraGlobalAgentCommands(getAgentCommands());
 }
 
 export async function pickAgentType(): Promise<AgentType | undefined> {


### PR DESCRIPTION
## Summary

- Add `sudocode` as a first-class Hydra agent for copilots and workers.
- Launch Sudo Code as a long-lived REPL, send tasks through tmux, and resume via `/resume <session-file>` after startup.
- Capture `.scode/sessions/...jsonl` session files, preserve them for archive/restore, and reject stale moved-worktree session files whose `workspace_root` no longer matches.
- Sync configurable `hydra.agentCommands` into CLI/runtime config so users can provide commands such as `env HTTPS_PROXY=... scode`.
- Add smoke coverage and a design/testing document for Sudo Code support.

Fixes #162.
Follow-up: #165 tracks Sudo Code automatic worker completion notifications.

## Validation

- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run smoke:session-file-resolve`
- `npm run smoke:sudocode-agent`
- `git diff --check`
- Real isolated extension e2e with Sudo Code copilot/worker multi-turn chat, stop/start resume, rename fresh-start behavior, archive/restore, delete cleanup.
- Real cross-agent e2e: Codex copilot -> Sudo worker and Sudo copilot -> Codex worker.