### PR TITLE
chore: release v0.3.2026051800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026051800] - 2026-05-18
+
+### Added
+- Add Sudo Code as a first-class Hydra agent for copilots and workers, including configurable launch commands, resume, archive/restore, CLI visibility, and smoke/e2e coverage
+
 ## [0.3.2026051302] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026051302",
+  "version": "0.3.2026051800",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026051302",
+      "version": "0.3.2026051800",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026051302",
+  "version": "0.3.2026051800",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026051800.

## Changes

- Add Sudo Code as a first-class Hydra agent for copilots and workers, including configurable launch commands, resume, archive/restore, CLI visibility, and smoke/e2e coverage.

## Validation

- `npm run compile`
- `npm run lint`
- `npm test`
- `git diff --check`

When this PR is merged, the auto-tag release workflow should create `v0.3.2026051800` and trigger the publish workflow.