### PR TITLE
chore: release v0.3.2026052700

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,27 @@ jobs:
         run: npx @vscode/vsce package --out "hydra-${{ steps.version.outputs.version }}.vsix"
 
       - name: Publish to VS Code Marketplace
-        run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            echo "Publishing to VS Code Marketplace (attempt ${attempt}/5)..."
+            if npx @vscode/vsce publish \
+              --packagePath "hydra-${{ steps.version.outputs.version }}.vsix" \
+              --skip-duplicate \
+              -p "$VSCE_PAT"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 5 ]; then
+              echo "VS Code Marketplace publish failed after ${attempt} attempts."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 60))
+            echo "Publish failed; retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+          done
         continue-on-error: false
 
       - name: Publish to Open VSX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026052700] - 2026-05-27
+
+### Fixed
+- Persist and resume copilot sessions across tmux restarts
+
 ## [0.3.2026052600] - 2026-05-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052600",
+  "version": "0.3.2026052700",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052600",
+      "version": "0.3.2026052700",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052600",
+  "version": "0.3.2026052700",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026052700.

## Summary

- Bump package and lockfile versions to `0.3.2026052700`
- Add changelog notes for copilot persistence across tmux restarts
- Harden the publish workflow by publishing the already packaged VSIX to Marketplace with retry/backoff and duplicate-version tolerance

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'yaml ok'"`
- `npm run compile`
- `npm run lint`
- `npx @vscode/vsce package --out /tmp/hydra-0.3.2026052700.vsix`
