### PR TITLE
[codex] Fix agent completion hook startup prompts

### DIFF
--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -11,8 +11,8 @@ export const DEFAULT_AGENT_COMMANDS: Record<string, string> = {
 /** Per-agent flag to enable full auto-approve (skip all permission prompts) */
 export const AGENT_YOLO_FLAGS: Record<string, string> = {
   claude: '--dangerously-skip-permissions',
-  codex: '--dangerously-bypass-approvals-and-sandbox',
-  gemini: '--yolo',
+  codex: '--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust',
+  gemini: '--yolo --skip-trust',
   sudocode: '--dangerously-skip-permissions',
 };
 
@@ -152,6 +152,15 @@ export const CLAUDE_TRUST_PROMPT_PATTERN = /trust this folder/;
  */
 export const CODEX_RESUME_CWD_PROMPT_PATTERN = /Choose working directory to resume this session/i;
 
+/** Codex asks before loading project-local config/hooks from a new worktree. */
+export const CODEX_TRUST_PROMPT_PATTERN = /Do you trust the contents of this directory/i;
+
+/** Codex requires review before newly injected hooks become active. */
+export const CODEX_HOOK_REVIEW_PROMPT_PATTERN = /Hooks need review|hook needs review before it can run|Trust all and continue/i;
+
+/** Gemini asks before loading project-local settings/hooks from a new worktree. */
+export const GEMINI_TRUST_PROMPT_PATTERN = /Do you trust the files in this folder\?|Trust folder/i;
+
 /** Sudo Code asks for explicit confirmation when launched from a broad directory. */
 export const SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN = /Continue anyway\?\s+\[y\/N\]:/i;
 
@@ -173,6 +182,14 @@ function ensureCommandFlag(command: string, flag: string): string {
   return appendCommandArgs(trimmed, flag);
 }
 
+function ensureStandaloneCommandFlags(command: string, flags: string): string {
+  return flags
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .reduce((current, flag) => ensureCommandFlag(current, flag), command.trim());
+}
+
 export interface AgentCommandOptions {
   copilotMode?: CopilotMode;
 }
@@ -180,7 +197,9 @@ export interface AgentCommandOptions {
 const PLAN_UNSAFE_FLAGS = [
   '--dangerously-skip-permissions',
   '--dangerously-bypass-approvals-and-sandbox',
+  '--dangerously-bypass-hook-trust',
   '--yolo',
+  '--skip-trust',
 ];
 
 function isPlanCopilot(options?: AgentCommandOptions): boolean {
@@ -202,7 +221,7 @@ function buildAgentBaseCommand(
 ): string {
   if (!isPlanCopilot(options)) {
     const yolo = AGENT_YOLO_FLAGS[agentType] || '';
-    return ensureCommandFlag(agentBinary, yolo);
+    return ensureStandaloneCommandFlags(agentBinary, yolo);
   }
 
   assertPlanCommandIsSafe(agentBinary);

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import { CopilotMode, MultiplexerBackendCore } from './types';
 import * as coreGit from './git';
 import { ensureHydraGlobalConfig, getHydraGlobalAgentCommand } from './hydraGlobalConfig';
-import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification, agentSupportsCopilotMode, getUnsupportedCopilotModeMessage, type AgentCommandOptions } from './agentConfig';
+import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, CODEX_TRUST_PROMPT_PATTERN, CODEX_HOOK_REVIEW_PROMPT_PATTERN, GEMINI_TRUST_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification, agentSupportsCopilotMode, getUnsupportedCopilotModeMessage, type AgentCommandOptions } from './agentConfig';
 import { exec, resolveCommandPath } from './exec';
 import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, resolveAgentSessionFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
@@ -538,7 +538,7 @@ export class SessionManager {
       });
       if (agentType === 'codex') {
         const scriptPath = path.join(getHydraHome(), 'hooks', `notify-${sessionName}.sh`);
-        agentCommand = this.withCodexCompletionHookOverrides(agentCommand, repoRoot, scriptPath);
+        agentCommand = this.withCodexCompletionHookOverrides(agentCommand, repoRoot, worktreePath, scriptPath);
       }
     }
 
@@ -1621,11 +1621,11 @@ export class SessionManager {
   private ensureCodexHooksEnabled(configTomlPath: string): void {
     fs.mkdirSync(path.dirname(configTomlPath), { recursive: true });
 
-    const featureLine = 'codex_hooks = true';
+    const featureLine = 'hooks = true';
     const content = fs.existsSync(configTomlPath)
       ? fs.readFileSync(configTomlPath, 'utf-8')
       : '';
-    if (/^\s*codex_hooks\s*=\s*true\s*(?:#.*)?$/m.test(content)) {
+    if (/^\s*hooks\s*=\s*true\s*(?:#.*)?$/m.test(content)) {
       return;
     }
 
@@ -1648,7 +1648,7 @@ export class SessionManager {
 
     if (featuresStart >= 0) {
       for (let i = featuresStart + 1; i < featuresEnd; i++) {
-        if (/^\s*codex_hooks\s*=/.test(lines[i])) {
+        if (/^\s*hooks\s*=/.test(lines[i])) {
           lines[i] = featureLine;
           fs.writeFileSync(configTomlPath, lines.join('\n').replace(/\n*$/, '\n'), 'utf-8');
           return;
@@ -1680,12 +1680,19 @@ export class SessionManager {
     }
   }
 
-  private withCodexCompletionHookOverrides(agentCommand: string, repoRoot: string, scriptPath: string): string {
-    const trustRoots = new Set([repoRoot]);
-    try {
-      trustRoots.add(fs.realpathSync(repoRoot));
-    } catch {
-      // Fall back to the original path when realpath is unavailable.
+  private withCodexCompletionHookOverrides(
+    agentCommand: string,
+    repoRoot: string,
+    worktreePath: string,
+    scriptPath: string,
+  ): string {
+    const trustRoots = new Set([repoRoot, worktreePath]);
+    for (const trustPath of [repoRoot, worktreePath]) {
+      try {
+        trustRoots.add(fs.realpathSync(trustPath));
+      } catch {
+        // Fall back to the original path when realpath is unavailable.
+      }
     }
 
     const projects = [...trustRoots]
@@ -1702,7 +1709,7 @@ export class SessionManager {
     return [
       agentCommand.trim(),
       '-c',
-      shellQuote('features.codex_hooks=true'),
+      shellQuote('features.hooks=true'),
       '-c',
       shellQuote(`projects={${projects}}`),
       '-c',
@@ -1854,8 +1861,9 @@ export class SessionManager {
    * Poll the tmux pane output until the agent's ready indicator appears,
    * or fall back to the fixed delay on timeout.
    *
-   * Handles the Claude trust prompt: if detected, sends Enter to accept it
-   * before continuing to poll for the actual input prompt.
+   * Handles startup trust/review prompts before checking ready patterns. Codex
+   * pickers also render `›`, so prompt handling must run before readiness
+   * detection or Hydra will send setup slash commands into a modal.
    */
   private async waitForAgentReady(sessionName: string, agentType: string): Promise<void> {
     const pattern = AGENT_READY_PATTERNS[agentType];
@@ -1867,7 +1875,10 @@ export class SessionManager {
 
     const deadline = Date.now() + AGENT_READY_TIMEOUT_MS;
     let trustPromptHandled = false;
+    let codexTrustPromptHandled = false;
+    let codexHookReviewPromptHandled = false;
     let codexResumeCwdPromptHandled = false;
+    let geminiTrustPromptHandled = false;
     let sudoCodeBroadDirectoryPromptHandled = false;
 
     // Initial delay before first poll (agent needs time to start the process)
@@ -1881,6 +1892,29 @@ export class SessionManager {
         if (!trustPromptHandled && CLAUDE_TRUST_PROMPT_PATTERN.test(output)) {
           await this.backend.sendKeys(sessionName, '');
           trustPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        if (
+          agentType === 'codex' &&
+          !codexTrustPromptHandled &&
+          CODEX_TRUST_PROMPT_PATTERN.test(output)
+        ) {
+          await this.backend.sendKeys(sessionName, '');
+          codexTrustPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        if (
+          agentType === 'codex' &&
+          !codexHookReviewPromptHandled &&
+          CODEX_HOOK_REVIEW_PROMPT_PATTERN.test(output)
+        ) {
+          // Select "Trust all and continue" for Hydra-injected completion hooks.
+          await this.backend.sendKeys(sessionName, 'Down');
+          codexHookReviewPromptHandled = true;
           await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
           continue;
         }
@@ -1905,6 +1939,29 @@ export class SessionManager {
         ) {
           await this.backend.sendKeys(sessionName, 'y');
           sudoCodeBroadDirectoryPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        if (
+          agentType === 'gemini' &&
+          !geminiTrustPromptHandled &&
+          GEMINI_TRUST_PROMPT_PATTERN.test(output)
+        ) {
+          await this.backend.sendKeys(sessionName, '');
+          geminiTrustPromptHandled = true;
+          await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
+          continue;
+        }
+
+        if (
+          (agentType === 'codex' && (
+            CODEX_TRUST_PROMPT_PATTERN.test(output) ||
+            CODEX_HOOK_REVIEW_PROMPT_PATTERN.test(output) ||
+            CODEX_RESUME_CWD_PROMPT_PATTERN.test(output)
+          )) ||
+          (agentType === 'gemini' && GEMINI_TRUST_PROMPT_PATTERN.test(output))
+        ) {
           await this.sleep(AGENT_READY_POLL_INTERVAL_MS);
           continue;
         }

--- a/src/smoke/codexBypassSmoke.ts
+++ b/src/smoke/codexBypassSmoke.ts
@@ -9,7 +9,9 @@ import type {
   SessionStatusInfo,
 } from '../core/types';
 
-const BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
+const APPROVAL_BYPASS_FLAG = '--dangerously-bypass-approvals-and-sandbox';
+const HOOK_TRUST_BYPASS_FLAG = '--dangerously-bypass-hook-trust';
+const BYPASS_FLAGS = `${APPROVAL_BYPASS_FLAG} ${HOOK_TRUST_BYPASS_FLAG}`;
 
 type SessionRecord = {
   agent?: string;
@@ -187,27 +189,29 @@ async function main(): Promise<void> {
   const { SessionManager } = await import('../core/sessionManager');
 
   const launchCommand = agentConfig.buildAgentLaunchCommand('codex', 'codex');
-  assert.equal(launchCommand, `codex ${BYPASS_FLAG}`);
+  assert.equal(launchCommand, `codex ${BYPASS_FLAGS}`);
 
   const dedupedLaunchCommand = agentConfig.buildAgentLaunchCommand(
     'codex',
-    `codex ${BYPASS_FLAG}`,
+    `codex ${BYPASS_FLAGS}`,
   );
-  assert.equal(countOccurrences(dedupedLaunchCommand, BYPASS_FLAG), 1);
+  assert.equal(countOccurrences(dedupedLaunchCommand, APPROVAL_BYPASS_FLAG), 1);
+  assert.equal(countOccurrences(dedupedLaunchCommand, HOOK_TRUST_BYPASS_FLAG), 1);
 
   const resumeCommand = agentConfig.buildAgentResumeCommand('codex', 'codex', 'resume-session-id');
   assert.equal(
     resumeCommand,
-    `codex ${BYPASS_FLAG} resume 'resume-session-id'`,
+    `codex ${BYPASS_FLAGS} resume 'resume-session-id'`,
   );
 
   const dedupedResumeCommand = agentConfig.buildAgentResumeCommand(
     'codex',
-    `codex ${BYPASS_FLAG}`,
+    `codex ${BYPASS_FLAGS}`,
     'resume-session-id',
   );
   assert.ok(dedupedResumeCommand);
-  assert.equal(countOccurrences(dedupedResumeCommand, BYPASS_FLAG), 1);
+  assert.equal(countOccurrences(dedupedResumeCommand, APPROVAL_BYPASS_FLAG), 1);
+  assert.equal(countOccurrences(dedupedResumeCommand, HOOK_TRUST_BYPASS_FLAG), 1);
 
   assert.equal(
     agentConfig.buildAgentLaunchCommand('codex', 'codex', undefined, undefined, { copilotMode: 'plan' }),
@@ -218,7 +222,7 @@ async function main(): Promise<void> {
     "codex --sandbox read-only --ask-for-approval never resume -C '/workspace' 'resume-session-id'",
   );
   assert.throws(
-    () => agentConfig.buildAgentLaunchCommand('codex', `codex ${BYPASS_FLAG}`, undefined, undefined, { copilotMode: 'plan' }),
+    () => agentConfig.buildAgentLaunchCommand('codex', `codex ${APPROVAL_BYPASS_FLAG}`, undefined, undefined, { copilotMode: 'plan' }),
     /Plan copilot mode cannot use unsafe agent flag/,
   );
 
@@ -243,7 +247,7 @@ async function main(): Promise<void> {
 
     assert.equal(
       backend.sendKeysCalls[0]?.keys,
-      `${smokeCodexCommand} ${BYPASS_FLAG}`,
+      `${smokeCodexCommand} ${BYPASS_FLAGS}`,
     );
     assert.equal(
       backend.sendMessageCalls.some(call => call.sessionName === 'copilot-fresh' && call.message === '/status'),
@@ -286,7 +290,7 @@ async function main(): Promise<void> {
 
     assert.equal(
       command,
-      `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${copilotRestoredWorkdir}' '22222222-2222-4222-8222-222222222222'`,
+      `${smokeCodexCommand} ${BYPASS_FLAGS} resume -C '${copilotRestoredWorkdir}' '22222222-2222-4222-8222-222222222222'`,
     );
     assert.ok(
       backend.capturePaneCalls.some(call => call.sessionName === 'copilot-restored'),
@@ -375,7 +379,7 @@ async function main(): Promise<void> {
     const command = lastSendKeysFor(backend, 'worker-start');
     assert.equal(
       command,
-      `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${workerWorkdir}' '33333333-3333-4333-8333-333333333333'`,
+      `${smokeCodexCommand} ${BYPASS_FLAGS} resume -C '${workerWorkdir}' '33333333-3333-4333-8333-333333333333'`,
     );
     assert.ok(
       backend.capturePaneCalls.some(call => call.sessionName === 'worker-start'),
@@ -438,7 +442,7 @@ async function main(): Promise<void> {
       const command = lastSendKeysFor(backend, 'worker-restored');
       assert.equal(
         command,
-        `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${restoredWorktree}' '44444444-4444-4444-8444-444444444444'`,
+        `${smokeCodexCommand} ${BYPASS_FLAGS} resume -C '${restoredWorktree}' '44444444-4444-4444-8444-444444444444'`,
       );
       assert.equal(result.workerInfo.sessionName, 'worker-restored');
       assert.equal(result.workerInfo.sessionId, '44444444-4444-4444-8444-444444444444');
@@ -533,7 +537,7 @@ async function main(): Promise<void> {
       assert.equal(result.workerInfo.workdir, fooSlashBarWorktree);
       assert.equal(
         lastSendKeysFor(backend, 'repo-ns_foo-bar-2'),
-        `${smokeCodexCommand} ${BYPASS_FLAG} resume -C '${fooSlashBarWorktree}' 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'`,
+        `${smokeCodexCommand} ${BYPASS_FLAGS} resume -C '${fooSlashBarWorktree}' 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'`,
       );
       assert.ok(
         backend.sendMessageCalls.some(call =>
@@ -629,7 +633,7 @@ async function main(): Promise<void> {
       assert.equal(result.workerInfo.workdir, currentWorktree);
       assert.ok(
         backend.sendKeysCalls.some(call =>
-          call.sessionName === 'repo-ns_foo-bar' && call.keys === `${smokeCodexCommand} ${BYPASS_FLAG}`
+          call.sessionName === 'repo-ns_foo-bar' && call.keys === `${smokeCodexCommand} ${BYPASS_FLAGS}`
         ),
       );
       assert.equal(

--- a/src/smoke/completionHookSmoke.ts
+++ b/src/smoke/completionHookSmoke.ts
@@ -40,6 +40,46 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
+class PromptBackend {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'tmux';
+  readonly installHint = '';
+  readonly sentKeys: string[] = [];
+  private captureIndex = 0;
+
+  constructor(private readonly captures: string[]) {}
+
+  async isInstalled(): Promise<boolean> { return true; }
+  async listSessions(): Promise<unknown[]> { return []; }
+  async createSession(): Promise<void> {}
+  async killSession(): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async hasSession(): Promise<boolean> { return true; }
+  async getSessionWorkdir(): Promise<string | undefined> { return undefined; }
+  async setSessionWorkdir(): Promise<void> {}
+  async getSessionRole(): Promise<undefined> { return undefined; }
+  async setSessionRole(): Promise<void> {}
+  async getSessionAgent(): Promise<string | undefined> { return undefined; }
+  async setSessionAgent(): Promise<void> {}
+  async sendKeys(_sessionName: string, keys: string): Promise<void> {
+    this.sentKeys.push(keys);
+    this.captureIndex = Math.min(this.captureIndex + 1, this.captures.length - 1);
+  }
+  async capturePane(): Promise<string> {
+    return this.captures[Math.min(this.captureIndex, this.captures.length - 1)] || '';
+  }
+  async sendMessage(): Promise<void> {}
+  async getSessionInfo(): Promise<{ attached: boolean; lastActive: number }> {
+    return { attached: false, lastActive: 0 };
+  }
+  async getSessionPaneCount(): Promise<number> { return 1; }
+  async getSessionPanePids(): Promise<string[]> { return []; }
+  async splitPane(): Promise<void> {}
+  async newWindow(): Promise<void> {}
+  buildSessionName(repoName: string, slug: string): string { return `${repoName}_${slug}`; }
+  sanitizeSessionName(name: string): string { return name; }
+}
+
 async function main(): Promise<void> {
   // Redirect Hydra state to a temp directory so we don't pollute the real one
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-smoke-hook-'));
@@ -99,9 +139,9 @@ async function main(): Promise<void> {
     codexConfig.hooks.Stop[0].hooks[0].command.includes("printf '{}'"),
     'Codex hook should emit JSON on stdout',
   );
-  // Verify codex_hooks feature flag is enabled in config.toml
+  // Verify hooks feature flag is enabled in config.toml
   const codexToml = fs.readFileSync(path.join(fakeWorktree, '.codex', 'config.toml'), 'utf-8');
-  assert.ok(codexToml.includes('codex_hooks = true'), 'Codex config.toml should enable hooks feature flag');
+  assert.ok(codexToml.includes('hooks = true'), 'Codex config.toml should enable hooks feature flag');
 
   // Verify existing Codex [features] table is updated instead of duplicated
   const codexTomlPath = path.join(fakeWorktree, '.codex', 'config.toml');
@@ -110,7 +150,7 @@ async function main(): Promise<void> {
   const mergedCodexToml = fs.readFileSync(codexTomlPath, 'utf-8');
   assert.equal((mergedCodexToml.match(/^\[features\]$/gm) || []).length, 1);
   assert.ok(
-    mergedCodexToml.includes('[features]\ncodex_hooks = true\nexperimental = true\n\n[model]'),
+    mergedCodexToml.includes('[features]\nhooks = true\nexperimental = true\n\n[model]'),
     `Codex config.toml should merge into existing [features], got:\n${mergedCodexToml}`,
   );
 
@@ -142,12 +182,53 @@ async function main(): Promise<void> {
   assert.ok(scriptContent.includes('PENDING='), 'Script should have a per-message pending marker');
   assert.ok(scriptContent.includes('LOCKDIR='), 'Script should use a lock for duplicate hook entries');
 
+  const codexLaunch = sm['withCodexCompletionHookOverrides'](
+    'codex',
+    '/tmp/hydra-primary-repo',
+    '/tmp/hydra-worker-worktree',
+    scriptPath,
+  );
+  assert.ok(codexLaunch.includes('"/tmp/hydra-primary-repo"={trust_level="trusted"}'));
+  assert.ok(codexLaunch.includes('"/tmp/hydra-worker-worktree"={trust_level="trusted"}'));
+
   // Verify merge behavior: inject again and check Claude has 2 Stop entries
   sm['injectCompletionHook'](fakeWorktree, 'claude', hookInfo);
   const claudeConfig2 = JSON.parse(fs.readFileSync(path.join(fakeWorktree, '.claude', 'settings.json'), 'utf-8'));
   assert.equal(claudeConfig2.hooks.Stop.length, 2, 'Merge should append, not overwrite');
 
   console.log('  Part 1 (config injection): ok');
+
+  const codexPromptBackend = new PromptBackend([
+    [
+      'Do you trust the contents of this directory?',
+      '› 1. Yes, continue',
+      '  2. No, quit',
+    ].join('\n'),
+    [
+      'Hooks need review',
+      '› 1. Review hooks',
+      '  2. Trust all and continue',
+      "  3. Continue without trusting (hooks won't run)",
+    ].join('\n'),
+    '› ',
+  ]);
+  const codexPromptSm = new SessionManager(codexPromptBackend as never) as never as { waitForAgentReady: (sessionName: string, agentType: string) => Promise<void> };
+  await codexPromptSm.waitForAgentReady('codex-prompt-test', 'codex');
+  assert.deepEqual(codexPromptBackend.sentKeys, ['', 'Down']);
+
+  const geminiPromptBackend = new PromptBackend([
+    [
+      'Do you trust the files in this folder?',
+      '● 1. Trust folder',
+      "  2. Don't trust",
+    ].join('\n'),
+    '⏵',
+  ]);
+  const geminiPromptSm = new SessionManager(geminiPromptBackend as never) as never as { waitForAgentReady: (sessionName: string, agentType: string) => Promise<void> };
+  await geminiPromptSm.waitForAgentReady('gemini-prompt-test', 'gemini');
+  assert.deepEqual(geminiPromptBackend.sentKeys, ['']);
+
+  console.log('  Part 1b (trust prompt handling): ok');
 
   // ── Part 2: Run the notification script against real tmux ──
 


### PR DESCRIPTION
## Summary

Fix worker completion notifications for Codex and Gemini startup flows where newly added trust and hook-review prompts could prevent Hydra-injected hooks from loading or running.

## Root Cause

Codex 0.133 can stop on directory trust and hook review prompts before reaching the real input prompt. The previous readiness detection could match the picker glyph and send setup commands into the modal. Gemini can similarly stop on its folder trust prompt before loading project settings/hooks.

## Changes

- Add Codex hook trust bypass and Gemini trust skip flags in normal agent launch/resume flows.
- Handle Codex trust, Codex hook review, Codex resume cwd, and Gemini trust prompts before checking ready patterns.
- Trust both the primary repo and worker worktree when injecting Codex hook overrides.
- Update Codex hook feature config from `codex_hooks` to current `hooks`.
- Extend smoke coverage for prompt handling, Codex trust roots, and multi-flag deduping.

## Validation

- `npm run lint`
- `npm test`
- Manual E2E: real Claude copilot + Claude worker, worker completed and copilot received hook notification.
- Manual E2E: real Codex copilot + Codex worker, worker completed and copilot received hook notification.
