### PR TITLE
[codex] add plan copilot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026052201] - 2026-05-22
+
+### Fixed
+- Fix sidebar loading sweep loop caused by synchronous writes
+
 ## [0.3.2026052200] - 2026-05-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052200",
+  "version": "0.3.2026052201",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052200",
+      "version": "0.3.2026052201",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,15 @@
       },
       {
         "view": "hydraCopilots",
+        "contents": "[Start Copilot](command:hydra.createCopilot)"
+      },
+      {
+        "view": "hydraCopilots",
+        "contents": "[Start Plan Copilot](command:hydra.startPlanCopilot)",
+        "when": "hydra.claudeAvailable || hydra.codexAvailable"
+      },
+      {
+        "view": "hydraCopilots",
         "contents": "[Start Copilot (Claude)](command:hydra.startCopilotClaude)",
         "when": "hydra.claudeAvailable"
       },
@@ -172,6 +181,10 @@
         "command": "hydra.createCopilot",
         "title": "Hydra: Create Copilot",
         "icon": "$(hubot)"
+      },
+      {
+        "command": "hydra.startPlanCopilot",
+        "title": "Hydra: Start Plan Copilot"
       },
       {
         "command": "hydra.startCopilotClaude",
@@ -309,6 +322,7 @@
     "onCommand:tmux.createWorktreeFromBranch",
     "onCommand:hydra.openPR",
     "onCommand:hydra.createCopilot",
+    "onCommand:hydra.startPlanCopilot",
     "onCommand:hydra.startCopilotClaude",
     "onCommand:hydra.startCopilotCodex",
     "onCommand:hydra.startCopilotGemini",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052200",
+  "version": "0.3.2026052201",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/cli/commands/copilot.ts
+++ b/src/cli/commands/copilot.ts
@@ -5,6 +5,7 @@ import { SessionManager } from '../../core/sessionManager';
 import { toCanonicalPath, resolveAgentSessionFile } from '../../core/path';
 import { resolveRepoInput } from '../../core/repoRegistry';
 import { fetchOriginRequired } from '../../core/git';
+import type { CopilotMode } from '../../core/types';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
 
@@ -30,6 +31,19 @@ function requireSessionName(sessionName: string): string {
   return trimmed;
 }
 
+function resolveCopilotMode(opts: { mode?: string; plan?: boolean }): CopilotMode {
+  if (opts.plan) {
+    return 'plan';
+  }
+
+  const mode = (opts.mode || 'normal').trim().toLowerCase();
+  if (mode === 'normal' || mode === 'plan') {
+    return mode;
+  }
+
+  throw new Error(`Invalid --mode value "${opts.mode}". Expected "normal" or "plan".`);
+}
+
 export function registerCopilotCommands(program: Command): void {
   const copilot = program
     .command('copilot')
@@ -41,14 +55,18 @@ export function registerCopilotCommands(program: Command): void {
     .option('--workdir <path>', 'Working directory for the copilot', process.cwd())
     .option('--repo <identifier>', 'Run inside a registered repo: <owner/name> or absolute path (overrides --workdir)')
     .option('--agent <type>', 'Agent type (claude, codex, gemini, sudocode)', 'claude')
+    .option('--mode <mode>', 'Copilot mode (normal, plan)', 'normal')
+    .option('--plan', 'Shortcut for --mode plan')
     .option('--name <name>', 'Display name for the copilot session')
     .option('--session <name>', 'Explicit tmux session name')
-    .action(async (opts: { workdir: string; repo?: string; agent: string; name?: string; session?: string }) => {
+    .action(async (opts: { workdir: string; repo?: string; agent: string; mode?: string; plan?: boolean; name?: string; session?: string }) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        const requestedSession = opts.session || opts.name || `hydra-copilot-${opts.agent}`;
+        const copilotMode = resolveCopilotMode(opts);
+        const defaultSessionName = copilotMode === 'plan' ? `hydra-plan-${opts.agent}` : `hydra-copilot-${opts.agent}`;
+        const requestedSession = opts.session || opts.name || defaultSessionName;
         const sessionName = backend.sanitizeSessionName(requestedSession);
 
         let workdir: string;
@@ -65,12 +83,14 @@ export function registerCopilotCommands(program: Command): void {
         const finalCopilot = await sm.createCopilotAndFinalize({
           workdir,
           agentType: opts.agent,
+          copilotMode,
           name: opts.name,
           sessionName,
         });
 
         getTelemetry().capture('copilot_created', {
           agent: normalizeAgentForTelemetry(finalCopilot.agent),
+          mode: finalCopilot.copilotMode,
         });
 
         outputResult(
@@ -78,6 +98,7 @@ export function registerCopilotCommands(program: Command): void {
             status: 'created',
             session: finalCopilot.sessionName,
             agent: finalCopilot.agent,
+            mode: finalCopilot.copilotMode,
             workdir: finalCopilot.workdir,
             agentSessionId: finalCopilot.sessionId,
           },
@@ -85,6 +106,7 @@ export function registerCopilotCommands(program: Command): void {
           () => {
             console.log(`Created copilot: ${finalCopilot.sessionName}`);
             console.log(`  Agent:      ${finalCopilot.agent}`);
+            console.log(`  Mode:       ${finalCopilot.copilotMode}`);
             console.log(`  Workdir:    ${finalCopilot.workdir}`);
             console.log(`  Session ID: ${finalCopilot.sessionId || 'none'}`);
           },
@@ -134,6 +156,7 @@ export function registerCopilotCommands(program: Command): void {
             type: 'copilot',
             session: finalCopilot.sessionName,
             agent: finalCopilot.agent,
+            mode: finalCopilot.copilotMode,
             workdir: finalCopilot.workdir,
             agentSessionId: finalCopilot.sessionId,
           },
@@ -141,6 +164,7 @@ export function registerCopilotCommands(program: Command): void {
           () => {
             console.log(`Restored copilot: ${finalCopilot.sessionName}`);
             console.log(`  Agent:      ${finalCopilot.agent}`);
+            console.log(`  Mode:       ${finalCopilot.copilotMode}`);
             console.log(`  Workdir:    ${finalCopilot.workdir}`);
             console.log(`  Session ID: ${finalCopilot.sessionId || 'none'}`);
           },

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -25,6 +25,7 @@ export function registerListCommand(program: Command): void {
             name: c.displayName || c.sessionName || c.tmuxSession,
             session: c.sessionName || c.tmuxSession,
             agent: c.agent,
+            mode: c.copilotMode,
             status: c.status,
             attached: c.attached,
             workdir: c.workdir || null,
@@ -68,7 +69,8 @@ export function registerListCommand(program: Command): void {
                 : `[${c.status}]`;
               const attached = c.attached ? ' (attached)' : '';
               const name = c.displayName || c.sessionName || c.tmuxSession;
-              console.log(`  ${statusIcon} ${name}  [${c.agent}]${attached}`);
+              const modeLabel = c.copilotMode === 'plan' ? ' [plan]' : '';
+              console.log(`  ${statusIcon} ${name}  [${c.agent}]${modeLabel}${attached}`);
               if (c.workdir) console.log(`    workdir: ${c.workdir}`);
             }
           } else {

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -1,7 +1,8 @@
 import * as os from 'os';
 import * as vscode from 'vscode';
 import { getActiveBackend, MultiplexerBackend } from '../utils/multiplexer';
-import { getAgentCommand, pickAgentType, AgentType } from '../utils/agentConfig';
+import { getAgentCommand, pickAgentType, AgentType, AGENT_LABELS } from '../utils/agentConfig';
+import { CopilotMode } from '../core/types';
 import { TmuxBackendCore } from '../core/tmux';
 import { SessionManager } from '../core/sessionManager';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
@@ -30,24 +31,81 @@ Workers cannot create other workers directly. If a worker reports that more para
 
 Full reference: https://github.com/joezhoujinjing/hydra/blob/main/AGENTS.md`;
 
-function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string): void {
+const PLAN_ONBOARDING_PROMPT = `You are a Hydra plan copilot — an AI planner that analyzes tasks and produces implementation plans only.
+
+## Operating rules
+- Do not edit files, run implementation commands, create workers, commit, push, or open PRs.
+- Read code and documentation as needed.
+- Ask clarifying questions when requirements are ambiguous.
+- Produce a concrete implementation plan that another agent can execute.
+- Include affected files, ordered steps, risks, and verification commands.
+
+The user or a separate executor will handle implementation after the plan is approved.`;
+
+function getOnboardingPrompt(copilotMode: CopilotMode): string {
+  return copilotMode === 'plan' ? PLAN_ONBOARDING_PROMPT : ONBOARDING_PROMPT;
+}
+
+function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string, copilotMode: CopilotMode): void {
   (async () => {
     try {
       await new Promise(resolve => setTimeout(resolve, 8000));
-      await backend.sendMessage(sessionName, ONBOARDING_PROMPT);
+      await backend.sendMessage(sessionName, getOnboardingPrompt(copilotMode));
     } catch {
       // Best-effort — agent may not be ready yet
     }
   })();
 }
 
-export async function createCopilotWithAgent(agentType: AgentType): Promise<void> {
+function getDefaultSessionName(agentType: AgentType, copilotMode: CopilotMode): string {
+  return copilotMode === 'plan' ? `hydra-plan-${agentType}` : `hydra-copilot-${agentType}`;
+}
+
+function getCreatedMessage(sessionName: string, agentType: AgentType, copilotMode: CopilotMode): string {
+  if (copilotMode === 'plan') {
+    const strategy = agentType === 'claude' ? 'native plan mode' : 'read-only plan mode';
+    return `Plan copilot created: ${sessionName} (${AGENT_LABELS[agentType]}, ${strategy})`;
+  }
+  return `Copilot created: ${sessionName} (${agentType})`;
+}
+
+async function pickCopilotMode(): Promise<CopilotMode | undefined> {
+  const picked = await vscode.window.showQuickPick([
+    {
+      label: 'Normal Copilot',
+      description: 'Orchestrates workers and implementation',
+      value: 'normal' as CopilotMode,
+    },
+    {
+      label: 'Plan Copilot',
+      description: 'Produces implementation plans only',
+      value: 'plan' as CopilotMode,
+    },
+  ], {
+    placeHolder: 'Select copilot mode',
+  });
+  return picked?.value;
+}
+
+async function pickPlanAgentType(): Promise<AgentType | undefined> {
+  const items = [
+    { label: AGENT_LABELS.claude, description: 'Native plan mode', value: 'claude' as AgentType },
+    { label: AGENT_LABELS.codex, description: 'Read-only guarded plan mode', value: 'codex' as AgentType },
+  ];
+
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Select agent for plan copilot',
+  });
+  return picked?.value;
+}
+
+export async function createCopilotWithAgent(agentType: AgentType, copilotMode: CopilotMode = 'normal'): Promise<void> {
   const backend = getActiveBackend();
   if (!await ensureBackendInstalled(backend)) {
     return;
   }
 
-  const sessionName = backend.sanitizeSessionName(`hydra-copilot-${agentType}`);
+  const sessionName = backend.sanitizeSessionName(getDefaultSessionName(agentType, copilotMode));
 
   // If session already exists, just attach
   if (await backend.hasSession(sessionName)) {
@@ -61,19 +119,26 @@ export async function createCopilotWithAgent(agentType: AgentType): Promise<void
     const copilotInfo = await sm.createCopilotAndFinalize({
       workdir: os.homedir(),
       agentType,
+      copilotMode,
       sessionName,
       agentCommand: getAgentCommand(agentType),
     });
 
-    sendCopilotOnboarding(backend, copilotInfo.sessionName);
+    sendCopilotOnboarding(backend, copilotInfo.sessionName, copilotMode);
     backend.attachSession(copilotInfo.sessionName, copilotInfo.workdir, undefined, 'copilot');
 
-    vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
+    vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, copilotMode));
     vscode.commands.executeCommand('tmux.refresh');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showErrorMessage(`Failed to create copilot: ${message}`);
   }
+}
+
+export async function createPlanCopilot(): Promise<void> {
+  const agentType = await pickPlanAgentType();
+  if (!agentType) return;
+  await createCopilotWithAgent(agentType, 'plan');
 }
 
 export async function createCopilot(): Promise<void> {
@@ -82,12 +147,17 @@ export async function createCopilot(): Promise<void> {
     return;
   }
 
+  const copilotMode = await pickCopilotMode();
+  if (!copilotMode) return;
+
   // Pick agent type
-  const agentType = await pickAgentType();
+  const agentType = copilotMode === 'plan'
+    ? await pickPlanAgentType()
+    : await pickAgentType();
   if (!agentType) return;
 
   // Ask for session name (default: hydra-copilot-<agent>)
-  const defaultName = `hydra-copilot-${agentType}`;
+  const defaultName = getDefaultSessionName(agentType, copilotMode);
   const nameInput = await vscode.window.showInputBox({
     prompt: 'Copilot session name',
     value: defaultName,
@@ -116,15 +186,16 @@ export async function createCopilot(): Promise<void> {
     const copilotInfo = await sm.createCopilotAndFinalize({
       workdir: os.homedir(),
       agentType,
+      copilotMode,
       sessionName,
       name: nameInput.trim(),
       agentCommand: getAgentCommand(agentType),
     });
 
-    sendCopilotOnboarding(backend, copilotInfo.sessionName);
+    sendCopilotOnboarding(backend, copilotInfo.sessionName, copilotMode);
     backend.attachSession(copilotInfo.sessionName, copilotInfo.workdir, undefined, 'copilot');
 
-    vscode.window.showInformationMessage(`Copilot created: ${sessionName} (${agentType})`);
+    vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, copilotMode));
     vscode.commands.executeCommand('tmux.refresh');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -1,4 +1,4 @@
-import { AgentType } from './types';
+import { AgentType, CopilotMode } from './types';
 
 export const AGENT_LABELS: Record<AgentType, string> = {
   claude: 'Claude', codex: 'Codex', gemini: 'Gemini', sudocode: 'Sudo Code', custom: 'Custom',
@@ -88,6 +88,20 @@ export function agentSupportsCompletionNotification(agentType: string): boolean 
   return AGENT_COMPLETION_NOTIFICATIONS[agentType] === true;
 }
 
+export function agentSupportsCopilotMode(agentType: string, copilotMode: CopilotMode): boolean {
+  if (copilotMode === 'normal') {
+    return true;
+  }
+  return agentType === 'claude' || agentType === 'codex';
+}
+
+export function getUnsupportedCopilotModeMessage(agentType: string, copilotMode: CopilotMode): string {
+  if (copilotMode === 'plan') {
+    return `Plan copilot mode is currently supported for Claude and Codex only. Agent "${agentType}" is not supported.`;
+  }
+  return `Copilot mode "${copilotMode}" is not supported for agent "${agentType}".`;
+}
+
 export function extractAgentCommandExecutable(command: string): string {
   const tokens = tokenizeCommand(command);
   if (tokens.length === 0) {
@@ -159,6 +173,53 @@ function ensureCommandFlag(command: string, flag: string): string {
   return appendCommandArgs(trimmed, flag);
 }
 
+export interface AgentCommandOptions {
+  copilotMode?: CopilotMode;
+}
+
+const PLAN_UNSAFE_FLAGS = [
+  '--dangerously-skip-permissions',
+  '--dangerously-bypass-approvals-and-sandbox',
+  '--yolo',
+];
+
+function isPlanCopilot(options?: AgentCommandOptions): boolean {
+  return options?.copilotMode === 'plan';
+}
+
+function assertPlanCommandIsSafe(agentBinary: string): void {
+  const tokens = tokenizeCommand(agentBinary);
+  const unsafe = PLAN_UNSAFE_FLAGS.find(flag => tokens.includes(flag));
+  if (unsafe) {
+    throw new Error(`Plan copilot mode cannot use unsafe agent flag "${unsafe}". Remove it from the configured agent command.`);
+  }
+}
+
+function buildAgentBaseCommand(
+  agentType: string,
+  agentBinary: string,
+  options?: AgentCommandOptions,
+): string {
+  if (!isPlanCopilot(options)) {
+    const yolo = AGENT_YOLO_FLAGS[agentType] || '';
+    return ensureCommandFlag(agentBinary, yolo);
+  }
+
+  assertPlanCommandIsSafe(agentBinary);
+
+  switch (agentType) {
+    case 'claude':
+      return ensureCommandFlag(agentBinary, '--permission-mode plan');
+    case 'codex': {
+      let command = ensureCommandFlag(agentBinary, '--sandbox read-only');
+      command = ensureCommandFlag(command, '--ask-for-approval never');
+      return command;
+    }
+    default:
+      throw new Error(getUnsupportedCopilotModeMessage(agentType, 'plan'));
+  }
+}
+
 /**
  * Build the shell command to RESUME an existing agent session.
  * Returns null if the agent type doesn't support resume.
@@ -168,8 +229,9 @@ export function buildAgentResumeCommand(
   agentBinary: string,
   sessionId: string,
   workdir?: string,
+  options?: AgentCommandOptions,
 ): string | null {
-  const plan = buildAgentResumePlan(agentType, agentBinary, sessionId, workdir);
+  const plan = buildAgentResumePlan(agentType, agentBinary, sessionId, workdir, null, options);
   return plan?.strategy === 'command' ? plan.command : null;
 }
 
@@ -187,21 +249,28 @@ export function buildAgentResumePlan(
   sessionId: string,
   workdir?: string,
   sessionFile?: string | null,
+  options?: AgentCommandOptions,
 ): AgentResumePlan | null {
   const quotedSessionId = shellQuoteForDisplay(sessionId);
   switch (agentType) {
     case 'claude': {
-      return { strategy: 'command', command: appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`) };
+      const command = isPlanCopilot(options)
+        ? buildAgentBaseCommand(agentType, agentBinary, options)
+        : agentBinary;
+      return { strategy: 'command', command: appendCommandArgs(command, `--resume ${quotedSessionId}`) };
     }
     case 'codex': {
-      const command = ensureCommandFlag(agentBinary, AGENT_YOLO_FLAGS.codex);
+      const command = buildAgentBaseCommand(agentType, agentBinary, options);
       const cdArgs = workdir ? ['-C', shellQuoteForDisplay(workdir)] : [];
       return { strategy: 'command', command: appendCommandArgs(command, 'resume', ...cdArgs, quotedSessionId) };
     }
     case 'gemini':
+      if (isPlanCopilot(options)) {
+        throw new Error(getUnsupportedCopilotModeMessage(agentType, 'plan'));
+      }
       return { strategy: 'command', command: appendCommandArgs(agentBinary, `--resume ${quotedSessionId}`) };
     case 'sudocode': {
-      const command = ensureCommandFlag(agentBinary, AGENT_YOLO_FLAGS.sudocode);
+      const command = buildAgentBaseCommand(agentType, agentBinary, options);
       const resumeRef = sessionFile?.trim() || sessionId;
       return {
         strategy: 'replSlashCommand',
@@ -223,9 +292,9 @@ export function buildAgentLaunchCommand(
   agentBinary: string,
   task?: string,
   sessionId?: string,
+  options?: AgentCommandOptions,
 ): string {
-  const yolo = AGENT_YOLO_FLAGS[agentType] || '';
-  const command = ensureCommandFlag(agentBinary, yolo);
+  const command = buildAgentBaseCommand(agentType, agentBinary, options);
 
   switch (agentType) {
     case 'claude': {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
-import { MultiplexerBackendCore } from './types';
+import { CopilotMode, MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig, getHydraGlobalAgentCommand } from './hydraGlobalConfig';
-import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification } from './agentConfig';
+import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification, agentSupportsCopilotMode, getUnsupportedCopilotModeMessage, type AgentCommandOptions } from './agentConfig';
 import { exec, resolveCommandPath } from './exec';
 import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, resolveAgentSessionFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
@@ -135,6 +135,7 @@ export interface CopilotInfo {
   status: 'running' | 'stopped';
   attached: boolean;
   agent: string;
+  copilotMode: CopilotMode;
   workdir: string;
   tmuxSession: string;
   createdAt: string;
@@ -198,6 +199,7 @@ export interface CreateWorkerOpts {
 export interface CreateCopilotOpts {
   workdir: string;
   agentType?: string;
+  copilotMode?: CopilotMode;
   /** User-given name for the copilot (used as displayName). */
   name?: string;
   sessionName?: string;
@@ -240,6 +242,10 @@ function consumeSessionStateDirty(state: SessionState): boolean | undefined {
   const value = record[SESSION_STATE_DIRTY_KEY] as boolean;
   delete record[SESSION_STATE_DIRTY_KEY];
   return value;
+}
+
+function normalizeCopilotMode(mode: CopilotMode | undefined): CopilotMode {
+  return mode === 'plan' ? 'plan' : 'normal';
 }
 
 // ── SessionManager Class ──
@@ -359,6 +365,7 @@ export class SessionManager {
             status: 'running',
             attached: session.attached,
             agent: discovered.agent,
+            copilotMode: 'normal',
             workdir: discovered.workdir,
             tmuxSession: session.name,
             createdAt: now,
@@ -780,9 +787,16 @@ export class SessionManager {
     ensureHydraGlobalConfig();
 
     const agentType = opts.agentType || 'claude';
+    const copilotMode = normalizeCopilotMode(opts.copilotMode);
+    if (!agentSupportsCopilotMode(agentType, copilotMode)) {
+      throw new Error(getUnsupportedCopilotModeMessage(agentType, copilotMode));
+    }
+
     const agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
-    const displayName = opts.name || opts.sessionName || `hydra-copilot-${agentType}`;
-    const sessionName = opts.sessionName || this.backend.sanitizeSessionName(`hydra-copilot-${agentType}`);
+    const defaultSessionName = copilotMode === 'plan' ? `hydra-plan-${agentType}` : `hydra-copilot-${agentType}`;
+    const displayName = opts.name || opts.sessionName || defaultSessionName;
+    const sessionName = opts.sessionName || this.backend.sanitizeSessionName(defaultSessionName);
+    const agentOptions: AgentCommandOptions = { copilotMode };
 
     const exists = await this.backend.hasSession(sessionName);
     if (exists) {
@@ -804,10 +818,10 @@ export class SessionManager {
 
     if (isResume) {
       sessionId = opts.resumeSessionId!;
-      await this.launchAgentResume(sessionName, agentType, agentCommand, sessionId, opts.workdir, opts.resumeSessionFile);
+      await this.launchAgentResume(sessionName, agentType, agentCommand, sessionId, opts.workdir, opts.resumeSessionFile, agentOptions);
     } else {
       sessionId = agentType === 'claude' ? randomUUID() : null;
-      const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined);
+      const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined, agentOptions);
       launchStartedAt = Date.now();
       await this.backend.sendKeys(sessionName, launchCmd);
     }
@@ -820,6 +834,7 @@ export class SessionManager {
       status: 'running',
       attached: false,
       agent: agentType,
+      copilotMode,
       workdir: opts.workdir,
       tmuxSession: sessionName,
       createdAt: now,
@@ -835,6 +850,7 @@ export class SessionManager {
         createdAt: existingCopilot?.createdAt ?? now,
         sessionId: sessionId ?? existingCopilot?.sessionId ?? null,
         agentSessionFile: opts.resumeSessionFile ?? existingCopilot?.agentSessionFile ?? null,
+        copilotMode,
       };
 
       state.copilots[sessionName] = nextCopilot;
@@ -1057,6 +1073,7 @@ export class SessionManager {
     workdir: string,
     sessionId: string | null,
     displayName?: string,
+    copilotMode?: CopilotMode,
   ): Promise<void> {
     await this.updateSessionState((state) => {
       const now = new Date().toISOString();
@@ -1067,6 +1084,7 @@ export class SessionManager {
         status: 'running',
         attached: false,
         agent: agentType,
+        copilotMode: normalizeCopilotMode(copilotMode ?? existingCopilot?.copilotMode),
         workdir,
         tmuxSession: sessionName,
         createdAt: existingCopilot?.createdAt ?? now,
@@ -1147,6 +1165,7 @@ export class SessionManager {
     return this.createCopilot({
       workdir: copilot.workdir,
       agentType: copilot.agent,
+      copilotMode: copilot.copilotMode,
       name: copilot.displayName,
       sessionName: copilot.sessionName,
       resumeSessionId: entry.agentSessionId || undefined,
@@ -1290,6 +1309,7 @@ export class SessionManager {
           c.sessionId ??= null;
           c.agentSessionFile ??= null;
           c.displayName ??= c.sessionName;
+          c.copilotMode = normalizeCopilotMode(c.copilotMode);
         }
         return state;
       }
@@ -1759,8 +1779,9 @@ export class SessionManager {
     sessionId: string,
     workdir: string,
     agentSessionFile?: string | null,
+    agentOptions?: AgentCommandOptions,
   ): Promise<void> {
-    const resumePlan = buildAgentResumePlan(agentType, agentCommand, sessionId, workdir, agentSessionFile);
+    const resumePlan = buildAgentResumePlan(agentType, agentCommand, sessionId, workdir, agentSessionFile, agentOptions);
     if (!resumePlan) {
       throw new Error(`Agent "${agentType}" does not support session resume`);
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,7 @@
 export type MultiplexerType = 'tmux';
 export type HydraRole = 'copilot' | 'worker';
 export type AgentType = 'claude' | 'codex' | 'gemini' | 'sudocode' | 'custom';
+export type CopilotMode = 'normal' | 'plan';
 
 export interface MultiplexerSession {
   name: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import {
 } from './commands/contextMenu';
 import { terminalSmartPaste, pasteImageForce, cleanupTempImages } from './commands/pasteImage';
 import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
-import { createCopilot, createCopilotWithAgent } from './commands/createCopilot';
+import { createCopilot, createCopilotWithAgent, createPlanCopilot } from './commands/createCopilot';
 import { ensureHydraGlobalConfig } from './utils/hydraGlobalConfig';
 import { installCli, ensurePathInShellProfile } from './core/cliInstaller';
 import { detectAvailableAgents, syncAgentCommandsToHydraConfig } from './utils/agentConfig';
@@ -135,6 +135,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
     vscode.commands.registerCommand('hydra.openPR', openPR),
     vscode.commands.registerCommand('hydra.createCopilot', createCopilot),
+    vscode.commands.registerCommand('hydra.startPlanCopilot', createPlanCopilot),
     vscode.commands.registerCommand('hydra.startCopilotClaude', () => createCopilotWithAgent('claude')),
     vscode.commands.registerCommand('hydra.startCopilotCodex', () => createCopilotWithAgent('codex')),
     vscode.commands.registerCommand('hydra.startCopilotGemini', () => createCopilotWithAgent('gemini')),

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -6,7 +6,7 @@ import { getRepoRoot, getBaseBranch } from '../utils/git';
 import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multiplexer';
 import { toCanonicalPath } from '../utils/path';
 import { SessionManager, WorkerInfo } from '../core/sessionManager';
-import { Worktree } from '../core/types';
+import { CopilotMode, Worktree } from '../core/types';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
 
@@ -32,6 +32,7 @@ interface SessionWithStatus extends MultiplexerSession {
   slug: string;
   hydraRole?: HydraRole;
   hydraAgent?: string;
+  hydraCopilotMode?: CopilotMode;
 }
 
 function isCurrentWorkspacePath(targetPath: string | undefined, activeWorkspacePath: string): boolean {
@@ -304,21 +305,27 @@ export class TmuxItem extends vscode.TreeItem {
 export class CopilotItem extends TmuxItem {
   public readonly worktreePath?: string;
   public readonly agentType: string;
+  public readonly copilotMode: CopilotMode;
   public readonly classification: Classification;
 
   constructor(opts: {
     sessionName: string;
     displayName?: string;
     agentType: string;
+    copilotMode?: CopilotMode;
     worktreePath?: string;
     classification: Classification;
   }) {
     const label = opts.displayName || opts.sessionName;
-    const description = `[${opts.agentType}]`;
+    const copilotMode = opts.copilotMode || 'normal';
+    const description = copilotMode === 'plan'
+      ? `[${opts.agentType}] [plan]`
+      : `[${opts.agentType}]`;
     super(label, vscode.TreeItemCollapsibleState.Expanded, undefined, opts.sessionName);
 
     this.worktreePath = opts.worktreePath;
     this.agentType = opts.agentType;
+    this.copilotMode = copilotMode;
     this.classification = opts.classification;
     this.id = opts.sessionName;
     this.description = description;
@@ -461,6 +468,10 @@ export class TmuxDetailItem extends TmuxItem {
 
     if (session.status.classification === 'orphan') {
       parts.push('orphan');
+    }
+
+    if (session.hydraRole === 'copilot' && session.hydraCopilotMode === 'plan') {
+      parts.push(session.hydraAgent === 'claude' ? 'Native Plan' : 'Read Only Plan');
     }
 
     const label = parts.join(' · ');
@@ -759,6 +770,7 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
           sessionName: c.sessionName,
           displayName: c.displayName,
           agentType: c.agent,
+          copilotMode: c.copilotMode,
           worktreePath: c.workdir,
           classification,
         }));
@@ -787,6 +799,7 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
       slug: 'copilot',
       hydraRole: 'copilot',
       hydraAgent: copilot.agentType,
+      hydraCopilotMode: copilot.copilotMode,
     };
     return [new TmuxDetailItem(session, '', undefined, this._extensionUri)];
   }

--- a/src/smoke/cliSessionFieldsSmoke.ts
+++ b/src/smoke/cliSessionFieldsSmoke.ts
@@ -25,6 +25,7 @@ interface ListJsonEntry {
   sessionId: string | null;
   sessionFile: string | null;
   agentSessionId: string | null;
+  mode?: string;
   [k: string]: unknown;
 }
 interface ListJson {
@@ -193,6 +194,7 @@ function main(): void {
     const copilot = list.copilots.find(c => c.session === ctx.copilotSession);
     assertSessionFields(worker, ctx.workerSessionId, ctx.workerTranscript, 'worker');
     assertSessionFields(copilot, ctx.copilotSessionId, ctx.copilotTranscript, 'copilot');
+    assert.equal(copilot!.mode, 'normal', 'copilot.mode');
 
     // worker logs --json: confirm sessionId/sessionFile present.
     const workerLogsOut = runCli(['worker', 'logs', ctx.workerSession, '--lines', '1', '--json'], env);

--- a/src/smoke/codexBypassSmoke.ts
+++ b/src/smoke/codexBypassSmoke.ts
@@ -209,6 +209,19 @@ async function main(): Promise<void> {
   assert.ok(dedupedResumeCommand);
   assert.equal(countOccurrences(dedupedResumeCommand, BYPASS_FLAG), 1);
 
+  assert.equal(
+    agentConfig.buildAgentLaunchCommand('codex', 'codex', undefined, undefined, { copilotMode: 'plan' }),
+    'codex --sandbox read-only --ask-for-approval never',
+  );
+  assert.equal(
+    agentConfig.buildAgentResumeCommand('codex', 'codex', 'resume-session-id', '/workspace', { copilotMode: 'plan' }),
+    "codex --sandbox read-only --ask-for-approval never resume -C '/workspace' 'resume-session-id'",
+  );
+  assert.throws(
+    () => agentConfig.buildAgentLaunchCommand('codex', `codex ${BYPASS_FLAG}`, undefined, undefined, { copilotMode: 'plan' }),
+    /Plan copilot mode cannot use unsafe agent flag/,
+  );
+
   const smokeCodexCommand = 'codex-smoke-test';
   agentConfig.DEFAULT_AGENT_COMMANDS.codex = smokeCodexCommand;
 
@@ -253,6 +266,7 @@ async function main(): Promise<void> {
         status: 'stopped',
         attached: false,
         agent: 'codex',
+        copilotMode: 'normal',
         workdir: copilotRestoredWorkdir,
         tmuxSession: 'copilot-restored',
         createdAt: new Date().toISOString(),
@@ -278,6 +292,46 @@ async function main(): Promise<void> {
       backend.capturePaneCalls.some(call => call.sessionName === 'copilot-restored'),
     );
     assert.equal(copilot.sessionId, '22222222-2222-4222-8222-222222222222');
+  }
+
+  {
+    const copilotPlanRestoredWorkdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-copilot-plan-restored-'));
+    const archive = readJson<{ entries: Array<Record<string, unknown>> }>(archiveFile, { entries: [] });
+    archive.entries.push({
+      type: 'copilot',
+      sessionName: 'copilot-plan-restored',
+      agentSessionId: '33333333-3333-4333-8333-333333333333',
+      archivedAt: new Date().toISOString(),
+      data: {
+        sessionName: 'copilot-plan-restored',
+        displayName: 'copilot-plan-restored',
+        status: 'stopped',
+        attached: false,
+        agent: 'codex',
+        copilotMode: 'plan',
+        workdir: copilotPlanRestoredWorkdir,
+        tmuxSession: 'copilot-plan-restored',
+        createdAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        sessionId: '33333333-3333-4333-8333-333333333333',
+      },
+    });
+    writeJson(archiveFile, archive);
+
+    const backend = new FakeBackend();
+    backend.paneOutputs.set('copilot-plan-restored', '⏵');
+    const sm = new SessionManager(backend);
+    forceFastSleeps(sm);
+
+    const copilot = await sm.restoreCopilotAndFinalize('copilot-plan-restored');
+    const command = lastSendKeysFor(backend, 'copilot-plan-restored');
+
+    assert.equal(
+      command,
+      `${smokeCodexCommand} --sandbox read-only --ask-for-approval never resume -C '${copilotPlanRestoredWorkdir}' '33333333-3333-4333-8333-333333333333'`,
+    );
+    assert.equal(copilot.copilotMode, 'plan');
+    assert.equal(copilot.sessionId, '33333333-3333-4333-8333-333333333333');
   }
 
   {

--- a/src/smoke/sudocodeAgentSmoke.ts
+++ b/src/smoke/sudocodeAgentSmoke.ts
@@ -116,6 +116,18 @@ function testAgentConfig(): void {
     buildAgentLaunchCommand('sudocode', 'scode --dangerously-skip-permissions', 'Implement the task'),
     'scode --dangerously-skip-permissions',
   );
+  assert.equal(
+    buildAgentLaunchCommand('claude', 'claude', undefined, '11111111-1111-4111-8111-111111111111', { copilotMode: 'plan' }),
+    "claude --permission-mode plan --session-id '11111111-1111-4111-8111-111111111111'",
+  );
+  assert.equal(
+    buildAgentResumeCommand('claude', 'claude', '11111111-1111-4111-8111-111111111111', undefined, { copilotMode: 'plan' }),
+    "claude --permission-mode plan --resume '11111111-1111-4111-8111-111111111111'",
+  );
+  assert.throws(
+    () => buildAgentLaunchCommand('gemini', 'gemini', undefined, undefined, { copilotMode: 'plan' }),
+    /Plan copilot mode is currently supported for Claude and Codex only/,
+  );
   assert.equal(buildAgentResumeCommand('sudocode', 'scode', 'session-1-0'), null);
 
   const plan = buildAgentResumePlan(


### PR DESCRIPTION
## Summary

- Add copilotMode as a first-class normal/plan axis instead of pseudo agent types.
- Support plan copilots for Claude and Codex only, with Claude native plan mode and Codex read-only guardrails.
- Persist plan mode through sessions, archive/restore, CLI output, and VS Code sidebar presentation.
- Add VS Code plan copilot entry points and plan-specific onboarding.

## Behavior

- Claude plan launch/resume uses --permission-mode plan.
- Codex plan launch/resume uses --sandbox read-only --ask-for-approval never.
- Gemini and Sudo Code reject plan mode with a clear unsupported-agent error.
- Normal copilot behavior is preserved, including Codex bypass mode for normal copilots.

## Validation

- npm run compile
- npm run lint
- npm run smoke:codex-bypass
- npm run smoke:sudocode-agent
- npm run smoke:cli-session-fields
- VS Code Extension Development Host E2E for plan Codex copilot: /tmp/hydra-plan-e2e-ext-1779699700/e2e-result.json
- VS Code Extension Development Host E2E for normal Codex copilot regression: /tmp/hydra-normal-e2e-ext-1779702138/e2e-result.json
