### PR TITLE
Fix review changes worktree resolution

### DIFF
--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -1,12 +1,7 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
 import {
   TmuxItem,
   TmuxSessionItem,
-  InactiveWorktreeItem,
-  WorktreeItem,
-  TmuxDetailItem,
-  InactiveDetailItem,
   GitStatusItem,
   CopilotItem,
 } from '../providers/tmuxSessionProvider';
@@ -15,21 +10,7 @@ import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
 import { exec } from '../utils/exec';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { openChangesReview } from './reviewChanges';
-import { getHydraSessionsFile } from '../core/path';
-
-interface SessionStateEntry {
-  sessionName?: string;
-  displayName?: string;
-  workerId?: number;
-  branch?: string;
-  slug?: string;
-  workdir?: string;
-}
-
-interface SessionStateFile {
-  copilots?: Record<string, SessionStateEntry>;
-  workers?: Record<string, SessionStateEntry>;
-}
+import { resolveSessionName, resolveWorktreePath } from './treeItemResolver';
 
 function getStringField(value: unknown, field: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
@@ -39,108 +20,10 @@ function getStringField(value: unknown, field: string): string | undefined {
 
 function getNestedStringField(value: unknown, objectField: string, stringField: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
-  return getStringField((value as Record<string, unknown>)[objectField], stringField);
-}
-
-function getItemSessionName(item?: TmuxItem): string | undefined {
-  return getStringField(item, 'sessionName') ||
-    getStringField(item, 'targetSessionName') ||
-    getNestedStringField(item, 'session', 'name');
-}
-
-function getItemLabel(item?: TmuxItem): string | undefined {
-  if (!item || typeof item !== 'object') return undefined;
-  const label = (item as { label?: unknown }).label;
-  if (typeof label === 'string') return label;
-  return getStringField(label, 'label');
-}
-
-function normalizeDisplayLabel(label: string): string {
-  return label.replace(/\s+#\d+.*$/, '').replace(/\s+\[[^\]]+\]$/, '').trim();
-}
-
-function readSessionState(): SessionStateFile {
-  try {
-    const sessionsFile = getHydraSessionsFile();
-    if (!fs.existsSync(sessionsFile)) return {};
-    return JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as SessionStateFile;
-  } catch {
-    return {};
-  }
-}
-
-function findSessionStateEntry(item?: TmuxItem): SessionStateEntry | undefined {
-  const state = readSessionState();
-  const sessionName = getItemSessionName(item);
-  if (sessionName) {
-    return state.workers?.[sessionName] || state.copilots?.[sessionName];
-  }
-
-  const rawLabel = getItemLabel(item);
-  if (!rawLabel) return undefined;
-  const label = normalizeDisplayLabel(rawLabel);
-  const entries = [
-    ...Object.entries(state.workers || {}),
-    ...Object.entries(state.copilots || {}),
-  ];
-
-  return entries.find(([key, entry]) =>
-    key === label ||
-    entry.sessionName === label ||
-    entry.displayName === label ||
-    entry.branch === label ||
-    entry.slug === label
-  )?.[1];
-}
-
-function findActiveHydraSessionStateEntry(): SessionStateEntry | undefined {
-  const labels = [
-    vscode.window.activeTerminal?.name,
-    vscode.window.tabGroups.activeTabGroup.activeTab?.label,
-  ].filter((label): label is string => typeof label === 'string' && label.length > 0);
-
-  const workerId = labels
-    .map(label => label.match(/\bWorker:\s*#(\d+)\b/)?.[1])
-    .find(Boolean);
-  if (!workerId) return undefined;
-
-  const state = readSessionState();
-  const targetId = Number(workerId);
-  return Object.values(state.workers || {}).find(entry => entry.workerId === targetId);
-}
-
-function getWorktreePath(item?: TmuxItem): string | undefined {
-  const structuralPath = getStringField(item, 'worktreePath') ||
-    getNestedStringField(item, 'session', 'worktreePath') ||
-    getNestedStringField(item, 'worktree', 'path');
-  if (structuralPath) return structuralPath;
-
-  if (item instanceof CopilotItem) return item.worktreePath;
-  if (item instanceof TmuxSessionItem) return item.session.worktreePath;
-  if (item instanceof InactiveWorktreeItem) return item.worktree.path;
-  if (item instanceof TmuxDetailItem) return item.session?.worktreePath;
-  if (item instanceof InactiveDetailItem) return item.worktree?.path;
-  if (item instanceof WorktreeItem) return item.worktreePath;
-  if (item instanceof GitStatusItem) return item.worktreePath;
-  return undefined;
-}
-
-async function resolveWorktreePath(item?: TmuxItem): Promise<string | undefined> {
-  const direct = getWorktreePath(item);
-  if (direct) return direct;
-
-  const stateEntry = findSessionStateEntry(item);
-  if (stateEntry?.workdir) return stateEntry.workdir;
-
-  const sessionName = getItemSessionName(item);
-  if (!sessionName) return findActiveHydraSessionStateEntry()?.workdir;
-
-  try {
-    const workdir = await getActiveBackend().getSessionWorkdir(sessionName);
-    return workdir || undefined;
-  } catch {
-    return findActiveHydraSessionStateEntry()?.workdir;
-  }
+  const candidate = (value as Record<string, unknown>)[objectField];
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  const nested = (candidate as Record<string, unknown>)[stringField];
+  return typeof nested === 'string' && nested ? nested : undefined;
 }
 
 function getRoleFromItem(item?: TmuxItem): HydraRole | undefined {
@@ -168,7 +51,8 @@ async function ensureSessionExists(sessionName: string, worktreePath?: string): 
 }
 
 export async function attach(item?: TmuxItem): Promise<void> {
-  if (!item?.sessionName) {
+  const sessionName = resolveSessionName(item);
+  if (!sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -179,18 +63,19 @@ export async function attach(item?: TmuxItem): Promise<void> {
 
   try {
     const worktreePath = await resolveWorktreePath(item);
-    await ensureSessionExists(item.sessionName, worktreePath);
+    await ensureSessionExists(sessionName, worktreePath);
 
-    const cwd = worktreePath || await backend.getSessionWorkdir(item.sessionName);
-    await backend.splitPane(item.sessionName, cwd);
-    vscode.window.showInformationMessage(`Opened terminal pane in ${item.sessionName}`);
+    const cwd = worktreePath || await backend.getSessionWorkdir(sessionName);
+    await backend.splitPane(sessionName, cwd);
+    vscode.window.showInformationMessage(`Opened terminal pane in ${sessionName}`);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to open terminal: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
 export async function attachInEditor(item?: TmuxItem): Promise<void> {
-  if (!item?.sessionName) {
+  const sessionName = resolveSessionName(item);
+  if (!sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -201,11 +86,11 @@ export async function attachInEditor(item?: TmuxItem): Promise<void> {
 
   try {
     const worktreePath = await resolveWorktreePath(item);
-    await ensureSessionExists(item.sessionName, worktreePath);
+    await ensureSessionExists(sessionName, worktreePath);
 
-    const workdir = worktreePath || await backend.getSessionWorkdir(item.sessionName);
+    const workdir = worktreePath || await backend.getSessionWorkdir(sessionName);
     const role = getRoleFromItem(item);
-    backend.attachSession(item.sessionName, workdir, getHydraEditorLocation(role), role);
+    backend.attachSession(sessionName, workdir, getHydraEditorLocation(role), role);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to attach: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -246,7 +131,8 @@ export async function copyPath(item?: TmuxItem): Promise<void> {
 }
 
 export async function newPane(item?: TmuxItem): Promise<void> {
-  if (!item?.sessionName) {
+  const sessionName = resolveSessionName(item);
+  if (!sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -257,16 +143,17 @@ export async function newPane(item?: TmuxItem): Promise<void> {
     }
 
     const cwd = await resolveWorktreePath(item);
-    await ensureSessionExists(item.sessionName, cwd);
-    await backend.splitPane(item.sessionName, cwd);
-    vscode.window.showInformationMessage(`New pane created in ${item.sessionName}`);
+    await ensureSessionExists(sessionName, cwd);
+    await backend.splitPane(sessionName, cwd);
+    vscode.window.showInformationMessage(`New pane created in ${sessionName}`);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to create pane: ${err}`);
   }
 }
 
 export async function newWindow(item?: TmuxItem): Promise<void> {
-  if (!item?.sessionName) {
+  const sessionName = resolveSessionName(item);
+  if (!sessionName) {
     vscode.window.showErrorMessage('No session selected');
     return;
   }
@@ -277,9 +164,9 @@ export async function newWindow(item?: TmuxItem): Promise<void> {
     }
 
     const cwd = await resolveWorktreePath(item);
-    await ensureSessionExists(item.sessionName, cwd);
-    await backend.newWindow(item.sessionName, cwd);
-    vscode.window.showInformationMessage(`New window created in ${item.sessionName}`);
+    await ensureSessionExists(sessionName, cwd);
+    await backend.newWindow(sessionName, cwd);
+    vscode.window.showInformationMessage(`New window created in ${sessionName}`);
   } catch (err) {
     vscode.window.showErrorMessage(`Failed to create window: ${err}`);
   }

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import {
   TmuxItem,
   TmuxSessionItem,
@@ -14,6 +15,21 @@ import { getHydraEditorLocation } from '../utils/hydraEditorGroup';
 import { exec } from '../utils/exec';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { openChangesReview } from './reviewChanges';
+import { getHydraSessionsFile } from '../core/path';
+
+interface SessionStateEntry {
+  sessionName?: string;
+  displayName?: string;
+  workerId?: number;
+  branch?: string;
+  slug?: string;
+  workdir?: string;
+}
+
+interface SessionStateFile {
+  copilots?: Record<string, SessionStateEntry>;
+  workers?: Record<string, SessionStateEntry>;
+}
 
 function getStringField(value: unknown, field: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
@@ -24,6 +40,73 @@ function getStringField(value: unknown, field: string): string | undefined {
 function getNestedStringField(value: unknown, objectField: string, stringField: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
   return getStringField((value as Record<string, unknown>)[objectField], stringField);
+}
+
+function getItemSessionName(item?: TmuxItem): string | undefined {
+  return getStringField(item, 'sessionName') ||
+    getStringField(item, 'targetSessionName') ||
+    getNestedStringField(item, 'session', 'name');
+}
+
+function getItemLabel(item?: TmuxItem): string | undefined {
+  if (!item || typeof item !== 'object') return undefined;
+  const label = (item as { label?: unknown }).label;
+  if (typeof label === 'string') return label;
+  return getStringField(label, 'label');
+}
+
+function normalizeDisplayLabel(label: string): string {
+  return label.replace(/\s+#\d+.*$/, '').replace(/\s+\[[^\]]+\]$/, '').trim();
+}
+
+function readSessionState(): SessionStateFile {
+  try {
+    const sessionsFile = getHydraSessionsFile();
+    if (!fs.existsSync(sessionsFile)) return {};
+    return JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as SessionStateFile;
+  } catch {
+    return {};
+  }
+}
+
+function findSessionStateEntry(item?: TmuxItem): SessionStateEntry | undefined {
+  const state = readSessionState();
+  const sessionName = getItemSessionName(item);
+  if (sessionName) {
+    return state.workers?.[sessionName] || state.copilots?.[sessionName];
+  }
+
+  const rawLabel = getItemLabel(item);
+  if (!rawLabel) return undefined;
+  const label = normalizeDisplayLabel(rawLabel);
+  const entries = [
+    ...Object.entries(state.workers || {}),
+    ...Object.entries(state.copilots || {}),
+  ];
+
+  return entries.find(([key, entry]) =>
+    key === label ||
+    entry.sessionName === label ||
+    entry.displayName === label ||
+    entry.branch === label ||
+    entry.slug === label
+  )?.[1];
+}
+
+function findActiveHydraSessionStateEntry(): SessionStateEntry | undefined {
+  const labels = [
+    vscode.window.activeTerminal?.name,
+    vscode.window.tabGroups.activeTabGroup.activeTab?.label,
+  ].filter((label): label is string => typeof label === 'string' && label.length > 0);
+
+  const workerId = labels
+    .map(label => label.match(/\bWorker:\s*#(\d+)\b/)?.[1])
+    .find(Boolean);
+  if (!workerId) return undefined;
+
+  const state = readSessionState();
+  const targetId = Number(workerId);
+  return Object.values(state.workers || {}).find(entry => entry.workerId === targetId);
 }
 
 function getWorktreePath(item?: TmuxItem): string | undefined {
@@ -40,6 +123,24 @@ function getWorktreePath(item?: TmuxItem): string | undefined {
   if (item instanceof WorktreeItem) return item.worktreePath;
   if (item instanceof GitStatusItem) return item.worktreePath;
   return undefined;
+}
+
+async function resolveWorktreePath(item?: TmuxItem): Promise<string | undefined> {
+  const direct = getWorktreePath(item);
+  if (direct) return direct;
+
+  const stateEntry = findSessionStateEntry(item);
+  if (stateEntry?.workdir) return stateEntry.workdir;
+
+  const sessionName = getItemSessionName(item);
+  if (!sessionName) return findActiveHydraSessionStateEntry()?.workdir;
+
+  try {
+    const workdir = await getActiveBackend().getSessionWorkdir(sessionName);
+    return workdir || undefined;
+  } catch {
+    return findActiveHydraSessionStateEntry()?.workdir;
+  }
 }
 
 function getRoleFromItem(item?: TmuxItem): HydraRole | undefined {
@@ -77,7 +178,7 @@ export async function attach(item?: TmuxItem): Promise<void> {
   }
 
   try {
-    const worktreePath = getWorktreePath(item);
+    const worktreePath = await resolveWorktreePath(item);
     await ensureSessionExists(item.sessionName, worktreePath);
 
     const cwd = worktreePath || await backend.getSessionWorkdir(item.sessionName);
@@ -99,7 +200,7 @@ export async function attachInEditor(item?: TmuxItem): Promise<void> {
   }
 
   try {
-    const worktreePath = getWorktreePath(item);
+    const worktreePath = await resolveWorktreePath(item);
     await ensureSessionExists(item.sessionName, worktreePath);
 
     const workdir = worktreePath || await backend.getSessionWorkdir(item.sessionName);
@@ -111,7 +212,7 @@ export async function attachInEditor(item?: TmuxItem): Promise<void> {
 }
 
 export async function openWorktree(item?: TmuxItem): Promise<void> {
-  const worktreePath = getWorktreePath(item);
+  const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
     return;
@@ -121,7 +222,7 @@ export async function openWorktree(item?: TmuxItem): Promise<void> {
 }
 
 export async function reviewChanges(item?: TmuxItem): Promise<void> {
-  const worktreePath = getWorktreePath(item);
+  const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
     return;
@@ -135,7 +236,7 @@ export async function reviewChanges(item?: TmuxItem): Promise<void> {
 }
 
 export async function copyPath(item?: TmuxItem): Promise<void> {
-  const worktreePath = getWorktreePath(item);
+  const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
     vscode.window.showErrorMessage('Worktree path not found');
     return;
@@ -155,7 +256,7 @@ export async function newPane(item?: TmuxItem): Promise<void> {
       return;
     }
 
-    const cwd = getWorktreePath(item);
+    const cwd = await resolveWorktreePath(item);
     await ensureSessionExists(item.sessionName, cwd);
     await backend.splitPane(item.sessionName, cwd);
     vscode.window.showInformationMessage(`New pane created in ${item.sessionName}`);
@@ -175,7 +276,7 @@ export async function newWindow(item?: TmuxItem): Promise<void> {
       return;
     }
 
-    const cwd = getWorktreePath(item);
+    const cwd = await resolveWorktreePath(item);
     await ensureSessionExists(item.sessionName, cwd);
     await backend.newWindow(item.sessionName, cwd);
     vscode.window.showInformationMessage(`New window created in ${item.sessionName}`);

--- a/src/commands/removeTask.ts
+++ b/src/commands/removeTask.ts
@@ -11,6 +11,7 @@ import {
 } from "../providers/tmuxSessionProvider";
 import { SessionManager } from "../core/sessionManager";
 import { TmuxBackendCore } from "../core/tmux";
+import { resolveSessionKind, resolveSessionName } from "./treeItemResolver";
 
 function isMainWorktreeItem(item: TmuxItem): boolean {
   if (item instanceof WorktreeItem) return item.isMainWorktree;
@@ -28,16 +29,17 @@ function isOrphanItem(item: TmuxItem): boolean {
 }
 
 export async function removeTask(item?: TmuxItem): Promise<void> {
-  if (!item || !item.sessionName) {
+  const sessionName = resolveSessionName(item);
+  if (!sessionName) {
     vscode.window.showErrorMessage("No session selected. Select a Hydra session and try again.");
     return;
   }
 
   const sm = new SessionManager(new TmuxBackendCore());
-  const sessionName = item.sessionName;
+  const kind = resolveSessionKind(item);
 
   // ── Copilot: archive + kill via SessionManager ──
-  if (item instanceof CopilotItem) {
+  if (kind === 'copilot' || item instanceof CopilotItem) {
     const confirm = await vscode.window.showWarningMessage(
       `Kill copilot session "${sessionName}"?`,
       { modal: true },
@@ -52,7 +54,7 @@ export async function removeTask(item?: TmuxItem): Promise<void> {
   }
 
   // ── Main worktree: stop only (cannot delete primary worktree) ──
-  if (isMainWorktreeItem(item)) {
+  if (item && isMainWorktreeItem(item)) {
     const backend = getActiveBackend();
     if (!await backend.hasSession(sessionName)) {
       vscode.window.showInformationMessage(
@@ -75,7 +77,7 @@ export async function removeTask(item?: TmuxItem): Promise<void> {
   }
 
   // ── Orphan: worktree already gone, delete via SessionManager ──
-  if (isOrphanItem(item)) {
+  if (item && isOrphanItem(item)) {
     const confirm = await vscode.window.showWarningMessage(
       `Kill orphan session "${sessionName}"? (Worktree no longer exists)`,
       { modal: true },

--- a/src/commands/reviewChanges.ts
+++ b/src/commands/reviewChanges.ts
@@ -11,6 +11,10 @@ const REVIEW_SCHEME = 'hydra-git';
 const MAX_GIT_OUTPUT = 50 * 1024 * 1024;
 const REVIEW_LABEL_PREFIX = `${HYDRA_PREFIX_REVIEW} `;
 
+interface ExecFileFailure extends Error {
+  code?: string | number;
+}
+
 interface ReviewLayoutState {
   column: vscode.ViewColumn;
   maximized: boolean;
@@ -50,10 +54,25 @@ async function getGitBinary(): Promise<string> {
 }
 
 async function git(args: string[], cwd: string): Promise<string> {
-  const { stdout } = await execFile(await getGitBinary(), args, {
-    cwd,
-    maxBuffer: MAX_GIT_OUTPUT,
-  });
+  const binary = await getGitBinary();
+  let stdout: string | Buffer;
+  try {
+    ({ stdout } = await execFile(binary, args, {
+      cwd,
+      maxBuffer: MAX_GIT_OUTPUT,
+    }));
+  } catch (error) {
+    const failure = error as ExecFileFailure;
+    if (failure.code !== 'ENOENT') {
+      throw error;
+    }
+
+    gitBinary = undefined;
+    ({ stdout } = await execFile(await getGitBinary(), args, {
+      cwd,
+      maxBuffer: MAX_GIT_OUTPUT,
+    }));
+  }
   return stdout.toString();
 }
 
@@ -172,6 +191,11 @@ async function getCurrentBranch(worktreePath: string): Promise<string> {
 }
 
 async function getReviewBaseRef(worktreePath: string): Promise<string> {
+  const isWorktree = (await git(['rev-parse', '--is-inside-work-tree'], worktreePath)).trim();
+  if (isWorktree !== 'true') {
+    throw new Error(`Not a git worktree: ${worktreePath}`);
+  }
+
   const branch = await getCurrentBranch(worktreePath);
   if (branch) {
     const configuredBase = (await tryGit(['config', '--get', `branch.${branch}.vscode-merge-base`], worktreePath)).trim();
@@ -187,7 +211,8 @@ async function getReviewBaseRef(worktreePath: string): Promise<string> {
     }
   }
 
-  throw new Error('Unable to find a base branch for this worktree.');
+  const suffix = branch ? ` on branch "${branch}"` : '';
+  throw new Error(`Unable to find a base branch for this worktree${suffix}: ${worktreePath}`);
 }
 
 async function refExists(worktreePath: string, ref: string): Promise<boolean> {

--- a/src/commands/treeItemResolver.ts
+++ b/src/commands/treeItemResolver.ts
@@ -1,0 +1,220 @@
+import * as fs from 'fs';
+import {
+  CopilotItem,
+  GitStatusItem,
+  InactiveDetailItem,
+  InactiveWorktreeItem,
+  TmuxDetailItem,
+  TmuxItem,
+  TmuxSessionItem,
+  WorktreeItem,
+} from '../providers/tmuxSessionProvider';
+import { getHydraSessionsFile } from '../core/path';
+import { getActiveBackend } from '../utils/multiplexer';
+
+interface SessionStateEntry {
+  sessionName?: string;
+  displayName?: string;
+  workerId?: number;
+  branch?: string;
+  slug?: string;
+  workdir?: string;
+  agent?: string;
+}
+
+interface SessionStateFile {
+  copilots?: Record<string, SessionStateEntry>;
+  workers?: Record<string, SessionStateEntry>;
+}
+
+export type HydraSessionKind = 'worker' | 'copilot';
+
+export interface HydraSessionChoice {
+  kind: HydraSessionKind;
+  sessionName: string;
+  label: string;
+  worktreePath?: string;
+  workerId?: number;
+  agent?: string;
+}
+
+function getStringField(value: unknown, field: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = (value as Record<string, unknown>)[field];
+  return typeof candidate === 'string' && candidate ? candidate : undefined;
+}
+
+function getNestedStringField(value: unknown, objectField: string, stringField: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  return getStringField((value as Record<string, unknown>)[objectField], stringField);
+}
+
+function getLabelText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  return getStringField(value, 'label');
+}
+
+function getTooltipText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  return getStringField(value, 'value');
+}
+
+function unique(values: (string | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+function getItemTextFields(item?: unknown): string[] {
+  if (typeof item === 'string') return [item];
+  if (!item || typeof item !== 'object') return [];
+  const record = item as unknown as Record<string, unknown>;
+  return unique([
+    getLabelText(record.label),
+    getStringField(item, 'description'),
+    getTooltipText(record.tooltip),
+    getNestedStringField(item, 'accessibilityInformation', 'label'),
+    getStringField(item, 'id'),
+    getStringField(item, 'contextValue'),
+  ]);
+}
+
+function getItemSessionName(item?: unknown): string | undefined {
+  return getStringField(item, 'sessionName') ||
+    getStringField(item, 'targetSessionName') ||
+    getNestedStringField(item, 'session', 'name');
+}
+
+function normalizeDisplayLabel(label: string): string {
+  return label
+    .replace(/^Review:\s*/, '')
+    .replace(/:\s+\d+\s+changes\b.*$/, '')
+    .replace(/\s+#\d+.*$/, '')
+    .replace(/\s+\[[^\]]+\]$/, '')
+    .trim();
+}
+
+function readSessionState(): SessionStateFile {
+  try {
+    const sessionsFile = getHydraSessionsFile();
+    if (!fs.existsSync(sessionsFile)) return {};
+    return JSON.parse(fs.readFileSync(sessionsFile, 'utf-8')) as SessionStateFile;
+  } catch {
+    return {};
+  }
+}
+
+function getEntries(state: SessionStateFile): [HydraSessionKind, string, SessionStateEntry][] {
+  return [
+    ...Object.entries(state.workers || {}).map(([key, entry]): [HydraSessionKind, string, SessionStateEntry] => ['worker', key, entry]),
+    ...Object.entries(state.copilots || {}).map(([key, entry]): [HydraSessionKind, string, SessionStateEntry] => ['copilot', key, entry]),
+  ];
+}
+
+function findEntryByText(state: SessionStateFile, texts: string[]): [HydraSessionKind, SessionStateEntry] | undefined {
+  const workerId = texts
+    .map(text => text.match(/\B#(\d+)\b/)?.[1] || text.match(/\bWorker:\s*#(\d+)\b/)?.[1])
+    .find(Boolean);
+  if (workerId) {
+    const targetId = Number(workerId);
+    const worker = Object.values(state.workers || {}).find(entry => entry.workerId === targetId);
+    if (worker) return ['worker', worker];
+  }
+
+  const normalizedTexts = texts.map(normalizeDisplayLabel).filter(Boolean);
+  for (const [kind, key, entry] of getEntries(state)) {
+    if (normalizedTexts.some(text =>
+      key === text ||
+      entry.sessionName === text ||
+      entry.displayName === text ||
+      entry.branch === text ||
+      entry.slug === text
+    )) {
+      return [kind, entry];
+    }
+  }
+
+  return undefined;
+}
+
+function findEntryForItem(item?: unknown): [HydraSessionKind, SessionStateEntry] | undefined {
+  const state = readSessionState();
+  const sessionName = getItemSessionName(item);
+  if (sessionName) {
+    const worker = state.workers?.[sessionName];
+    if (worker) return ['worker', worker];
+    const copilot = state.copilots?.[sessionName];
+    if (copilot) return ['copilot', copilot];
+  }
+  return findEntryByText(state, getItemTextFields(item));
+}
+
+export function resolveSessionKind(item?: TmuxItem): HydraSessionKind | undefined {
+  if (item instanceof CopilotItem) return 'copilot';
+  if (item instanceof TmuxSessionItem) return item.session.hydraRole;
+  return findEntryForItem(item)?.[0];
+}
+
+export function resolveSessionName(item?: TmuxItem): string | undefined {
+  return getItemSessionName(item) ||
+    findEntryForItem(item)?.[1].sessionName;
+}
+
+export function hasHydraItemIdentity(item?: TmuxItem): boolean {
+  return Boolean(getWorktreePath(item) || findEntryForItem(item));
+}
+
+export function listHydraSessionChoices(kinds: HydraSessionKind[] = ['worker', 'copilot']): HydraSessionChoice[] {
+  const allowed = new Set(kinds);
+  return getEntries(readSessionState())
+    .filter(([kind, , entry]) => allowed.has(kind) && Boolean(entry.sessionName))
+    .map(([kind, , entry]) => {
+      const suffixes = [
+        entry.workerId != null ? `#${entry.workerId}` : undefined,
+        entry.agent ? `[${entry.agent}]` : undefined,
+      ].filter(Boolean);
+      const displayName = entry.displayName || entry.branch || entry.slug || entry.sessionName || '';
+      return {
+        kind,
+        sessionName: entry.sessionName || '',
+        label: suffixes.length > 0 ? `${displayName} ${suffixes.join(' ')}` : displayName,
+        worktreePath: entry.workdir,
+        workerId: entry.workerId,
+        agent: entry.agent,
+      };
+    });
+}
+
+export function getWorktreePath(item?: TmuxItem): string | undefined {
+  const structuralPath = getStringField(item, 'worktreePath') ||
+    getNestedStringField(item, 'session', 'worktreePath') ||
+    getNestedStringField(item, 'worktree', 'path');
+  if (structuralPath) return structuralPath;
+
+  if (item instanceof CopilotItem) return item.worktreePath;
+  if (item instanceof TmuxSessionItem) return item.session.worktreePath;
+  if (item instanceof InactiveWorktreeItem) return item.worktree.path;
+  if (item instanceof TmuxDetailItem) return item.session?.worktreePath;
+  if (item instanceof InactiveDetailItem) return item.worktree?.path;
+  if (item instanceof WorktreeItem) return item.worktreePath;
+  if (item instanceof GitStatusItem) return item.worktreePath;
+  return undefined;
+}
+
+export async function resolveWorktreePath(item?: TmuxItem): Promise<string | undefined> {
+  const direct = getWorktreePath(item);
+  if (direct) return direct;
+
+  const itemEntry = findEntryForItem(item);
+  if (itemEntry?.[1].workdir) return itemEntry[1].workdir;
+
+  const sessionName = resolveSessionName(item);
+  if (sessionName) {
+    try {
+      const workdir = await getActiveBackend().getSessionWorkdir(sessionName);
+      if (workdir) return workdir;
+    } catch {
+      // Fall through to undefined.
+    }
+  }
+
+  return undefined;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,15 @@ import { detectAvailableAgents, syncAgentCommandsToHydraConfig } from './utils/a
 import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } from './utils/hydraEditorGroup';
 import { lookupWorkerId } from './core/sessionManager';
 import { getHydraSessionsFile } from './core/path';
+import { HydraSessionKind, hasHydraItemIdentity, listHydraSessionChoices } from './commands/treeItemResolver';
 
 const SESSION_REFRESH_DEBOUNCE_MS = 200;
+const RECENT_TREE_SELECTION_MS = 1000;
+const TREE_SELECTION_SETTLE_MS = 75;
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 export function activate(context: vscode.ExtensionContext) {
   const copilotProvider = new CopilotProvider();
@@ -36,15 +43,77 @@ export function activate(context: vscode.ExtensionContext) {
   const copilotView = vscode.window.createTreeView('hydraCopilots', { treeDataProvider: copilotProvider });
   const workerView = vscode.window.createTreeView('hydraWorkers', { treeDataProvider: workerProvider });
   let selectedHydraItem: TmuxItem | undefined;
+  let selectedHydraItemAt = 0;
   const rememberHydraSelection = (event: vscode.TreeViewSelectionChangeEvent<TmuxItem>) => {
-    const selected = event.selection.find((item) => Boolean(item.sessionName));
-    if (selected) selectedHydraItem = selected;
+    const selected = event.selection.find((item) => hasHydraItemIdentity(item));
+    if (selected) {
+      selectedHydraItem = selected;
+      selectedHydraItemAt = Date.now();
+    }
   };
   const getSelectedHydraItem = () => {
-    if (selectedHydraItem?.sessionName) return selectedHydraItem;
-    const selectedCopilot = copilotView.selection.find((item) => Boolean(item.sessionName));
-    if (selectedCopilot) return selectedCopilot;
-    return workerView.selection.find((item) => Boolean(item.sessionName));
+    if (selectedHydraItem && Date.now() - selectedHydraItemAt <= RECENT_TREE_SELECTION_MS) {
+      return selectedHydraItem;
+    }
+    return undefined;
+  };
+
+  const getCommandHydraItemFromArgs = (...args: unknown[]) => {
+    const queue = [...args];
+    for (const candidate of queue) {
+      if (Array.isArray(candidate)) {
+        queue.push(...candidate);
+        continue;
+      }
+      if (hasHydraItemIdentity(candidate as TmuxItem)) {
+        return candidate as TmuxItem;
+      }
+    }
+    return undefined;
+  };
+
+  const pickHydraItem = async (kinds: HydraSessionKind[]) => {
+    const choices = listHydraSessionChoices(kinds);
+    if (choices.length === 0) return undefined;
+
+    const picked = choices.length === 1 ? { choice: choices[0] } : await vscode.window.showQuickPick(
+      choices.map(choice => ({
+        label: choice.label,
+        description: choice.kind,
+        detail: choice.worktreePath,
+        choice,
+      })),
+      { placeHolder: 'Select a Hydra session' },
+    );
+    if (!picked) return undefined;
+
+    return {
+      label: picked.choice.label,
+      sessionName: picked.choice.sessionName,
+      worktreePath: picked.choice.worktreePath,
+      contextValue: picked.choice.kind === 'copilot' ? 'copilotItem' : 'workerItem',
+    } as unknown as TmuxItem;
+  };
+
+  const getCommandHydraItem = async (kinds: HydraSessionKind[], ...args: unknown[]) => {
+    const itemFromArgs = getCommandHydraItemFromArgs(...args);
+    if (itemFromArgs) {
+      return itemFromArgs;
+    }
+
+    await delay(TREE_SELECTION_SETTLE_MS);
+    const selected = getSelectedHydraItem();
+    return hasHydraItemIdentity(selected) ? selected : await pickHydraItem(kinds);
+  };
+
+  const runWithHydraItem = async (
+    kinds: HydraSessionKind[],
+    action: (item: TmuxItem) => Promise<void>,
+    ...args: unknown[]
+  ) => {
+    const item = await getCommandHydraItem(kinds, ...args);
+    if (!item) return;
+    await action(item);
   };
 
   context.subscriptions.push(
@@ -52,15 +121,15 @@ export function activate(context: vscode.ExtensionContext) {
     workerView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
     vscode.commands.registerCommand('hydra.createWorker', newTask),
-    vscode.commands.registerCommand('tmux.removeTask', (item?: TmuxItem) => removeTask(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.removeTask', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], removeTask, ...args)),
     vscode.commands.registerCommand('tmux.refresh', () => { copilotProvider.refresh(); workerProvider.refresh(); }),
-    vscode.commands.registerCommand('tmux.attach', (item?: TmuxItem) => attach(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.attachInEditor', (item?: TmuxItem) => attachInEditor(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.openWorktree', (item?: TmuxItem) => openWorktree(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.reviewChanges', (item?: TmuxItem) => reviewChanges(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.copyPath', (item?: TmuxItem) => copyPath(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.newPane', (item?: TmuxItem) => newPane(item ?? getSelectedHydraItem())),
-    vscode.commands.registerCommand('tmux.newWindow', (item?: TmuxItem) => newWindow(item ?? getSelectedHydraItem())),
+    vscode.commands.registerCommand('tmux.attach', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], attach, ...args)),
+    vscode.commands.registerCommand('tmux.attachInEditor', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], attachInEditor, ...args)),
+    vscode.commands.registerCommand('tmux.openWorktree', async (...args: unknown[]) => runWithHydraItem(['worker'], openWorktree, ...args)),
+    vscode.commands.registerCommand('tmux.reviewChanges', async (...args: unknown[]) => runWithHydraItem(['worker'], reviewChanges, ...args)),
+    vscode.commands.registerCommand('tmux.copyPath', async (...args: unknown[]) => runWithHydraItem(['worker'], copyPath, ...args)),
+    vscode.commands.registerCommand('tmux.newPane', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newPane, ...args)),
+    vscode.commands.registerCommand('tmux.newWindow', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newWindow, ...args)),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
@@ -171,7 +240,7 @@ function revealSidebarItem(
       return name === buildHydraTerminalName(shortName, 'copilot');
     });
     if (found) {
-      copilotView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
+      copilotView.reveal(found, { select: false, focus: false }).then(undefined, () => {});
     }
     return;
   }
@@ -185,7 +254,7 @@ function revealSidebarItem(
       return name === buildHydraTerminalName(shortName, 'worker', workerId);
     });
     if (found) {
-      workerView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
+      workerView.reveal(found, { select: false, focus: false }).then(undefined, () => {});
     }
   }
 }

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -301,6 +301,7 @@ export class CopilotItem extends TmuxItem {
     this.worktreePath = opts.worktreePath;
     this.agentType = opts.agentType;
     this.classification = opts.classification;
+    this.id = opts.sessionName;
     this.description = description;
     this.contextValue = 'copilotItem';
     this.command = {
@@ -374,6 +375,7 @@ export class WorktreeItem extends TmuxItem {
     this.hasGit = opts.hasGit;
     this.hasTmux = opts.hasTmux;
     this.isMainWorktree = Boolean(opts.isMainWorktree);
+    this.id = opts.sessionName;
     this.description = description;
 
     this.contextValue = 'workerItem';


### PR DESCRIPTION
## Summary
- Resolve Hydra tree action worktree paths through sessions.json when VS Code command args are incomplete
- Fall back from active Hydra worker terminal/tab IDs to the persisted worker workdir
- Make review git execution recover from stale git binary resolution and report clearer base-ref errors

## Verification
- npm run compile
- npm run lint
- Reloaded the installed VS Code extension locally and ran Review Changes against worker #28 `codex-issue-165-sudocode-notifications`; it opened `Review: codex-issue-165-sudocode-notifications: 9 changes since origin/main` instead of showing `Worktree path not found` or base-branch errors.