### PR TITLE
fix(copilot): persist and resume copilot across tmux restarts

### DIFF
--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -6,6 +6,7 @@ import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/session
 import { SessionManager } from '../core/sessionManager';
 import { TmuxBackendCore } from '../core/tmux';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
+import { sendCopilotOnboarding } from './createCopilot';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
@@ -50,7 +51,10 @@ async function handleTreeViewItem(item: TmuxItem): Promise<void> {
         const sm = new SessionManager(new TmuxBackendCore());
         const result = await sm.startCopilot(sessionName);
         result.postCreatePromise.catch(() => {});
-        const workdir = result.copilotInfo.workdir;
+        const { workdir, copilotMode } = result.copilotInfo;
+        if (!result.resumed) {
+            sendCopilotOnboarding(backend, sessionName, copilotMode ?? 'normal');
+        }
         backend.attachSession(sessionName, workdir, undefined, 'copilot');
         vscode.window.showInformationMessage(`Resumed copilot: ${sessionName}`);
         vscode.commands.executeCommand('tmux.refresh');

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getRepoRoot } from '../utils/git';
 import { getActiveBackend } from '../utils/multiplexer';
-import { InactiveWorktreeItem, InactiveDetailItem, TmuxItem } from '../providers/tmuxSessionProvider';
+import { InactiveWorktreeItem, InactiveDetailItem, CopilotItem, TmuxItem } from '../providers/tmuxSessionProvider';
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
 import { SessionManager } from '../core/sessionManager';
 import { TmuxBackendCore } from '../core/tmux';
@@ -42,6 +42,18 @@ async function handleTreeViewItem(item: TmuxItem): Promise<void> {
         const workdir = await backend.getSessionWorkdir(sessionName);
         const role = await backend.getSessionRole(sessionName);
         backend.attachSession(sessionName, workdir, undefined, role);
+        return;
+    }
+
+    // Stopped copilot: resume via SessionManager
+    if (item instanceof CopilotItem && item.classification === 'stopped') {
+        const sm = new SessionManager(new TmuxBackendCore());
+        const result = await sm.startCopilot(sessionName);
+        result.postCreatePromise.catch(() => {});
+        const workdir = result.copilotInfo.workdir;
+        backend.attachSession(sessionName, workdir, undefined, 'copilot');
+        vscode.window.showInformationMessage(`Resumed copilot: ${sessionName}`);
+        vscode.commands.executeCommand('tmux.refresh');
         return;
     }
 

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -46,7 +46,7 @@ function getOnboardingPrompt(copilotMode: CopilotMode): string {
   return copilotMode === 'plan' ? PLAN_ONBOARDING_PROMPT : ONBOARDING_PROMPT;
 }
 
-function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string, copilotMode: CopilotMode): void {
+export function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string, copilotMode: CopilotMode): void {
   (async () => {
     try {
       await new Promise(resolve => setTimeout(resolve, 8000));

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -220,6 +220,8 @@ export interface CreateCopilotResult {
   copilotInfo: CopilotInfo;
   /** Resolves after the agent is ready and any deferred session ID capture has completed. */
   postCreatePromise: Promise<void>;
+  /** True when the agent was resumed from a stored sessionId; false on fresh start. */
+  resumed: boolean;
 }
 
 // Non-enumerable sentinel used by sync() to tell updateSessionState whether the
@@ -308,7 +310,7 @@ export class SessionManager {
       }
 
       // Reconcile copilots
-      for (const [key, copilot] of Object.entries(state.copilots)) {
+      for (const copilot of Object.values(state.copilots)) {
         const live = liveSessionMap.get(copilot.sessionName);
         if (live) {
           if (copilot.status !== 'running') { copilot.status = 'running'; dirty = true; }
@@ -851,6 +853,7 @@ export class SessionManager {
     return {
       copilotInfo,
       postCreatePromise: this.withPostCreateTimeout(postCreatePromise, sessionName, 'copilot startup'),
+      resumed: canResume,
     };
   }
 
@@ -939,7 +942,7 @@ export class SessionManager {
       'copilot startup',
     );
 
-    return { copilotInfo: persistedCopilotInfo, postCreatePromise };
+    return { copilotInfo: persistedCopilotInfo, postCreatePromise, resumed: isResume };
   }
 
   async createCopilotAndFinalize(opts: CreateCopilotOpts): Promise<CopilotInfo> {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -784,6 +784,76 @@ export class SessionManager {
     };
   }
 
+  async startCopilot(sessionName: string): Promise<CreateCopilotResult> {
+    const existingCopilot = this.readSessionState().copilots[sessionName];
+    if (!existingCopilot) {
+      throw new Error(`Copilot "${sessionName}" not found in sessions.json`);
+    }
+
+    const agent = existingCopilot.agent || 'claude';
+    const copilotMode = normalizeCopilotMode(existingCopilot.copilotMode);
+    const agentOptions: AgentCommandOptions = { copilotMode };
+    const command = await this.resolveAgentCommand(this.getDefaultAgentCommand(agent));
+
+    await this.backend.createSession(sessionName, existingCopilot.workdir);
+    await this.backend.setSessionWorkdir(sessionName, existingCopilot.workdir);
+    await this.backend.setSessionRole(sessionName, 'copilot');
+    await this.backend.setSessionAgent(sessionName, agent);
+
+    const storedSessionId = existingCopilot.sessionId;
+    const resolvedResumeSessionFile = storedSessionId
+      ? resolveAgentSessionFile(agent, existingCopilot.workdir, storedSessionId, existingCopilot.agentSessionFile)
+      : null;
+    const canResume = !!storedSessionId &&
+      (agent !== 'sudocode' || !!resolvedResumeSessionFile) &&
+      !!buildAgentResumePlan(agent, command, storedSessionId, existingCopilot.workdir, resolvedResumeSessionFile);
+
+    let copilotInfo: CopilotInfo;
+    let postCreatePromise: Promise<void>;
+
+    if (canResume && storedSessionId) {
+      await this.launchAgentResume(
+        sessionName, agent, command, storedSessionId,
+        existingCopilot.workdir, resolvedResumeSessionFile, agentOptions,
+      );
+      copilotInfo = await this.updateSessionState((currentState) => {
+        const current = currentState.copilots[sessionName];
+        if (!current) throw new Error(`Copilot "${sessionName}" not found in sessions.json`);
+        current.status = 'running';
+        current.attached = false;
+        current.agentSessionFile = resolvedResumeSessionFile ?? existingCopilot.agentSessionFile ?? current.agentSessionFile ?? null;
+        current.lastSeenAt = new Date().toISOString();
+        currentState.updatedAt = current.lastSeenAt;
+        return { ...current };
+      });
+      postCreatePromise = this.waitForAgentReady(sessionName, agent);
+    } else {
+      const preAssignedSessionId = agent === 'claude' ? randomUUID() : null;
+      const launchCmd = buildAgentLaunchCommand(agent, command, undefined, preAssignedSessionId ?? undefined, agentOptions);
+      const launchStartedAt = Date.now();
+      await this.backend.sendKeys(sessionName, launchCmd);
+      copilotInfo = await this.updateSessionState((currentState) => {
+        const current = currentState.copilots[sessionName];
+        if (!current) throw new Error(`Copilot "${sessionName}" not found in sessions.json`);
+        current.status = 'running';
+        current.attached = false;
+        current.sessionId = preAssignedSessionId;
+        current.agentSessionFile = null;
+        current.lastSeenAt = new Date().toISOString();
+        currentState.updatedAt = current.lastSeenAt;
+        return { ...current };
+      });
+      postCreatePromise = this.waitForReadyAndCaptureSessionId(
+        sessionName, agent, preAssignedSessionId, existingCopilot.workdir, launchStartedAt,
+      );
+    }
+
+    return {
+      copilotInfo,
+      postCreatePromise: this.withPostCreateTimeout(postCreatePromise, sessionName, 'copilot startup'),
+    };
+  }
+
   // ── Copilot Lifecycle ──
 
   async createCopilot(opts: CreateCopilotOpts): Promise<CreateCopilotResult> {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -314,8 +314,11 @@ export class SessionManager {
           if (copilot.status !== 'running') { copilot.status = 'running'; dirty = true; }
           if (copilot.attached !== live.attached) { copilot.attached = live.attached; dirty = true; }
         } else {
-          delete state.copilots[key];
-          dirty = true;
+          if (copilot.status !== 'stopped' || copilot.attached !== false) {
+            copilot.status = 'stopped';
+            copilot.attached = false;
+            dirty = true;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- **Persist on reboot**: When `sync()` finds a copilot's tmux session gone, mark it `stopped` instead of deleting it from `sessions.json`. The copilot now only leaves state when explicitly deleted via `deleteCopilot()`.
- **Resume on click**: Add `SessionManager.startCopilot()` (mirrors `startWorker()`) — recreates the tmux session and resumes from the stored `sessionId` if available, otherwise fresh-starts. The `attachCreate` handler now calls this when a stopped `CopilotItem` is clicked instead of showing an error.

## Test plan

- [ ] Create a copilot, verify it appears in sidebar
- [ ] Kill the tmux session manually (`tmux kill-session -t <name>`)
- [ ] Trigger a sync — confirm copilot shows as stopped (grey outline) instead of disappearing
- [ ] Click the stopped copilot — confirm it resumes and attaches
- [ ] Reboot machine, reopen VS Code — confirm copilot persists as stopped and can be resumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)