### PR TITLE
fix(sidebar): refresh data before reveal on terminal tab switch

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,7 +180,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const intervalId = setInterval(() => {
       refreshAll();
-  }, 30000);
+  }, 60000);
 
   context.subscriptions.push({
       dispose: () => clearInterval(intervalId)
@@ -234,7 +234,7 @@ async function revealSidebarItem(
   const name = terminal.name;
 
   if (name.startsWith(HYDRA_PREFIX_COPILOT)) {
-    const items = copilotProvider.getCopilotItems();
+    const items = await copilotProvider.refreshAndGetCopilotItems();
     const found = items.find(item => {
       if (!item.sessionName) return false;
       const shortName = getShortName(item.sessionName);
@@ -247,7 +247,7 @@ async function revealSidebarItem(
   }
 
   if (name.startsWith(HYDRA_PREFIX_WORKER)) {
-    const items = await workerProvider.getWorkerItems();
+    const items = await workerProvider.refreshAndGetWorkerItems();
     const found = items.find(item => {
       if (!item.sessionName) return false;
       const shortName = getShortName(item.sessionName);

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -356,6 +356,7 @@ export class RepoGroupItem extends TmuxItem {
     baseBranch?: string
   ) {
     super(repoName, vscode.TreeItemCollapsibleState.Expanded, repoName);
+    this.id = repoRoot;
     this.contextValue = 'repoGroup';
     this.iconPath = new vscode.ThemeIcon('repo');
     if (baseBranch) {
@@ -715,6 +716,12 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
 
   getCopilotItems(): CopilotItem[] { return this._copilotItems; }
 
+  async refreshAndGetCopilotItems(): Promise<CopilotItem[]> {
+    await this.getChildren(undefined);
+    this._onDidChangeTreeData.fire(undefined);
+    return this._copilotItems;
+  }
+
   async getChildren(element?: TmuxItem): Promise<TmuxItem[]> {
     if (!element) return this.getRootItems();
     if (element instanceof CopilotItem) return this.getCopilotDetailItems(element);
@@ -811,6 +818,15 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
     }
     return undefined;
+  }
+
+  async refreshAndGetWorkerItems(): Promise<TmuxItem[]> {
+    const groups = await this.getChildren(undefined);
+    await Promise.all(groups.map(g => this.getChildren(g)));
+    this._onDidChangeTreeData.fire(undefined);
+    const all: TmuxItem[] = [];
+    for (const items of this._workerItemsByRepo.values()) all.push(...items);
+    return all;
   }
 
   async getWorkerItems(): Promise<TmuxItem[]> {


### PR DESCRIPTION
## Summary

- 降低轮询频率 30s → 60s：CPU/git-dirty 等状态信息低优先级，session 文件 watcher 已覆盖结构性变更
- 切换 terminal tab 时强制刷新 provider 缓存再做 reveal，解决新建 worker 后高亮不跟的问题
- 给 `RepoGroupItem` 加稳定 `id`，VS Code reveal 时用 id 匹配父节点，不再依赖对象引用

## Test plan

- [ ] 新建 worker，切换到该 terminal tab，sidebar 应立即高亮对应条目
- [ ] 在多个已有 worker tab 间切换，sidebar 高亮应实时跟随
- [ ] copilot tab 切换，copilot sidebar 同样高亮正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)