### PR TITLE
[codex] fix Hydra tree action fallbacks

### DIFF
--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -15,7 +15,23 @@ import { exec } from '../utils/exec';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { openChangesReview } from './reviewChanges';
 
-function getWorktreePath(item: TmuxItem): string | undefined {
+function getStringField(value: unknown, field: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = (value as Record<string, unknown>)[field];
+  return typeof candidate === 'string' && candidate ? candidate : undefined;
+}
+
+function getNestedStringField(value: unknown, objectField: string, stringField: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  return getStringField((value as Record<string, unknown>)[objectField], stringField);
+}
+
+function getWorktreePath(item?: TmuxItem): string | undefined {
+  const structuralPath = getStringField(item, 'worktreePath') ||
+    getNestedStringField(item, 'session', 'worktreePath') ||
+    getNestedStringField(item, 'worktree', 'path');
+  if (structuralPath) return structuralPath;
+
   if (item instanceof CopilotItem) return item.worktreePath;
   if (item instanceof TmuxSessionItem) return item.session.worktreePath;
   if (item instanceof InactiveWorktreeItem) return item.worktree.path;
@@ -26,7 +42,11 @@ function getWorktreePath(item: TmuxItem): string | undefined {
   return undefined;
 }
 
-function getRoleFromItem(item: TmuxItem): HydraRole | undefined {
+function getRoleFromItem(item?: TmuxItem): HydraRole | undefined {
+  const structuralRole = getNestedStringField(item, 'session', 'hydraRole');
+  if (structuralRole === 'worker' || structuralRole === 'copilot') return structuralRole;
+  if (getStringField(item, 'contextValue') === 'copilotItem') return 'copilot';
+
   if (item instanceof CopilotItem) return 'copilot';
   if (item instanceof TmuxSessionItem) return item.session.hydraRole;
   return undefined;
@@ -46,8 +66,8 @@ async function ensureSessionExists(sessionName: string, worktreePath?: string): 
   await backend.setSessionWorkdir(sessionName, worktreePath);
 }
 
-export async function attach(item: TmuxItem): Promise<void> {
-  if (!item.sessionName) {
+export async function attach(item?: TmuxItem): Promise<void> {
+  if (!item?.sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -68,8 +88,8 @@ export async function attach(item: TmuxItem): Promise<void> {
   }
 }
 
-export async function attachInEditor(item: TmuxItem): Promise<void> {
-  if (!item.sessionName) {
+export async function attachInEditor(item?: TmuxItem): Promise<void> {
+  if (!item?.sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -90,7 +110,7 @@ export async function attachInEditor(item: TmuxItem): Promise<void> {
   }
 }
 
-export async function openWorktree(item: TmuxItem): Promise<void> {
+export async function openWorktree(item?: TmuxItem): Promise<void> {
   const worktreePath = getWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
@@ -100,7 +120,7 @@ export async function openWorktree(item: TmuxItem): Promise<void> {
   await vscode.commands.executeCommand('vscode.openFolder', worktreeUri, true);
 }
 
-export async function reviewChanges(item: TmuxItem): Promise<void> {
+export async function reviewChanges(item?: TmuxItem): Promise<void> {
   const worktreePath = getWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
@@ -114,7 +134,7 @@ export async function reviewChanges(item: TmuxItem): Promise<void> {
   }
 }
 
-export async function copyPath(item: TmuxItem): Promise<void> {
+export async function copyPath(item?: TmuxItem): Promise<void> {
   const worktreePath = getWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
@@ -124,8 +144,8 @@ export async function copyPath(item: TmuxItem): Promise<void> {
   vscode.window.showInformationMessage(`Copied: ${worktreePath}`);
 }
 
-export async function newPane(item: TmuxItem): Promise<void> {
-  if (!item.sessionName) {
+export async function newPane(item?: TmuxItem): Promise<void> {
+  if (!item?.sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -144,8 +164,8 @@ export async function newPane(item: TmuxItem): Promise<void> {
   }
 }
 
-export async function newWindow(item: TmuxItem): Promise<void> {
-  if (!item.sessionName) {
+export async function newWindow(item?: TmuxItem): Promise<void> {
+  if (!item?.sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }

--- a/src/commands/removeTask.ts
+++ b/src/commands/removeTask.ts
@@ -27,9 +27,9 @@ function isOrphanItem(item: TmuxItem): boolean {
   return false;
 }
 
-export async function removeTask(item: TmuxItem): Promise<void> {
+export async function removeTask(item?: TmuxItem): Promise<void> {
   if (!item || !item.sessionName) {
-    vscode.window.showErrorMessage("No session selected");
+    vscode.window.showErrorMessage("No session selected. Select a Hydra session and try again.");
     return;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,20 +35,32 @@ export function activate(context: vscode.ExtensionContext) {
 
   const copilotView = vscode.window.createTreeView('hydraCopilots', { treeDataProvider: copilotProvider });
   const workerView = vscode.window.createTreeView('hydraWorkers', { treeDataProvider: workerProvider });
+  let selectedHydraItem: TmuxItem | undefined;
+  const rememberHydraSelection = (event: vscode.TreeViewSelectionChangeEvent<TmuxItem>) => {
+    const selected = event.selection.find((item) => Boolean(item.sessionName));
+    if (selected) selectedHydraItem = selected;
+  };
+  const getSelectedHydraItem = () => {
+    if (selectedHydraItem?.sessionName) return selectedHydraItem;
+    const selectedCopilot = copilotView.selection.find((item) => Boolean(item.sessionName));
+    if (selectedCopilot) return selectedCopilot;
+    return workerView.selection.find((item) => Boolean(item.sessionName));
+  };
+
   context.subscriptions.push(
     copilotView,
     workerView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
     vscode.commands.registerCommand('hydra.createWorker', newTask),
-    vscode.commands.registerCommand('tmux.removeTask', (item) => removeTask(item)),
+    vscode.commands.registerCommand('tmux.removeTask', (item?: TmuxItem) => removeTask(item ?? getSelectedHydraItem())),
     vscode.commands.registerCommand('tmux.refresh', () => { copilotProvider.refresh(); workerProvider.refresh(); }),
-    vscode.commands.registerCommand('tmux.attach', attach),
-    vscode.commands.registerCommand('tmux.attachInEditor', attachInEditor),
-    vscode.commands.registerCommand('tmux.openWorktree', openWorktree),
-    vscode.commands.registerCommand('tmux.reviewChanges', reviewChanges),
-    vscode.commands.registerCommand('tmux.copyPath', copyPath),
-    vscode.commands.registerCommand('tmux.newPane', newPane),
-    vscode.commands.registerCommand('tmux.newWindow', newWindow),
+    vscode.commands.registerCommand('tmux.attach', (item?: TmuxItem) => attach(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.attachInEditor', (item?: TmuxItem) => attachInEditor(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.openWorktree', (item?: TmuxItem) => openWorktree(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.reviewChanges', (item?: TmuxItem) => reviewChanges(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.copyPath', (item?: TmuxItem) => copyPath(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.newPane', (item?: TmuxItem) => newPane(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.newWindow', (item?: TmuxItem) => newWindow(item ?? getSelectedHydraItem())),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
@@ -58,6 +70,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('hydra.startCopilotCodex', () => createCopilotWithAgent('codex')),
     vscode.commands.registerCommand('hydra.startCopilotGemini', () => createCopilotWithAgent('gemini')),
     vscode.commands.registerCommand('hydra.startCopilotSudoCode', () => createCopilotWithAgent('sudocode')),
+    copilotView.onDidChangeSelection(rememberHydraSelection),
+    workerView.onDidChangeSelection(rememberHydraSelection),
   );
 
   ensureHydraGlobalConfig();


### PR DESCRIPTION
## Summary

- Make Hydra tree context commands resilient when VS Code does not pass the tree item argument by falling back to the current Hydra tree selection.
- Resolve worktree paths structurally before using `instanceof`, so actions still work when tree items come from another loaded extension copy or stale command binding.
- Improve the empty selection message for remove actions.

## Root cause

The tree context menu depends on VS Code passing the selected tree item to global command handlers. In mixed extension-host states or duplicate extension installs, handlers can receive no item or an object whose prototype does not match this extension copy, causing `Review Changes` to report `Worktree path not found` and `Remove` to report no selected session.

## Validation

- `npm run compile`
- `npm run lint`
