### PR TITLE
chore: update repo references to sudoprivacy/hydra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         # Clone the repo with core.symlinks=false to simulate typical Windows behavior
         # (GitHub Actions runners have Developer Mode enabled, so we must force this)
         $cloneDir = "$env:RUNNER_TEMP\hydra-clone"
-        git clone -c core.symlinks=false https://github.com/joezhoujinjing/hydra.git $cloneDir
+        git clone -c core.symlinks=false https://github.com/sudoprivacy/hydra.git $cloneDir
 
         # Show what git created for the symlink files (should be regular text files)
         Write-Host "=== Before fix: .codex/skills is a file containing target path ==="

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@ points fall out of that:
   user happens to have on `main`. If they forgot to fetch, workers branch
   off stale code.
 - **Ergonomics.** Telling an AI agent "create a worker on
-  `joezhoujinjing/hydra`" requires it to know exactly where the user
+  `sudoprivacy/hydra`" requires it to know exactly where the user
   cloned the repo on disk. There's no canonical name.
 
 ## Model
@@ -43,7 +43,7 @@ Three input forms are accepted:
 
 | Input form | Behavior |
 | --- | --- |
-| `joezhoujinjing/hydra` | **Recommended.** Resolves to `~/.hydra/repos/joezhoujinjing/hydra/`. Errors with "Run: hydra repo add ..." if not registered. |
+| `sudoprivacy/hydra` | **Recommended.** Resolves to `~/.hydra/repos/sudoprivacy/hydra/`. Errors with "Run: hydra repo add ..." if not registered. |
 | `/Users/me/code/hydra`, `.`, `./foo`, `../foo`, `~/foo` | **Backward-compat.** Used as-is. Existing workflows keep working — `hydra worker create --repo . --branch foo` from a clone is still the natural path-based form. |
 | `https://github.com/...` | Rejected with a hint to run `hydra repo add <url>` first. |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <img src="https://vsmarketplacebadges.dev/installs/zhoujinjing.hydra-code.svg" alt="Installs" />
   </a>
   <a href="LICENSE.md">
-    <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />
+    <img src="https://img.shields.io/github/license/sudoprivacy/hydra" alt="License" />
   </a>
 </p>
 
@@ -117,8 +117,8 @@ hoping you remembered to pull `main` before spawning a worker? Register
 it once, then refer to it by its `<owner>/<name>`:
 
 ```bash
-hydra repo add joezhoujinjing/hydra
-hydra worker create --repo joezhoujinjing/hydra --branch feat/foo
+hydra repo add sudoprivacy/hydra
+hydra worker create --repo sudoprivacy/hydra --branch feat/foo
 ```
 
 Hydra clones the repo into `~/.hydra/repos/<owner>/<name>/` and treats
@@ -138,7 +138,7 @@ remote — no more "I forgot to pull" drift.
 ### Commands
 
 ```bash
-hydra repo add <identifier>     # joezhoujinjing/hydra | https://github.com/... | git@github.com:...
+hydra repo add <identifier>     # sudoprivacy/hydra | https://github.com/... | git@github.com:...
 hydra repo list                 # show registered repos and last-fetched time
 hydra repo fetch <owner/name>   # git fetch origin in the managed clone
 hydra repo fetch --all          # refresh every registered repo

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -17,7 +17,7 @@
     <img src="https://vsmarketplacebadges.dev/installs/zhoujinjing.hydra-code.svg" alt="Installs" />
   </a>
   <a href="../LICENSE.md">
-    <img src="https://img.shields.io/github/license/joezhoujinjing/hydra" alt="License" />
+    <img src="https://img.shields.io/github/license/sudoprivacy/hydra" alt="License" />
   </a>
 </p>
 

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "theme": "dark"
   },
   "badges": [],
-  "homepage": "https://github.com/joezhoujinjing/hydra",
+  "homepage": "https://github.com/sudoprivacy/hydra",
   "bugs": {
-    "url": "https://github.com/joezhoujinjing/hydra/issues"
+    "url": "https://github.com/sudoprivacy/hydra/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/joezhoujinjing/hydra.git"
+    "url": "https://github.com/sudoprivacy/hydra.git"
   },
   "main": "./out/extension.js",
   "bin": {

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -29,7 +29,7 @@ Before anything else, run \`hydra --version\`. If the command is not found, the 
 
 Workers cannot create other workers directly. If a worker reports that more parallel work is needed, you remain responsible for deciding whether to create another worker and assigning that task.
 
-Full reference: https://github.com/joezhoujinjing/hydra/blob/main/AGENTS.md`;
+Full reference: https://github.com/sudoprivacy/hydra/blob/main/AGENTS.md`;
 
 const PLAN_ONBOARDING_PROMPT = `You are a Hydra planner — a plan-only agent that analyzes tasks and produces implementation plans.
 

--- a/src/core/repoRegistry.ts
+++ b/src/core/repoRegistry.ts
@@ -160,7 +160,7 @@ export function resolveRepoIdentifier(input: string): string {
  * Everything else is treated as a registry identifier (short form / URL).
  *
  * This rule is what makes the legacy `hydra worker create --repo . --branch foo`
- * flow keep working alongside the new short-form `--repo joezhoujinjing/hydra`.
+ * flow keep working alongside the new short-form `--repo sudoprivacy/hydra`.
  */
 export function looksLikePathInput(input: string): boolean {
   const trimmed = (input ?? '').trim();

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -26,7 +26,7 @@ const DEFAULT_TIMEOUT_MS = 500;
 // past this window; the bounded race below races the backend against an
 // unref'd timer, so process exit is not blocked even if the network stalls.
 const FLUSH_TIMEOUT_MS = 1500;
-const TELEMETRY_README_URL = 'https://github.com/joezhoujinjing/hydra#telemetry';
+const TELEMETRY_README_URL = 'https://github.com/sudoprivacy/hydra#telemetry';
 
 const FIRST_RUN_NOTICE =
   'Hydra collects anonymous usage stats to improve the tool. ' +


### PR DESCRIPTION
## Summary

- Repo 已从 `joezhoujinjing/hydra` 迁移至 `sudoprivacy/hydra`
- 更新 8 个文件中的所有引用（package.json、README、docs、CI、源码注释）
- 未改动 `src/smoke/repoRegistrySmoke.ts`（测试数据，不涉及真实路径）

🤖 Generated with [Claude Code](https://claude.com/claude-code)