### PR TITLE
[codex] Refine planner copilot entry UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,15 +81,6 @@
       },
       {
         "view": "hydraCopilots",
-        "contents": "[Start Copilot](command:hydra.createCopilot)"
-      },
-      {
-        "view": "hydraCopilots",
-        "contents": "[Start Plan Copilot](command:hydra.startPlanCopilot)",
-        "when": "hydra.claudeAvailable || hydra.codexAvailable"
-      },
-      {
-        "view": "hydraCopilots",
         "contents": "[Start Copilot (Claude)](command:hydra.startCopilotClaude)",
         "when": "hydra.claudeAvailable"
       },
@@ -184,7 +175,7 @@
       },
       {
         "command": "hydra.startPlanCopilot",
-        "title": "Hydra: Start Plan Copilot"
+        "title": "Hydra: Start Planner"
       },
       {
         "command": "hydra.startCopilotClaude",

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -69,7 +69,7 @@ export function registerListCommand(program: Command): void {
                 : `[${c.status}]`;
               const attached = c.attached ? ' (attached)' : '';
               const name = c.displayName || c.sessionName || c.tmuxSession;
-              const modeLabel = c.copilotMode === 'plan' ? ' [plan]' : '';
+              const modeLabel = c.copilotMode === 'plan' ? ' [planner]' : '';
               console.log(`  ${statusIcon} ${name}  [${c.agent}]${modeLabel}${attached}`);
               if (c.workdir) console.log(`    workdir: ${c.workdir}`);
             }

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -31,7 +31,7 @@ Workers cannot create other workers directly. If a worker reports that more para
 
 Full reference: https://github.com/joezhoujinjing/hydra/blob/main/AGENTS.md`;
 
-const PLAN_ONBOARDING_PROMPT = `You are a Hydra plan copilot — an AI planner that analyzes tasks and produces implementation plans only.
+const PLAN_ONBOARDING_PROMPT = `You are a Hydra planner — a plan-only agent that analyzes tasks and produces implementation plans.
 
 ## Operating rules
 - Do not edit files, run implementation commands, create workers, commit, push, or open PRs.
@@ -40,7 +40,7 @@ const PLAN_ONBOARDING_PROMPT = `You are a Hydra plan copilot — an AI planner t
 - Produce a concrete implementation plan that another agent can execute.
 - Include affected files, ordered steps, risks, and verification commands.
 
-The user or a separate executor will handle implementation after the plan is approved.`;
+This planner cannot create Hydra workers. The user or a separate executor will handle implementation after the plan is approved.`;
 
 function getOnboardingPrompt(copilotMode: CopilotMode): string {
   return copilotMode === 'plan' ? PLAN_ONBOARDING_PROMPT : ONBOARDING_PROMPT;
@@ -63,49 +63,63 @@ function getDefaultSessionName(agentType: AgentType, copilotMode: CopilotMode): 
 
 function getCreatedMessage(sessionName: string, agentType: AgentType, copilotMode: CopilotMode): string {
   if (copilotMode === 'plan') {
-    const strategy = agentType === 'claude' ? 'native plan mode' : 'read-only plan mode';
-    return `Plan copilot created: ${sessionName} (${AGENT_LABELS[agentType]}, ${strategy})`;
+    const strategy = agentType === 'claude' ? 'native planner' : 'read-only planner';
+    return `Planner created: ${sessionName} (${AGENT_LABELS[agentType]}, ${strategy})`;
   }
   return `Copilot created: ${sessionName} (${agentType})`;
 }
 
-async function pickCopilotMode(): Promise<CopilotMode | undefined> {
+function agentSupportsPlanner(agentType: AgentType): boolean {
+  return agentType === 'claude' || agentType === 'codex';
+}
+
+async function pickModeForAgent(agentType: AgentType): Promise<CopilotMode | undefined> {
+  if (!agentSupportsPlanner(agentType)) {
+    return 'normal';
+  }
+
+  const plannerDescription = agentType === 'claude'
+    ? 'Native planner; cannot create workers'
+    : 'Read-only planner; cannot create workers';
   const picked = await vscode.window.showQuickPick([
     {
-      label: 'Normal Copilot',
-      description: 'Orchestrates workers and implementation',
+      label: 'Copilot',
+      description: 'Can create workers and drive implementation',
       value: 'normal' as CopilotMode,
     },
     {
-      label: 'Plan Copilot',
-      description: 'Produces implementation plans only',
+      label: 'Planner',
+      description: plannerDescription,
       value: 'plan' as CopilotMode,
     },
   ], {
-    placeHolder: 'Select copilot mode',
+    placeHolder: `Select ${AGENT_LABELS[agentType]} mode`,
   });
   return picked?.value;
 }
 
-async function pickPlanAgentType(): Promise<AgentType | undefined> {
+async function pickPlannerAgentType(): Promise<AgentType | undefined> {
   const items = [
-    { label: AGENT_LABELS.claude, description: 'Native plan mode', value: 'claude' as AgentType },
-    { label: AGENT_LABELS.codex, description: 'Read-only guarded plan mode', value: 'codex' as AgentType },
+    { label: AGENT_LABELS.claude, description: 'Native planner', value: 'claude' as AgentType },
+    { label: AGENT_LABELS.codex, description: 'Read-only guarded planner', value: 'codex' as AgentType },
   ];
 
   const picked = await vscode.window.showQuickPick(items, {
-    placeHolder: 'Select agent for plan copilot',
+    placeHolder: 'Select agent for planner',
   });
   return picked?.value;
 }
 
-export async function createCopilotWithAgent(agentType: AgentType, copilotMode: CopilotMode = 'normal'): Promise<void> {
+export async function createCopilotWithAgent(agentType: AgentType, copilotMode?: CopilotMode): Promise<void> {
   const backend = getActiveBackend();
   if (!await ensureBackendInstalled(backend)) {
     return;
   }
 
-  const sessionName = backend.sanitizeSessionName(getDefaultSessionName(agentType, copilotMode));
+  const resolvedMode = copilotMode ?? await pickModeForAgent(agentType);
+  if (!resolvedMode) return;
+
+  const sessionName = backend.sanitizeSessionName(getDefaultSessionName(agentType, resolvedMode));
 
   // If session already exists, just attach
   if (await backend.hasSession(sessionName)) {
@@ -119,15 +133,15 @@ export async function createCopilotWithAgent(agentType: AgentType, copilotMode: 
     const copilotInfo = await sm.createCopilotAndFinalize({
       workdir: os.homedir(),
       agentType,
-      copilotMode,
+      copilotMode: resolvedMode,
       sessionName,
       agentCommand: getAgentCommand(agentType),
     });
 
-    sendCopilotOnboarding(backend, copilotInfo.sessionName, copilotMode);
+    sendCopilotOnboarding(backend, copilotInfo.sessionName, resolvedMode);
     backend.attachSession(copilotInfo.sessionName, copilotInfo.workdir, undefined, 'copilot');
 
-    vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, copilotMode));
+    vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, resolvedMode));
     vscode.commands.executeCommand('tmux.refresh');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -136,7 +150,7 @@ export async function createCopilotWithAgent(agentType: AgentType, copilotMode: 
 }
 
 export async function createPlanCopilot(): Promise<void> {
-  const agentType = await pickPlanAgentType();
+  const agentType = await pickPlannerAgentType();
   if (!agentType) return;
   await createCopilotWithAgent(agentType, 'plan');
 }
@@ -147,14 +161,12 @@ export async function createCopilot(): Promise<void> {
     return;
   }
 
-  const copilotMode = await pickCopilotMode();
-  if (!copilotMode) return;
-
   // Pick agent type
-  const agentType = copilotMode === 'plan'
-    ? await pickPlanAgentType()
-    : await pickAgentType();
+  const agentType = await pickAgentType();
   if (!agentType) return;
+
+  const copilotMode = await pickModeForAgent(agentType);
+  if (!copilotMode) return;
 
   // Ask for session name (default: hydra-copilot-<agent>)
   const defaultName = getDefaultSessionName(agentType, copilotMode);

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -97,7 +97,7 @@ export function agentSupportsCopilotMode(agentType: string, copilotMode: Copilot
 
 export function getUnsupportedCopilotModeMessage(agentType: string, copilotMode: CopilotMode): string {
   if (copilotMode === 'plan') {
-    return `Plan copilot mode is currently supported for Claude and Codex only. Agent "${agentType}" is not supported.`;
+    return `Planner mode is currently supported for Claude and Codex only. Agent "${agentType}" is not supported.`;
   }
   return `Copilot mode "${copilotMode}" is not supported for agent "${agentType}".`;
 }
@@ -210,7 +210,7 @@ function assertPlanCommandIsSafe(agentBinary: string): void {
   const tokens = tokenizeCommand(agentBinary);
   const unsafe = PLAN_UNSAFE_FLAGS.find(flag => tokens.includes(flag));
   if (unsafe) {
-    throw new Error(`Plan copilot mode cannot use unsafe agent flag "${unsafe}". Remove it from the configured agent command.`);
+    throw new Error(`Planner mode cannot use unsafe agent flag "${unsafe}". Remove it from the configured agent command.`);
   }
 }
 

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -319,7 +319,7 @@ export class CopilotItem extends TmuxItem {
     const label = opts.displayName || opts.sessionName;
     const copilotMode = opts.copilotMode || 'normal';
     const description = copilotMode === 'plan'
-      ? `[${opts.agentType}] [plan]`
+      ? `[${opts.agentType}] [planner]`
       : `[${opts.agentType}]`;
     super(label, vscode.TreeItemCollapsibleState.Expanded, undefined, opts.sessionName);
 
@@ -471,7 +471,7 @@ export class TmuxDetailItem extends TmuxItem {
     }
 
     if (session.hydraRole === 'copilot' && session.hydraCopilotMode === 'plan') {
-      parts.push(session.hydraAgent === 'claude' ? 'Native Plan' : 'Read Only Plan');
+      parts.push(session.hydraAgent === 'claude' ? 'Native Planner' : 'Read-only Planner');
     }
 
     const label = parts.join(' · ');

--- a/src/smoke/codexBypassSmoke.ts
+++ b/src/smoke/codexBypassSmoke.ts
@@ -223,7 +223,7 @@ async function main(): Promise<void> {
   );
   assert.throws(
     () => agentConfig.buildAgentLaunchCommand('codex', `codex ${APPROVAL_BYPASS_FLAG}`, undefined, undefined, { copilotMode: 'plan' }),
-    /Plan copilot mode cannot use unsafe agent flag/,
+    /Planner mode cannot use unsafe agent flag/,
   );
 
   const smokeCodexCommand = 'codex-smoke-test';

--- a/src/smoke/sudocodeAgentSmoke.ts
+++ b/src/smoke/sudocodeAgentSmoke.ts
@@ -126,7 +126,7 @@ function testAgentConfig(): void {
   );
   assert.throws(
     () => buildAgentLaunchCommand('gemini', 'gemini', undefined, undefined, { copilotMode: 'plan' }),
-    /Plan copilot mode is currently supported for Claude and Codex only/,
+    /Planner mode is currently supported for Claude and Codex only/,
   );
   assert.equal(buildAgentResumeCommand('sudocode', 'scode', 'session-1-0'), null);
 


### PR DESCRIPTION
## Summary
- Keep the empty Copilots welcome view focused on the four agent-specific Start Copilot entries.
- Route Claude and Codex starts through a Copilot vs Planner mode picker, while Gemini and Sudo Code continue creating normal copilots directly.
- Rename user-facing plan-mode copy to Planner and keep the internal `plan` mode / CLI flags compatible.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- Verified `viewsWelcome` has exactly the four agent command links.
- Launched an isolated VS Code Extension Development Host and verified isolated normal-mode Gemini/Sudo Code copilot sessions stayed `mode: "normal"`.
