### PR TITLE
fix(ui): re-highlight active worker/copilot in sidebar when switching tabs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,7 +241,7 @@ function revealSidebarItem(
       return name === buildHydraTerminalName(shortName, 'copilot');
     });
     if (found) {
-      copilotView.reveal(found, { select: false, focus: false }).then(undefined, () => {});
+      copilotView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
     }
     return;
   }
@@ -255,7 +255,7 @@ function revealSidebarItem(
       return name === buildHydraTerminalName(shortName, 'worker', workerId);
     });
     if (found) {
-      workerView.reveal(found, { select: false, focus: false }).then(undefined, () => {});
+      workerView.reveal(found, { select: true, focus: false }).then(undefined, () => {});
     }
   }
 }


### PR DESCRIPTION
## Summary

- `reveal({ select: false })` only scrolls the item into view — it does NOT highlight/select it
- Commit ebf530d ("Fix review changes worktree resolution") accidentally regressed both `copilotView.reveal()` and `workerView.reveal()` calls from `select: true` to `select: false`
- This PR restores `select: true` so clicking a Worker or Copilot terminal tab once again highlights the corresponding entry in the sidebar

## Test plan

- [ ] Open a worker terminal tab → corresponding worker item should highlight in the sidebar Workers panel
- [ ] Open a copilot terminal tab → corresponding copilot item should highlight in the sidebar Copilots panel
- [ ] Switch between multiple worker tabs → sidebar highlight follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)