### PR TITLE
chore: release v0.3.2026052600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.2026052600] - 2026-05-26
+
+### Changed
+- Improve planner copilot entry UX with clearer create/start behavior and sidebar presentation
+- Replace the Activity Bar icon with a simplified abstract Hydra glyph optimized for small VS Code sidebar rendering
+
+### Fixed
+- Keep worker and copilot sidebar selection highlighted when switching terminal tabs, including workers inside collapsed repo groups
+- Fix agent completion hook startup prompts
+
 ## [0.3.2026052500] - 2026-05-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052500",
+  "version": "0.3.2026052600",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052500",
+      "version": "0.3.2026052600",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052500",
+  "version": "0.3.2026052600",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026052600.

## Summary

- Bump package and lockfile versions to `0.3.2026052600`
- Add changelog notes for the merged sidebar fixes, completion hook prompt fix, planner entry UX refinement, and Activity Bar icon update

## Validation

- `npm run compile`
- `npm run lint`
