### PR TITLE
chore: release v0.3.2026052500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026052500] - 2026-05-25
+
+### Added
+- Add plan copilot mode for Claude and Codex, including guarded launch/resume behavior, CLI and VS Code entry points, persisted session mode, sidebar labels, and plan-specific onboarding
+
 ## [0.3.2026052201] - 2026-05-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052201",
+  "version": "0.3.2026052500",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052201",
+      "version": "0.3.2026052500",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052201",
+  "version": "0.3.2026052500",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026052500

## Summary
- Bump extension version to 0.3.2026052500
- Add changelog entry for plan copilot mode

## Validation
- npm run compile

After this PR is merged, the auto-tag-release workflow should create v0.3.2026052500 and trigger publishing.