### PR TITLE
[codex] clarify missing tmux prompt

### DIFF
--- a/src/commands/ensureBackendInstalled.ts
+++ b/src/commands/ensureBackendInstalled.ts
@@ -5,6 +5,7 @@ const INSTALL_PSMUX_ACTION = 'Install psmux';
 const COPY_COMMAND_ACTION = 'Copy command';
 
 const PSMUX_INSTALL_COMMAND = 'winget install psmux --accept-source-agreements --accept-package-agreements';
+const TMUX_INSTALL_COMMAND = 'brew install tmux';
 
 function showPsmuxInstallTerminal(): void {
   const terminal = vscode.window.createTerminal({ name: 'Hydra Setup: psmux' });
@@ -34,6 +35,18 @@ async function promptForPsmuxInstall(): Promise<void> {
   }
 }
 
+async function promptForTmuxInstall(backend: MultiplexerBackend): Promise<void> {
+  const choice = await vscode.window.showErrorMessage(
+    `${backend.displayName} is required but not installed. Run: ${TMUX_INSTALL_COMMAND}`,
+    COPY_COMMAND_ACTION,
+  );
+
+  if (choice === COPY_COMMAND_ACTION) {
+    await vscode.env.clipboard.writeText(TMUX_INSTALL_COMMAND);
+    void vscode.window.showInformationMessage('Copied tmux install command to clipboard.');
+  }
+}
+
 export async function ensureBackendInstalled(backend: MultiplexerBackend): Promise<boolean> {
   if (await backend.isInstalled()) {
     return true;
@@ -44,6 +57,6 @@ export async function ensureBackendInstalled(backend: MultiplexerBackend): Promi
     return false;
   }
 
-  vscode.window.showErrorMessage(`${backend.displayName} not found. ${backend.installHint}`);
+  await promptForTmuxInstall(backend);
   return false;
 }


### PR DESCRIPTION
## Summary
- Show a clear tmux-required error when Hydra cannot find tmux on macOS/Linux.
- Add a Copy command action that copies `brew install tmux` to the clipboard.
- Keep the existing Windows psmux install prompt unchanged.

## Root Cause
When tmux was missing, the UI only surfaced a generic "not found" message. Users clicking a copilot entry did not get a direct install command, which made the failure look silent unless they checked logs.

## Validation
- `npm run compile`
- `npm run lint`
- `npm test`
- `npm run e2e:isolated`
- isolated CLI e2e: create/list/delete custom copilot
- mocked VS Code API harness for missing-tmux prompt and Copy command behavior

Fixes #188
