### PR TITLE
[codex] Fix sidebar refresh after worker creation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
 import { attachCreate } from './commands/attachCreate';
@@ -27,6 +28,7 @@ import { getHydraSessionsFile } from './core/path';
 import { HydraSessionKind, hasHydraItemIdentity, listHydraSessionChoices } from './commands/treeItemResolver';
 
 const SESSION_REFRESH_DEBOUNCE_MS = 200;
+const SESSION_REFRESH_POLL_INTERVAL_MS = 1000;
 const RECENT_TREE_SELECTION_MS = 1000;
 const TREE_SELECTION_SETTLE_MS = 75;
 
@@ -193,8 +195,10 @@ function registerSessionFileRefreshWatcher(context: vscode.ExtensionContext, ref
     new vscode.RelativePattern(path.dirname(sessionsFile), path.basename(sessionsFile)),
   );
   let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+  let lastSessionsFileSignature = getFileSignature(sessionsFile);
 
   const scheduleRefresh = () => {
+    lastSessionsFileSignature = getFileSignature(sessionsFile);
     if (refreshTimer) {
       clearTimeout(refreshTimer);
     }
@@ -203,6 +207,17 @@ function registerSessionFileRefreshWatcher(context: vscode.ExtensionContext, ref
       refreshAll();
     }, SESSION_REFRESH_DEBOUNCE_MS);
   };
+
+  fs.watchFile(sessionsFile, { interval: SESSION_REFRESH_POLL_INTERVAL_MS }, (current, previous) => {
+    if (current.mtimeMs === previous.mtimeMs && current.size === previous.size) {
+      return;
+    }
+    const currentSignature = getFileStatSignature(current);
+    if (currentSignature === lastSessionsFileSignature) {
+      return;
+    }
+    scheduleRefresh();
+  });
 
   context.subscriptions.push(
     watcher,
@@ -214,9 +229,25 @@ function registerSessionFileRefreshWatcher(context: vscode.ExtensionContext, ref
         if (refreshTimer) {
           clearTimeout(refreshTimer);
         }
+        fs.unwatchFile(sessionsFile);
       },
     },
   );
+}
+
+function getFileSignature(filePath: string): string {
+  try {
+    return getFileStatSignature(fs.statSync(filePath));
+  } catch {
+    return 'missing';
+  }
+}
+
+function getFileStatSignature(stat: fs.Stats): string {
+  if (stat.mtimeMs === 0 && stat.size === 0) {
+    return 'missing';
+  }
+  return `${stat.mtimeMs}:${stat.size}`;
 }
 
 function getShortName(sessionName: string): string {

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -791,7 +791,10 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
   private _workerItemsByRepo = new Map<string, TmuxItem[]>();
 
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
-  refresh(): void { this._onDidChangeTreeData.fire(undefined); }
+  refresh(): void {
+    this._workerItemsByRepo.clear();
+    this._onDidChangeTreeData.fire(undefined);
+  }
   getTreeItem(element: TmuxItem): vscode.TreeItem { return element; }
   getParent(element: TmuxItem): TmuxItem | undefined {
     if (element instanceof RepoGroupItem) return undefined;


### PR DESCRIPTION
## Summary
- Add an fs.watchFile fallback for ~/.hydra/sessions.json so external CLI writes refresh the sidebar even when VS Code file watcher misses an atomic rename.
- Clear cached worker children when the Workers tree refreshes so refreshed repo groups do not reuse stale worker rows.

## Root cause
Hydra CLI worker creation writes sessions.json outside the VS Code extension process. The sidebar previously depended on VS Code FileSystemWatcher plus a 30s poll; when the watcher missed an external atomic write, newly created workers could remain invisible until a later fallback refresh.

## Validation
- npm run compile
- npm run lint
- npm run e2e:isolated -- --cleanup -- hydra list --json
- npm run smoke:telemetry-e2e
- Targeted sidebar refresh e2e: mocked the VS Code extension host, disabled FileSystemWatcher callbacks, atomically rewrote sessions.json, and verified both tree providers refreshed via fs.watchFile.
- Launched an isolated VS Code Extension Development Host, created a worker through the isolated hydra CLI, and confirmed hydra list plus sessions.json reflected the new worker.

Fixes https://github.com/sudoprivacy/hydra/issues/190
