### PR TITLE
Fix sidebar loading sweep loop from sync writes

### DIFF
--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -220,6 +220,28 @@ export interface CreateCopilotResult {
   postCreatePromise: Promise<void>;
 }
 
+// Non-enumerable sentinel used by sync() to tell updateSessionState whether the
+// mutator actually changed anything. Callers that don't set it keep the legacy
+// unconditional-write semantics.
+const SESSION_STATE_DIRTY_KEY = '__hydraDirty';
+
+function markSessionStateDirty(state: SessionState, dirty: boolean): void {
+  Object.defineProperty(state, SESSION_STATE_DIRTY_KEY, {
+    value: dirty,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function consumeSessionStateDirty(state: SessionState): boolean | undefined {
+  const record = state as unknown as Record<string, unknown>;
+  if (!(SESSION_STATE_DIRTY_KEY in record)) return undefined;
+  const value = record[SESSION_STATE_DIRTY_KEY] as boolean;
+  delete record[SESSION_STATE_DIRTY_KEY];
+  return value;
+}
+
 // ── SessionManager Class ──
 
 export class SessionManager {
@@ -254,24 +276,28 @@ export class SessionManager {
 
     return this.updateSessionState((state) => {
       const now = new Date().toISOString();
+      let dirty = false;
 
-      // Reconcile workers
+      // Reconcile workers — only mark dirty on real status/attached/membership changes.
+      // lastSeenAt is deliberately NOT bumped on every sidebar read; the real mutation
+      // paths (createWorker, startWorker, persistCopilotSessionId, etc.) already refresh it.
       for (const [key, worker] of Object.entries(state.workers)) {
         // Backfill workerId for workers created before this feature
         if (worker.workerId == null) {
           worker.workerId = state.nextWorkerId++;
+          dirty = true;
         }
         const live = liveSessionMap.get(worker.sessionName);
         if (live) {
-          worker.status = 'running';
-          worker.attached = live.attached;
-          worker.lastSeenAt = now;
+          if (worker.status !== 'running') { worker.status = 'running'; dirty = true; }
+          if (worker.attached !== live.attached) { worker.attached = live.attached; dirty = true; }
         } else if (worker.workdir && fs.existsSync(worker.workdir)) {
-          worker.status = 'stopped';
-          worker.attached = false;
+          if (worker.status !== 'stopped') { worker.status = 'stopped'; dirty = true; }
+          if (worker.attached !== false) { worker.attached = false; dirty = true; }
         } else {
           // Orphan: tmux dead + no worktree
           delete state.workers[key];
+          dirty = true;
         }
       }
 
@@ -279,11 +305,11 @@ export class SessionManager {
       for (const [key, copilot] of Object.entries(state.copilots)) {
         const live = liveSessionMap.get(copilot.sessionName);
         if (live) {
-          copilot.status = 'running';
-          copilot.attached = live.attached;
-          copilot.lastSeenAt = now;
+          if (copilot.status !== 'running') { copilot.status = 'running'; dirty = true; }
+          if (copilot.attached !== live.attached) { copilot.attached = live.attached; dirty = true; }
         } else {
           delete state.copilots[key];
+          dirty = true;
         }
       }
 
@@ -325,6 +351,7 @@ export class SessionManager {
             agentSessionFile: null,
             copilotSessionName: null,
           };
+          dirty = true;
         } else {
           state.copilots[session.name] = {
             sessionName: session.name,
@@ -339,10 +366,12 @@ export class SessionManager {
             sessionId: null,
             agentSessionFile: null,
           };
+          dirty = true;
         }
       }
 
-      state.updatedAt = now;
+      if (dirty) state.updatedAt = now;
+      markSessionStateDirty(state, dirty);
       return state;
     });
   }
@@ -1280,7 +1309,13 @@ export class SessionManager {
     try {
       const state = this.readSessionState();
       const result = mutate(state);
-      this.writeSessionState(state);
+      // Mutators that opt in (currently only sync()) signal whether anything
+      // actually changed via markSessionStateDirty(). Other callers keep the
+      // legacy unconditional-write behavior.
+      const dirty = consumeSessionStateDirty(state);
+      if (dirty === undefined || dirty) {
+        this.writeSessionState(state);
+      }
       return result;
     } finally {
       await release();

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -243,13 +243,27 @@ interface PrInfo {
   state: 'open' | 'closed' | 'merged';
 }
 
+const PR_STATUS_CACHE_TTL_MS = 30_000;
+const PR_STATUS_FETCH_TIMEOUT_MS = 3_000;
+const prStatusCache = new Map<string, { fetchedAt: number; value: Map<string, PrInfo> }>();
+
 async function fetchRepoPrStatuses(repoRoot: string): Promise<Map<string, PrInfo>> {
+  const cached = prStatusCache.get(repoRoot);
+  if (cached && Date.now() - cached.fetchedAt < PR_STATUS_CACHE_TTL_MS) {
+    return cached.value;
+  }
+
   const map = new Map<string, PrInfo>();
   try {
-    const json = await exec(
-      'gh pr list --state all --json headRefName,number,state --limit 100',
-      { cwd: repoRoot }
-    );
+    const json = await Promise.race([
+      exec(
+        'gh pr list --state all --json headRefName,number,state --limit 100',
+        { cwd: repoRoot }
+      ),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error('gh pr list timeout')), PR_STATUS_FETCH_TIMEOUT_MS)
+      ),
+    ]);
     const prs: { headRefName: string; number: number; state: string }[] = JSON.parse(json);
     // Keep the first (most recent) PR per branch
     for (const pr of prs) {
@@ -261,8 +275,13 @@ async function fetchRepoPrStatuses(repoRoot: string): Promise<Map<string, PrInfo
       }
     }
   } catch {
-    void 0;
+    // Timeout, gh not installed, or non-zero exit: fall back to last good cache
+    // if we have one, otherwise return an empty map. Either way, do not block
+    // TreeView rendering on gh CLI latency.
+    if (cached) return cached.value;
   }
+
+  prStatusCache.set(repoRoot, { fetchedAt: Date.now(), value: map });
   return map;
 }
 


### PR DESCRIPTION
## Summary
- `SessionManager.sync()` was unconditionally bumping `lastSeenAt`/`updatedAt` and writing `~/.hydra/sessions.json` on every sidebar read, which the file watcher in `extension.ts` picked up and turned into a continuous refresh loop (`listWorkers/listCopilots → sync → write → watcher → refreshAll → repeat`).
- `sync()` now tracks a dirty flag (real `status` / `attached` / membership changes, plus `workerId` legacy backfill) and passes it to `updateSessionState` via a non-enumerable sentinel; `updateSessionState` skips `writeSessionState` when nothing changed. All other mutation callers (createWorker, deleteWorker, startWorker, persistCopilotSessionId, etc.) keep the legacy unconditional-write semantics — no behavior change there.
- `fetchRepoPrStatuses` now has a 30 s per-repo TTL cache and a 3 s timeout around `gh pr list`, so the TreeView is no longer held in a visible loading state by GitHub CLI latency.

Fixes #173.

## Test plan
Verified end-to-end in an isolated Hydra env with the locally-compiled extension loaded into an Extension Development Host:

- [x] `npm run compile` — passes
- [x] `npm run lint` — passes
- [x] Stable empty `sessions.json` + 5× `hydra list` (each call runs `sync()`) → mtime unchanged (0 writes)
- [x] Stable state with a running copilot + 5× `hydra list` → mtime and `updatedAt` both unchanged (0 writes)
- [x] Stale session in `sessions.json` (tmux dead) + 1× `hydra list` → mtime advances, dead copilot is reaped
- [x] Kill a live tmux session + 1× `hydra list` → mtime advances, copilot is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)