### PR TITLE
chore: release v0.3.2026052800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.2026052800] - 2026-05-28
+
+### Added
+- Add configurable default agent support across CLI config, copilot/worker creation, global config, docs, and smoke coverage
+
+### Changed
+- Update repository references from `joezhoujinjing/hydra` to `sudoprivacy/hydra`
+
+### Fixed
+- Refresh the sidebar promptly after external worker creation updates session state
+- Detect copilot identity from process environment for CLI commands running inside copilot sessions
+- Clarify the missing tmux install prompt on macOS and Linux
+
 ## [0.3.2026052700] - 2026-05-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052700",
+  "version": "0.3.2026052800",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052700",
+      "version": "0.3.2026052800",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052700",
+  "version": "0.3.2026052800",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026052800

## Included changes
- Added configurable default agent support across CLI, global config, docs, and smoke coverage.
- Updated repository references to `sudoprivacy/hydra`.
- Fixed sidebar refresh after external worker creation, copilot detection from process env, and the missing tmux prompt.

## Validation
- npm run compile
- npm run lint
- git diff --check
