### PR TITLE
chore: release v0.3.2026052201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026052201] - 2026-05-22
+
+### Fixed
+- Fix sidebar loading sweep loop caused by synchronous writes
+
 ## [0.3.2026052200] - 2026-05-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052200",
+  "version": "0.3.2026052201",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052200",
+      "version": "0.3.2026052201",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052200",
+  "version": "0.3.2026052201",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary
Release v0.3.2026052201, picking up PR #174 which has merged to main since the previous release (v0.3.2026052200).

### Fixed
- Fix sidebar loading sweep loop caused by synchronous writes (#174)

## Release mechanics
- Bumps `package.json` / `package-lock.json` to `0.3.2026052201`
- Adds CHANGELOG entry
- Merging to `main` triggers `auto-tag-release` → tag `v0.3.2026052201` → `publish.yml` publishes to the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)