### PR TITLE
[codex] Add task worker support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Hydra — Agent Operating Manual
 
-Hydra is a VS Code extension that lets an AI agent orchestrate parallel workers. Each worker is a git worktree + tmux session + AI agent. You manage them through the `hydra` CLI.
+Hydra is a VS Code extension that lets an AI agent orchestrate parallel workers. A worker is a tmux session + AI agent running in a workdir; code workers add a git worktree and branch, while task workers use a plain folder. You manage them through the `hydra` CLI.
 
 Guidelines for AI agents and developers working on this project.
 
@@ -36,13 +36,15 @@ To test the extension in a VS Code Extension Development Host, use the `/test-hy
 
 ## Key Patterns
 
-- **Worktree Location**: Extension-managed worktrees go under `~/.hydra/worktrees/<repo-identifier>/` (outside the repo to avoid tool/config leakage from parent). Legacy worktrees under `<repo>/.hydra/worktrees/` and `~/.tmux-worktrees/<hash>/` are still recognized.
-- **Session Namespace**: `{repoName}-{pathHash}_{branchSlug}` for collision safety across same-name repos in different directories.
+- **Worker Sources**: Code workers are repo/branch/git-worktree backed. Task workers are directory-backed and have no repo, branch, or git worktree.
+- **Worktree Location**: Extension-managed code-worker worktrees go under `~/.hydra/worktrees/<repo-identifier>/` (outside the repo to avoid tool/config leakage from parent). Legacy worktrees under `<repo>/.hydra/worktrees/` and `~/.tmux-worktrees/<hash>/` are still recognized.
+- **Task Folder Location**: Hydra-managed task-worker folders go under `~/.hydra/tasks/<task-slug>/`. User-provided task folders are never deleted unless a product decision introduces a separate force flag.
+- **Session Namespace**: Code workers use `{repoName}-{pathHash}_{branchSlug}` for collision safety across same-name repos in different directories. Task workers use `task_<taskSlug>`.
 - **Root Detection**: Compare worktree path to primary via `git rev-parse --git-common-dir` — never infer from branch name or folder basename.
 - **Slug Collision**: basename → parent dir disambiguation → short path hash. Reserve `main` for the primary worktree.
 - **Canonical Path Matching**: Normalize to absolute paths with `~` expansion for equality checks. Do not collapse symlinks via `realpath`.
 - **Unpublished Task Branches**: Don't set `branch.<name>.remote`/`.merge` before first push — VS Code SCM would try to sync against a non-existent remote. Set only `branch.<name>.vscode-merge-base`.
-- **Tree Context Menu**: Use per-type `contextValue` — `copilotItem`, `workerItem`, `inactiveWorkerItem`, `detailItem`, `gitStatusItem` — to scope right-click actions to relevant item types.
+- **Tree Context Menu**: Use per-type `contextValue` — `copilotItem`, `workerItem`, `inactiveWorkerItem`, `taskWorkerItem`, `inactiveTaskWorkerItem`, `detailItem`, `gitStatusItem` — to scope right-click actions to relevant item types.
 - **No-Git Workspace**: Show one primary item labeled `current project (no git)` mapped to workspace path.
 - **Polymorphism**: Commands must handle `TmuxItem` base class and variants (`TmuxSessionItem`, `InactiveWorktreeItem`, etc.). Use `getWorktreePath(item)` helper.
 - **Legacy Compatibility**: Centralized in `src/utils/sessionCompatibility.ts`.
@@ -63,7 +65,7 @@ Critical lessons learned — do not change without understanding the full implic
 
 - **Session Presentation**: Two-line layout (Group/Status + Detail).
 - **Terminal Interaction**: Open in Editor Area (Tabs) by default.
-- **Tree Levels**: Level 2 = branch/HEAD with green circle status. Level 3 = tmux usage. Level 4 = git summary (only when non-empty).
+- **Tree Levels**: Code worker Level 2 = branch/HEAD with green circle status, Level 3 = tmux usage, Level 4 = git summary (only when non-empty). Task workers are grouped under `Local Tasks` and show folder/workdir language, not worktree language.
 - **Current Workspace**: Sort to top with `👆` marker, match against workspace folder path.
 - **Deduplication**: Active Session > Inactive Worktree.
 
@@ -101,6 +103,7 @@ hydra list --json                                    # What's running?
 hydra config set default-agent codex                 # Optional: make Codex the default agent
 hydra copilot create --workdir .                     # Launch a copilot in the current directory
 hydra worker create --repo . --branch feat/foo       # Spawn a worker
+hydra worker create --dir ~/notes --name research    # Spawn a task worker
 hydra worker logs <session> --lines 30               # Read its output
 hydra worker send <session> "fix the failing test"   # Send instructions
 hydra copilot restore <session>                      # Restore an archived copilot by session name
@@ -170,7 +173,7 @@ gh pr create -R <owner>/<repo> --head <branch> --title "<title>" --body "<body>"
 
 ## Rules
 
-- **One branch per worker** — don't reuse sessions for unrelated tasks
+- **One branch per code worker** — don't reuse sessions for unrelated tasks
 - **Copilot owns worker creation** — workers must not run `hydra worker create`; if more parallel work is needed, ask the parent copilot to create and assign another worker
 - **Be specific in tasks** — include file paths, function names, and acceptance criteria
 - **Parallelize independent work** — two non-conflicting tasks = two workers

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Greek mythology, the Hydra was a beast that grew two heads for every one cut 
 Imagine you're porting 40 features from an old codebase. Doing it alone is a weeks-long slog. With Hydra, it looks like this:
 
 1. **Spawn a Copilot** on your `main` branch. You tell it: "Analyze these 40 features and break them into 8 logical groups."
-2. **Delegate to Workers.** With a single command, your Copilot spawns 8 Workers. Each gets its own git branch, its own isolated worktree, and its own AI agent (Claude, Gemini, or Codex).
+2. **Delegate to Code Workers.** With a single command, your Copilot spawns 8 Workers. Each gets its own git branch, its own isolated worktree, and its own AI agent (Claude, Gemini, or Codex).
 3. **Orchestrate.** You watch your sidebar. 8 terminals are alive. 8 agents are coding. You see their CPU usage, their git diffs, and their progress in real-time.
 4. **Review & Ship.** As Workers finish, you review their diffs, merge their branches, and move on.
 
@@ -80,9 +80,10 @@ Imagine you're porting 40 features from an old codebase. Doing it alone is a wee
 1. **Install:** Search for **"Hydra Code"** in the VS Code Marketplace.
 2. **Prerequisites:** Ensure `tmux` and `git` are installed on your system.
 3. **Launch Copilot:** Open the Hydra sidebar (robot icon) and click **"Create Copilot"**.
-4. **Spawn your first Worker:** 
+4. **Spawn your first Worker:**
    - Click **"Create Worker"**.
-   - Name your branch (e.g., `feat/my-new-idea`).
+   - In a git repo, choose **Code Worker** and name your branch (e.g., `feat/my-new-idea`).
+   - Outside a git repo, Hydra creates a **Task Worker** in the current folder.
    - Choose an agent or use your configured default.
    - **Watch the magic happen.**
 
@@ -96,9 +97,10 @@ Your sidebar is no longer just a file explorer. It's a high-fidelity dashboard f
 - **Git Intelligence:** Track how many commits every worker is ahead of main, and see exactly how many files they've touched.
 - **One-Click Attach:** Jump into any agent's terminal or embed it directly as an editor tab.
 
-### 💂 The Army (Workers & Worktrees)
-Hydra automates the heavy lifting of git management.
-- **Isolated Worktrees:** Every worker gets a dedicated directory under `~/.hydra/worktrees/` (outside the repo). They won't mess with your primary workspace.
+### 💂 The Army (Workers)
+Hydra automates the heavy lifting of running many agents at once.
+- **Code Workers:** Every code worker gets a dedicated git worktree under `~/.hydra/worktrees/` (outside the repo). They won't mess with your primary workspace.
+- **Task Workers:** Run an agent in a plain folder for research, writing, analysis, or other work that does not need a branch.
 - **Autonomous Mode:** Workers can be launched with auto-approved permissions, letting them work while you sleep.
 
 ### 🧠 The Brain (Copilots)
@@ -121,6 +123,7 @@ hydra config set default-agent codex
 hydra config get default-agent
 
 hydra worker create --repo . --branch feat/foo
+hydra worker create --dir ~/Desktop/research --name market-research --task "Write a competitor summary"
 hydra copilot create
 ```
 
@@ -150,8 +153,10 @@ remote — no more "I forgot to pull" drift.
 ├── repos/
 │   └── joezhoujinjing/
 │       └── hydra/          ← managed clone (always clean)
-└── worktrees/
-    └── <repo-id>/<slug>/   ← per-worker worktree
+├── worktrees/
+│   └── <repo-id>/<slug>/   ← per-worker worktree
+└── tasks/
+    └── <task-slug>/        ← managed task worker folder
 ```
 
 ### Commands

--- a/docs/task-worker-design.md
+++ b/docs/task-worker-design.md
@@ -1,0 +1,506 @@
+# Task Worker Product Design
+
+Status: product design for issue #191.
+
+Issue: https://github.com/sudoprivacy/hydra/issues/191
+
+This document defines how Hydra should support workers that are not bound to a
+git repository, branch, or git worktree. It is the product contract for the
+implementation that follows.
+
+## Summary
+
+Hydra workers should be generalized from "git worktree + tmux session + AI
+agent" to "isolated AI execution unit with a workdir and lifecycle." A worker
+always has a tmux session, an agent, a workdir, and lifecycle operations. A
+worker does not always have a git repo, branch, or git worktree.
+
+Hydra should expose two first-class worker types:
+
+| Type | User-facing name | Workdir source | Git repo | Branch | Git worktree |
+| --- | --- | --- | --- | --- | --- |
+| Code worker | Code Worker | Hydra-managed git worktree | Yes | Yes | Yes |
+| Task worker | Task Worker | User directory or Hydra-managed task directory | No | No | No |
+
+Code workers preserve Hydra's existing coding workflow. Task workers expand the
+same orchestration model to research, writing, document work, email triage,
+data analysis, and other non-coding tasks.
+
+## Resolved Product Decisions
+
+- If `hydra worker create` is run inside a git repo without enough information
+  to create a code worker, Hydra should ask for `--branch` instead of silently
+  creating a task worker.
+- If `hydra worker create` is run outside a git repo without `--repo`, `--dir`,
+  or `--temp`, Hydra should create a task worker in the current directory.
+- For `--dir`, `--name` may be omitted and defaults to the directory basename.
+- For `--temp`, the MVP requires `--name`; deriving a stable name from `--task`
+  can be added later.
+- `delete` keeps task worker files by default. Only `--delete-files` may remove
+  Hydra-managed temp task directories.
+- UI copy should use "folder" or "workdir" for task workers, not "worktree."
+
+## Goals
+
+- Support creating workers without requiring a git repo or branch.
+- Support arbitrary local directories as task worker workdirs.
+- Support Hydra-managed temporary task directories.
+- Preserve the full worker lifecycle for task workers:
+  - create
+  - logs
+  - send
+  - stop
+  - start
+  - delete
+- Make task workers a first-class UI concept instead of showing them as
+  `unknown` repos.
+- Keep code worker behavior backward compatible.
+- Avoid deleting user-owned directories by default.
+- Give copilots clear rules for choosing between code workers and task workers.
+
+## Non-Goals
+
+- Do not change the existing git worktree isolation model for code workers.
+- Do not require task worker directories to be git repositories.
+- Do not add PR, branch, or git diff workflows to task workers in the initial
+  implementation.
+- Do not support sharing task workers in the first implementation.
+- Do not introduce artifact browsing, task templates, or automatic final report
+  generation in the first implementation.
+- Do not allow workers to create other workers. The existing parent copilot rule
+  still applies.
+
+## Worker Concepts
+
+### Code Worker
+
+A code worker is the current Hydra worker model:
+
+- Requires a repo.
+- Requires a branch.
+- Creates a git worktree.
+- Runs an agent inside that worktree.
+- Supports git status, review changes, branch rename, PR discovery, and current
+  code-worker delete semantics.
+
+Example:
+
+```bash
+hydra worker create --repo . --branch feat/new-flow --task "Implement the new flow"
+```
+
+### Task Worker
+
+A task worker is a worker that runs in a plain directory:
+
+- Requires a workdir.
+- Does not require a repo.
+- Does not require a branch.
+- Does not create a git worktree.
+- Runs an agent inside the selected workdir.
+- Supports normal Hydra lifecycle operations.
+- Is displayed separately from repo groups in the UI.
+
+Examples:
+
+```bash
+hydra worker create --dir ~/Desktop/research --name market-research --task "Research competitors and write a summary"
+hydra worker create --temp --name inbox-triage --task "Review the exported email notes and extract follow-ups"
+```
+
+## CLI Product Contract
+
+`hydra worker create` should support two mutually exclusive modes.
+
+### Code Worker Mode
+
+```bash
+hydra worker create --repo <path> --branch <branch> [--agent <agent>] [--task <prompt>] [--task-file <path>]
+hydra worker create --branch <branch> [--agent <agent>] [--task <prompt>] [--task-file <path>]
+```
+
+Rules:
+
+- When `--repo` is provided, `--branch` is required.
+- `--repo` may be omitted when the command runs inside a git repository; Hydra
+  should infer the current repo and still require `--branch`.
+- Existing branch and worktree resume behavior remains unchanged.
+- Existing output fields remain available for backward compatibility.
+
+### Task Worker Mode
+
+```bash
+hydra worker create --dir <path> [--name <name>] [--agent <agent>] [--task <prompt>] [--task-file <path>]
+hydra worker create --temp --name <name> [--agent <agent>] [--task <prompt>] [--task-file <path>]
+```
+
+Rules:
+
+- `--dir` and `--temp` are mutually exclusive.
+- `--repo` is mutually exclusive with `--dir` and `--temp`.
+- `--branch` is not valid for task workers.
+- `--name` replaces `--branch` as the task worker identity.
+- For `--dir`, `--name` is optional. If omitted, Hydra derives the name from the
+  directory basename and prints the resolved name in the command output.
+- For `--temp`, `--name` is required in the MVP. If automatic task-name
+  derivation is implemented later, the resolved name must be stable and printed
+  in the command output.
+- `--task` is recommended but not strictly required. Creating an interactive
+  empty task worker should remain possible.
+- `--task-file` should be copied into the task worker workdir using the same
+  behavior as code workers.
+
+### Default Create Behavior
+
+When `hydra worker create` is called without `--repo`, `--dir`, or `--temp`:
+
+- If the current directory is inside a git repo, Hydra should fail with a clear
+  message telling the user to provide `--branch` for a code worker or `--dir` /
+  `--temp` for a task worker.
+- If the current directory is not inside a git repo, Hydra should default to a
+  task worker in the current directory.
+- The current-directory task worker should derive its name from the directory
+  basename unless `--name` is provided.
+
+This keeps code-worker branch creation explicit while making non-git directories
+usable without extra ceremony.
+
+### Delete Behavior
+
+Task worker deletion must be conservative:
+
+```bash
+hydra worker delete <session>
+hydra worker delete <session> --delete-files
+```
+
+Rules:
+
+- For code workers, existing delete semantics remain unchanged:
+  - kill session
+  - remove worktree
+  - delete branch
+  - archive worker metadata
+- For task workers created with `--dir`, delete must not remove the workdir.
+- For task workers created with `--temp`, delete must not remove the workdir by
+  default.
+- `--delete-files` may remove a Hydra-managed temp workdir.
+- `--delete-files` must not remove a user-provided `--dir` workdir unless a
+  later product decision explicitly allows a separate force flag.
+
+## CLI Output
+
+Code worker output can remain branch-oriented:
+
+```text
+Worker created: hydra-abc123_feat-new-flow
+  Type:     code
+  Branch:   feat/new-flow
+  Agent:    codex
+  Workdir:  /Users/me/.hydra/worktrees/repo-abc123/feat-new-flow
+  Session:  hydra-abc123_feat-new-flow
+```
+
+Task worker output should be task-oriented:
+
+```text
+Worker created: task-market-research
+  Type:     task
+  Name:     market-research
+  Agent:    codex
+  Workdir:  /Users/me/Desktop/research
+  Session:  task-market-research
+```
+
+JSON output should include a stable worker type/source field, for example:
+
+```json
+{
+  "status": "created",
+  "type": "task",
+  "session": "task-market-research",
+  "name": "market-research",
+  "agent": "codex",
+  "workdir": "/Users/me/Desktop/research",
+  "managedWorkdir": false
+}
+```
+
+## VS Code Product Flow
+
+The "Hydra: Create Worker" command should become a type-aware flow.
+
+### When the Workspace Is a Git Repo
+
+Show a worker type picker:
+
+- Code Worker
+- Task Worker
+
+Code Worker flow:
+
+1. Detect the current repo.
+2. Prompt for branch.
+3. Prompt for agent.
+4. Optionally prompt for task.
+5. Create git worktree and start the agent.
+
+Task Worker flow:
+
+1. Prompt for workdir source:
+   - Current workspace folder
+   - Choose local folder
+   - Create Hydra-managed temp folder
+2. Prompt for worker name.
+3. Prompt for agent.
+4. Prompt for task.
+5. Start the agent in the selected workdir.
+
+### When the Workspace Is Not a Git Repo
+
+Default to Task Worker flow instead of failing.
+
+Suggested flow:
+
+1. Use current workspace folder as the default workdir.
+2. Allow choosing another folder.
+3. Allow creating a Hydra-managed temp folder.
+4. Prompt for worker name, agent, and task.
+5. Start the agent.
+
+## Sidebar Product Model
+
+The Workers view should separate repo-backed code workers from task workers.
+
+Suggested tree:
+
+```text
+Workers
+  hydra
+    feat/new-flow
+      running · codex
+      git: M:2 A:1
+  Local Tasks
+    market-research
+      running · codex
+      ~/Desktop/research
+    inbox-triage
+      stopped · claude
+      ~/.hydra/tasks/inbox-triage
+```
+
+Rules:
+
+- Do not group task workers under `unknown`.
+- Do not label task worker directories as worktrees.
+- UI strings should use "workdir" or "folder" for task workers.
+- Existing code worker repo grouping remains unchanged.
+- The current workspace marker should work for both code worker workdirs and
+  task worker workdirs.
+
+### Context Menu
+
+Code worker context menu:
+
+- Review Changes
+- Open Worktree or Open Folder
+- Open Terminal
+- Copy Path
+- Remove
+
+Task worker context menu:
+
+- Open Folder
+- Open Terminal
+- Copy Path
+- Stop or Resume
+- Delete Worker
+- Delete Worker and Files, only for Hydra-managed temp workdirs
+
+Task workers should not show Review Changes in the first implementation. If a
+task worker directory happens to be a git repo, Hydra should still treat it as a
+task worker unless it was created through code worker mode.
+
+## Copilot Product Flow
+
+Copilot onboarding should teach both creation modes.
+
+Suggested guidance:
+
+```text
+# Code task: use a code worker
+hydra worker create --repo <path> --branch <branch> --task "<task>"
+
+# Non-code task: use a task worker
+hydra worker create --temp --name <task-name> --task "<task>"
+hydra worker create --dir <path> --name <task-name> --task "<task>"
+```
+
+Decision rules for copilots:
+
+- Use a code worker when the task requires code edits, tests, commits, PRs, or
+  git diff review.
+- Use a task worker when the task is research, writing, document organization,
+  email triage, data analysis, or another non-code task.
+- Use `--dir` when the task needs access to an existing local folder.
+- Use `--temp` when the task is one-off and Hydra can own the workspace.
+- Include a clear `--task` prompt whenever delegating work.
+
+Workers still must not create other workers. If a worker reports that more
+parallel work is needed, the parent copilot remains responsible for creating and
+assigning additional workers.
+
+## Lifecycle Semantics
+
+Task workers should match existing worker lifecycle expectations:
+
+| Command | Code worker | Task worker |
+| --- | --- | --- |
+| `create` | Create/resume branch worktree and launch agent | Create/select workdir and launch agent |
+| `logs` | Capture tmux pane output | Capture tmux pane output |
+| `send` | Send message to tmux session | Send message to tmux session |
+| `stop` | Kill session and keep worktree | Kill session and keep workdir |
+| `start` | Restart agent in worktree | Restart agent in workdir |
+| `delete` | Remove session, worktree, branch, and state | Remove session and state; keep files by default |
+
+Archive and restore should preserve task worker metadata. Restoring a task
+worker should restart the agent in the original workdir if it still exists. If
+the workdir no longer exists:
+
+- For user-provided `--dir`, Hydra should fail with a clear error.
+- For Hydra-managed `--temp`, Hydra may recreate the directory if product and
+  implementation constraints allow it.
+
+## Data Model Requirements
+
+Implementation should add an explicit worker source/type instead of inferring
+from missing repo fields.
+
+Suggested shape:
+
+```ts
+type WorkerSource = 'repo' | 'directory';
+
+interface WorkerInfo {
+  source?: WorkerSource; // missing means 'repo' for backward compatibility
+  sessionName: string;
+  displayName: string;
+  workerId: number;
+  repo?: string | null;
+  repoRoot?: string | null;
+  branch?: string | null;
+  slug: string;
+  status: 'running' | 'stopped';
+  attached: boolean;
+  agent: string;
+  workdir: string;
+  managedWorkdir?: boolean;
+  tmuxSession: string;
+  createdAt: string;
+  lastSeenAt: string;
+  sessionId: string | null;
+  agentSessionFile?: string | null;
+  copilotSessionName: string | null;
+}
+```
+
+Rules:
+
+- Existing workers without `source` are repo/code workers.
+- Task workers use `source: 'directory'`.
+- Task workers created with `--dir` use `managedWorkdir: false`.
+- Task workers created with `--temp` use `managedWorkdir: true`.
+- `workdir` remains required for all workers.
+- Code paths should branch on `source`, not on `repoRoot` truthiness alone.
+
+## Naming
+
+Product naming:
+
+- User-facing type: Task Worker
+- Sidebar group: Local Tasks
+- Technical source field: `directory`
+- CLI workdir flags: `--dir` and `--temp`
+- CLI identity flag: `--name`
+
+Avoid using "repo-free worker" as user-facing product language. It describes
+the implementation constraint rather than the user value.
+
+## Backward Compatibility
+
+- Existing `hydra worker create --repo <path> --branch <branch>` must keep
+  working.
+- Existing sessions without `source` must load as code workers.
+- Existing archive entries without `source` must restore as code workers.
+- Existing JSON output fields should remain present for code workers.
+- Any new fields should be additive.
+- Existing code-worker delete behavior should not change.
+
+## Implementation Milestones
+
+Recommended order:
+
+1. Add worker source metadata and backward-compatible session state loading.
+2. Extract shared agent/tmux launch lifecycle from repo-specific worktree
+   creation.
+3. Add task worker creation in `SessionManager`.
+4. Add CLI parsing and validation for `--dir`, `--temp`, `--name`, and
+   `--delete-files`.
+5. Update `logs`, `send`, `stop`, `start`, `delete`, and `restore` behavior for
+   task workers.
+6. Update VS Code create-worker flow.
+7. Update sidebar grouping and context menus.
+8. Update copilot onboarding, README, AGENTS, and Hydra skill docs.
+9. Add smoke tests for task worker lifecycle.
+
+## Acceptance Criteria
+
+- A user can run:
+
+  ```bash
+  hydra worker create --dir /tmp/hydra-notes --name notes --task "Summarize these files"
+  ```
+
+  and then use `logs`, `send`, `stop`, `start`, and `delete` successfully.
+
+- A user can run:
+
+  ```bash
+  hydra worker create --temp --name research --task "Research the topic and write notes"
+  ```
+
+  and Hydra creates a managed task workdir.
+
+- Deleting a `--dir` task worker does not delete the directory.
+- Deleting a `--temp` task worker does not delete the directory unless
+  `--delete-files` is supplied.
+- Running `hydra worker create` in a non-git directory creates a task worker in
+  the current directory.
+- Running `hydra worker create` in a git repo without `--branch` fails with a
+  clear message.
+- Code worker creation remains backward compatible.
+- Task workers appear under Local Tasks in the sidebar.
+- Task workers do not show branch, PR, worktree, or git review affordances.
+- The UI uses "folder" or "workdir" rather than "worktree" for task workers.
+
+## Test Coverage
+
+Add smoke tests for:
+
+- CLI task worker create with `--dir`.
+- CLI task worker create with `--temp`.
+- Default create behavior in a non-git directory.
+- Default create behavior in a git repo without `--branch`.
+- Task worker delete keeps user-provided directories.
+- Task worker delete keeps managed directories by default.
+- Task worker delete removes managed directories with `--delete-files`.
+- Task worker start resumes in the same workdir.
+- Existing code worker create smoke tests still pass.
+
+Manual VS Code checks:
+
+- Create Code Worker from a git workspace.
+- Create Task Worker from a git workspace.
+- Create Task Worker from a non-git workspace.
+- Confirm sidebar grouping and context menu differences.
+- Confirm task worker labels use "folder" or "workdir," not "worktree."

--- a/docs/task-worker-technical-design.md
+++ b/docs/task-worker-technical-design.md
@@ -1,0 +1,793 @@
+# Task Worker Technical Design
+
+Status: technical design for issue #191.
+
+Product design: [task-worker-design.md](./task-worker-design.md)
+
+Issue: https://github.com/sudoprivacy/hydra/issues/191
+
+## Summary
+
+Task workers should be implemented by adding an explicit worker source and by
+splitting repo/worktree setup from the shared tmux + agent launch lifecycle.
+The current worker implementation has three responsibilities coupled inside
+`SessionManager.createWorker()`:
+
+1. Resolve a git repo, branch, base branch, slug, and worktree path.
+2. Create or resume the git worktree.
+3. Create a tmux session, launch the agent, persist worker state, capture the
+   agent session id, and send the initial task.
+
+The implementation should keep the repo-specific code path intact for code
+workers, add a directory-specific preparation path for task workers, and reuse a
+single launch/persist path for both.
+
+## Design Constraints
+
+- Preserve existing code worker behavior and CLI compatibility.
+- Existing workers without a source field must continue to behave as code
+  workers.
+- Do not infer worker type from missing repo fields once new state is written.
+  Use an explicit source field.
+- Do not delete user-provided task worker directories.
+- Do not display task workers as `unknown` repos.
+- Do not add git affordances to task workers in the first implementation.
+- Keep path comparisons based on normalized absolute paths with `~` expansion;
+  do not introduce `realpath` as the primary equality check.
+
+## Data Model
+
+Add a worker source/type and make repo-specific fields nullable.
+
+```ts
+export type WorkerSource = 'repo' | 'directory';
+
+export interface WorkerInfo {
+  source?: WorkerSource; // undefined means 'repo' for backward compatibility
+  sessionName: string;
+  displayName: string;
+  workerId: number;
+  repo: string | null;
+  repoRoot: string | null;
+  branch: string | null;
+  slug: string;
+  status: 'running' | 'stopped';
+  attached: boolean;
+  agent: string;
+  workdir: string;
+  managedWorkdir?: boolean;
+  tmuxSession: string;
+  createdAt: string;
+  lastSeenAt: string;
+  sessionId: string | null;
+  agentSessionFile?: string | null;
+  copilotSessionName: string | null;
+}
+```
+
+Helper functions should centralize source checks:
+
+```ts
+function getWorkerSource(worker: WorkerInfo): WorkerSource {
+  return worker.source ?? 'repo';
+}
+
+function isRepoWorker(worker: WorkerInfo): boolean {
+  return getWorkerSource(worker) === 'repo';
+}
+
+function isDirectoryWorker(worker: WorkerInfo): boolean {
+  return getWorkerSource(worker) === 'directory';
+}
+```
+
+Rules:
+
+- New code workers write `source: 'repo'`.
+- New task workers write `source: 'directory'`.
+- Existing session and archive entries with no `source` are treated as repo
+  workers.
+- Directory workers created with `--dir` write `managedWorkdir: false`.
+- Directory workers created with `--temp` write `managedWorkdir: true`.
+- Code workers may omit `managedWorkdir` or write `false`; cleanup is governed
+  by `source`, not by `managedWorkdir`.
+
+## Path Helpers
+
+Add a task-directory root next to existing Hydra paths:
+
+```ts
+hydraTasksRoot: path.join(hydraHome, 'tasks')
+```
+
+Suggested exported helpers in `src/core/path.ts`:
+
+```ts
+export function getHydraTasksRoot(): string;
+export function expandAndResolvePath(input: string): string;
+```
+
+The implementation can reuse existing path normalization helpers, but it should
+avoid spreading `~` expansion and absolute-path normalization across CLI and
+SessionManager call sites.
+
+Task worker workdir rules:
+
+- `--dir <path>` resolves to an absolute path.
+- If `--dir` does not exist, create it with `mkdir -p` semantics.
+- If `--dir` exists and is not a directory, fail.
+- `--dir` always records `managedWorkdir: false`, even when Hydra created the
+  missing directory at the user's requested path.
+- `--temp --name <name>` resolves to
+  `<hydraTasksRoot>/<task-slug>`.
+- If a temp task directory already exists, fail with a message asking for a
+  different `--name` or manual cleanup. Do not reuse it implicitly.
+
+## Name and Slug Handling
+
+Add a task-worker name validator separate from git branch validation.
+
+Suggested behavior:
+
+```ts
+function normalizeTaskWorkerName(name: string, backend: MultiplexerBackendCore): string {
+  const slug = backend.sanitizeSessionName(name.trim());
+  if (!slug) throw new Error('Task worker name is required.');
+  return slug;
+}
+```
+
+Rules:
+
+- Do not run `validateBranchName()` for task workers.
+- For `--dir` without `--name`, derive the input name from
+  `path.basename(workdir)`.
+- For default current-directory task workers, derive the name from the current
+  directory basename.
+- For `--temp`, require `--name` in the MVP.
+- Use the normalized slug as `displayName` for consistency with existing worker
+  display behavior.
+- A task worker name collision should fail clearly instead of adding an
+  automatic numeric suffix. Users can choose a different `--name`.
+
+## Session Names
+
+Use a stable namespace for task workers:
+
+```ts
+const TASK_WORKER_SESSION_NAMESPACE = 'task';
+const sessionName = backend.buildSessionName(TASK_WORKER_SESSION_NAMESPACE, slug);
+```
+
+With the current tmux backend this produces names like
+`task_market-research`.
+
+Before creating a task worker, check for collisions in:
+
+- `sessions.json` workers
+- `sessions.json` copilots
+- live backend sessions
+
+If the session name already exists, fail with:
+
+```text
+Task worker "<name>" already exists. Use a different --name or start/delete the existing worker.
+```
+
+Archived task workers are restored through the archive command, not by creating
+a new worker with the same name.
+
+## Public SessionManager API
+
+Keep the existing `createWorker()` name as the repo/code-worker API to minimize
+call-site churn, but introduce clearer typed aliases internally.
+
+Suggested interfaces:
+
+```ts
+export interface CreateRepoWorkerOpts {
+  repoRoot: string;
+  branchName: string;
+  agentType?: string;
+  baseBranchOverride?: string;
+  task?: string;
+  taskFile?: string;
+  agentCommand?: string;
+  resumeSessionId?: string;
+  resumeSessionFile?: string | null;
+  copilotSessionName?: string;
+  notifyCopilot?: boolean;
+  preservedWorkerInfo?: WorkerInfo;
+  fetchMode?: 'best-effort' | 'required';
+}
+
+export interface CreateDirectoryWorkerOpts {
+  workdir: string;
+  name?: string;
+  managedWorkdir?: boolean;
+  agentType?: string;
+  task?: string;
+  taskFile?: string;
+  agentCommand?: string;
+  resumeSessionId?: string;
+  resumeSessionFile?: string | null;
+  copilotSessionName?: string;
+  notifyCopilot?: boolean;
+  preservedWorkerInfo?: WorkerInfo;
+}
+
+export interface DeleteWorkerOpts {
+  deleteFiles?: boolean;
+}
+```
+
+Methods:
+
+```ts
+async createWorker(opts: CreateRepoWorkerOpts): Promise<CreateWorkerResult>;
+async createRepoWorker(opts: CreateRepoWorkerOpts): Promise<CreateWorkerResult>;
+async createDirectoryWorker(opts: CreateDirectoryWorkerOpts): Promise<CreateWorkerResult>;
+async deleteWorker(sessionName: string, opts?: DeleteWorkerOpts): Promise<void>;
+```
+
+`createWorker()` should delegate to `createRepoWorker()` for backward
+compatibility.
+
+## Shared Worker Launch Pipeline
+
+Extract the common launch sequence from `createWorker()`, `startWorker()`, and
+eventually `createCopilot()` only as far as needed for this feature. Do not do a
+large copilot refactor as part of the task worker implementation.
+
+Suggested internal shape:
+
+```ts
+interface PreparedWorkerLaunch {
+  source: WorkerSource;
+  sessionName: string;
+  displayName: string;
+  slug: string;
+  workdir: string;
+  repo: string | null;
+  repoRoot: string | null;
+  branch: string | null;
+  managedWorkdir: boolean;
+  agentType: string;
+  agentCommand: string;
+  task?: string;
+  resumeSessionId?: string;
+  resumeSessionFile?: string | null;
+  copilotSessionName?: string;
+  notifyCopilot: boolean;
+  preservedWorkerInfo?: WorkerInfo;
+  preservedStateKey?: string;
+}
+
+private async launchPreparedWorker(prepared: PreparedWorkerLaunch): Promise<CreateWorkerResult>;
+```
+
+`launchPreparedWorker()` owns:
+
+1. Completion-hook injection.
+2. `backend.createSession()`.
+3. `backend.setSessionWorkdir()`.
+4. `backend.setSessionRole('worker')`.
+5. `backend.setSessionAgent()`.
+6. Fresh or resume agent launch.
+7. Initial `sessions.json` write.
+8. Post-create readiness wait.
+9. Session id capture.
+10. Initial task send.
+
+Repo-specific preparation owns:
+
+- branch validation
+- fetch
+- base branch detection
+- slug collision resolution
+- `git worktree add`
+- Windows symlink repair
+- instruction import resolution
+
+Directory-specific preparation owns:
+
+- workdir resolution and creation
+- task name validation
+- temp directory creation
+- task session name collision checks
+
+This split prevents task workers from duplicating agent startup logic.
+
+## Task File Handling
+
+Move task-file copying into a helper used by both worker sources:
+
+```ts
+private prepareTaskFile(
+  workdir: string,
+  task: string | undefined,
+  taskFile: string | undefined,
+  source: WorkerSource,
+  defaultPromptVerb: 'implement' | 'complete',
+): { task?: string; taskFilename?: string }
+```
+
+Rules:
+
+- Resolve relative `--task-file` from the CLI process cwd.
+- If the file does not exist:
+  - code workers preserve existing behavior for compatibility
+  - task workers fail with `Task file "<path>" not found`
+- Copy the task file into the worker workdir.
+- If source and target are the same absolute path, skip the copy.
+- If no `--task` was supplied:
+  - code worker prompt: `Read the task in \`<file>\` and implement it.`
+  - task worker prompt: `Read the task in \`<file>\` and complete it.`
+
+## Instruction Imports
+
+Keep existing `@import` resolution for code workers only.
+
+Do not run `resolveImports()` against user-provided task worker directories in
+the MVP. It mutates instruction files, and arbitrary user folders are not
+Hydra-managed worktrees.
+
+Completion-hook injection may still write agent config under the task workdir
+when `notifyCopilot` is enabled. This mirrors existing code-worker behavior and
+is needed for completion notifications. Users can opt out with
+`--no-notify-copilot`.
+
+## Completion Notifications
+
+The current notification script is branch-oriented. Refactor notification
+metadata so task workers do not report a fake branch.
+
+Suggested metadata:
+
+```ts
+interface WorkerNotificationInfo {
+  copilotSessionName: string;
+  sessionName: string;
+  workerId: number;
+  displayName: string;
+  source: WorkerSource;
+  branch?: string | null;
+  workdir: string;
+}
+```
+
+Rules:
+
+- Code worker completion message includes branch.
+- Task worker completion message includes task name and workdir.
+- `withCodexCompletionHookOverrides()` should accept a list of trusted roots:
+  - code worker: `[repoRoot, workdir]`
+  - task worker: `[workdir]`
+
+## CLI Changes
+
+Update `src/cli/commands/worker.ts`.
+
+### `worker create`
+
+Change required options to optional options:
+
+```ts
+.option('--repo <path>', 'Path to the repository')
+.option('--branch <name>', 'Branch name for a code worker')
+.option('--dir <path>', 'Directory for a task worker')
+.option('--temp', 'Create a Hydra-managed temporary task directory')
+.option('--name <name>', 'Task worker name')
+```
+
+Mode resolution:
+
+1. Reject `--repo` with `--dir` or `--temp`.
+2. Reject `--branch` with `--dir` or `--temp`.
+3. Reject `--base` with `--dir` or `--temp`.
+4. Reject `--name` with code-worker mode.
+5. If `--temp`, require `--name` and create a managed directory worker.
+6. Else if `--dir`, create an unmanaged directory worker.
+7. Else if `--repo` or `--branch`, create a code worker:
+   - If `--repo` is omitted, infer the current git repo.
+   - Require `--branch`.
+8. Else if current directory is inside a git repo, fail with a clear message:
+
+   ```text
+   Current directory is a git repository. Provide --branch for a code worker, or use --dir/--temp for a task worker.
+   ```
+
+9. Else create an unmanaged directory worker in the current directory.
+
+This makes `hydra worker create --branch feat/x --task "..."`
+work from inside a git repo while preserving the explicit branch requirement.
+
+### `worker delete`
+
+Add:
+
+```ts
+.option('--delete-files', 'Delete Hydra-managed task worker files')
+```
+
+Pass `{ deleteFiles: opts.deleteFiles }` to `SessionManager.deleteWorker()`.
+
+### Output
+
+Include:
+
+- `type`
+- `name`
+- `managedWorkdir`
+
+For code workers keep existing `branch` output for compatibility.
+
+## Lifecycle Behavior
+
+### Start
+
+`startWorker()` mostly works for both sources because it starts the saved worker
+inside `existingWorker.workdir`. Required changes:
+
+- Error text should say `Workdir "<path>" does not exist` instead of
+  `Worktree`.
+- If a directory worker has `managedWorkdir: true` and the workdir is missing,
+  the implementation may recreate the directory before starting. The MVP can
+  choose to fail clearly instead; product acceptance only requires restore
+  semantics to be clear.
+- Do not add git-specific behavior to task workers.
+
+### Stop
+
+No source-specific changes needed.
+
+### Delete
+
+`deleteWorker()` must branch by source.
+
+Repo worker:
+
+- Existing behavior:
+  - kill session
+  - remove worktree
+  - delete branch
+  - archive after destructive cleanup succeeds
+  - remove state
+
+Directory worker:
+
+- Kill session, treating already-absent sessions as success.
+- Archive metadata.
+- If `deleteFiles`:
+  - only proceed when `managedWorkdir === true`
+  - remove the workdir with `fs.rm({ recursive: true, force: true })`
+  - if removal fails, keep the worker state as stopped and rethrow
+- If no `deleteFiles`, do not remove the workdir.
+- Remove state after any requested cleanup succeeds.
+
+If `--delete-files` is used on an unmanaged `--dir` task worker, fail with:
+
+```text
+Worker "<session>" uses a user-provided directory. --delete-files is only supported for Hydra-managed task workers.
+```
+
+### Rename
+
+Keep `worker rename` code-worker-only in the MVP.
+
+If called on a task worker, fail with:
+
+```text
+Worker "<session>" is a task worker. Branch rename is only available for code workers.
+```
+
+Task worker rename can be a later feature.
+
+### Restore
+
+`restoreWorker()` must branch by archived worker source:
+
+- Repo worker: current `createWorker({ repoRoot, branchName, ... })` path.
+- Directory worker:
+  - if `workdir` exists, call `createDirectoryWorker()` with preserved worker
+    metadata and resume session details
+  - if missing and `managedWorkdir === true`, either recreate it or fail clearly
+    in MVP
+  - if missing and `managedWorkdir !== true`, fail clearly
+
+Preserved task workers should reuse their original `sessionName`, `workerId`,
+`createdAt`, `displayName`, and `slug`.
+
+## Sync and Discovery
+
+Update `sync()` reconciliation:
+
+- Existing workers without `source` are repo workers.
+- Repo workers keep current orphan behavior when tmux is gone and workdir is
+  missing.
+- Directory workers should not be deleted from state merely because the workdir
+  is missing. Mark them stopped and let `startWorker()` produce a clear workdir
+  error.
+
+Update live-session discovery:
+
+- If a live worker session has a workdir that resolves to a managed repo
+  worktree marker, create a repo worker entry as today.
+- If no repo root can be resolved, create a directory worker entry with:
+  - `source: 'directory'`
+  - `repo: null`
+  - `repoRoot: null`
+  - `branch: null`
+  - `managedWorkdir: false`
+
+This prevents discovered task-like sessions from appearing under `unknown`.
+
+## Sidebar Changes
+
+Update `src/providers/tmuxSessionProvider.ts`.
+
+Recommended shape:
+
+- Add `LocalTasksGroupItem`.
+- Add task-specific item context values:
+  - `taskWorkerItem`
+  - `inactiveTaskWorkerItem`
+- Split workers before grouping:
+  - repo workers by `repoRoot`
+  - directory workers under one Local Tasks group
+
+Repo worker build path:
+
+- Existing PR status fetch.
+- Existing git status and branch labels.
+- Existing git status child item.
+- Existing `workerItem` / `inactiveWorkerItem` context values.
+
+Task worker build path:
+
+- Do not fetch PR statuses.
+- Do not call git status helpers, even if the task workdir is inside a git repo.
+- Use task name or slug as the label.
+- Show folder/workdir in the detail line.
+- Set `hasGit` false for menu purposes.
+- Use task-specific context values so `Review Changes` is hidden.
+
+Package menu changes:
+
+- `tmux.reviewChanges`: only `workerItem` and `inactiveWorkerItem`.
+- `tmux.openWorktree`: rename command title to "Open Folder" or add a task-safe
+  alias. The existing implementation can still call `openWorktree()` internally
+  until names are cleaned up.
+- `tmux.copyPath`, `tmux.attach`, and `tmux.removeTask`: include task worker
+  context values.
+
+Internal variable names such as `worktreePath` can be migrated gradually. UI
+copy should use "folder" or "workdir" for task workers in this feature.
+
+## VS Code Create Worker Flow
+
+Update `src/commands/newTask.ts`.
+
+Suggested implementation:
+
+1. Ensure backend is installed.
+2. Detect whether current workspace is inside a git repo.
+3. Block nested worker creation as today.
+4. If in a git repo, show worker type picker:
+   - Code Worker
+   - Task Worker
+5. If not in a git repo, default to Task Worker flow.
+
+Code Worker flow:
+
+- Existing branch input.
+- Existing agent picker.
+- Existing `SessionManager.createWorker()` call.
+
+Task Worker flow:
+
+- Workdir source quick pick:
+  - Current workspace folder
+  - Choose local folder
+  - Create Hydra-managed temp folder
+- Name input:
+  - default to selected folder basename for current/choose-folder
+  - required for temp
+- Agent picker.
+- Task prompt input.
+- `SessionManager.createDirectoryWorker()`.
+- Attach session in editor area as worker.
+
+The first implementation can keep task prompt optional, but the UI should make
+it natural to provide one.
+
+## Context Menu Commands
+
+Update `src/commands/contextMenu.ts` and `treeItemResolver.ts` as needed.
+
+Short-term:
+
+- Continue resolving paths through the existing `resolveWorktreePath()` helper.
+- Add aliases or comments that treat this as a generic workdir for task worker
+  items.
+
+Behavior changes:
+
+- `reviewChanges()` remains git/code-worker-only through menu visibility.
+- `openWorktree()` user-facing title becomes "Open Folder".
+- `removeTask()` confirmation text should branch by worker source:
+  - code worker: mention session + worktree
+  - task worker unmanaged: mention session only; files are kept
+  - task worker managed: offer ordinary delete; a separate delete-files command
+    or CLI flag handles file removal
+
+## Share, Whoami, and List
+
+### List
+
+Update `src/cli/commands/list.ts`:
+
+- JSON worker entries include `type`, `name`, and `managedWorkdir`.
+- Pretty output groups task workers under `Local Tasks`.
+- Pretty output avoids branch parentheses for task workers.
+
+### Whoami
+
+Update `src/cli/commands/whoami.ts`:
+
+- Print `Type: code` or `Type: task`.
+- Print branch/repo only for code workers.
+- Print name/workdir for task workers.
+
+### Share
+
+Task worker sharing is a non-goal for the first implementation.
+
+Update share creation to fail early for directory workers:
+
+```text
+Task workers cannot be shared yet.
+```
+
+This is safer than generating partial bundles with null repo metadata.
+
+## Telemetry
+
+Keep telemetry path-free.
+
+Add worker source to existing events:
+
+- `worker_created`: `{ agent, workerType: 'code' | 'task' }`
+- `worker_resumed`: `{ agent, workerType: 'code' | 'task' }`
+- `worker_deleted`: `{ workerType: 'code' | 'task', deleteFiles?: boolean }`
+
+Do not include workdir, repo path, branch name, or task name.
+
+## Documentation Updates
+
+After implementation, update:
+
+- `AGENTS.md`
+- `README.md`
+- `skills/hydra/SKILL.md`
+- Copilot onboarding in `src/commands/createCopilot.ts`
+- CLI help strings
+
+Docs should use:
+
+- Code Worker
+- Task Worker
+- Local Tasks
+- folder/workdir for task worker directories
+
+Avoid user-facing "repo-free worker" terminology.
+
+## Test Plan
+
+Add focused smoke tests rather than broad e2e coverage first.
+
+Suggested new file:
+
+```text
+src/smoke/taskWorkerSmoke.ts
+```
+
+Test cases:
+
+- `createDirectoryWorker()` with unmanaged `workdir`.
+- `createDirectoryWorker()` with managed temp workdir.
+- CLI create in a non-git directory defaults to a task worker.
+- CLI create in a git repo without `--branch` fails with the required message.
+- CLI create with `--branch` and no `--repo` inside a git repo uses the current
+  repo.
+- `deleteWorker()` keeps unmanaged directories.
+- `deleteWorker()` keeps managed directories by default.
+- `deleteWorker({ deleteFiles: true })` removes managed directories.
+- `deleteWorker({ deleteFiles: true })` rejects unmanaged directories.
+- `startWorker()` restarts a task worker in the saved workdir.
+- `restoreWorker()` handles archived task worker metadata.
+- Existing repo worker smoke tests still pass.
+
+Use fake or stub backends where possible to avoid long-lived real agent
+processes. Reuse existing smoke-test patterns for session state setup and fake
+tmux behavior.
+
+Manual checks:
+
+- Create Code Worker from a git workspace.
+- Create Task Worker from a git workspace.
+- Create Task Worker from a non-git workspace.
+- Confirm Local Tasks grouping.
+- Confirm Review Changes is unavailable for task workers.
+- Confirm Open Folder, Copy Path, Attach, Stop/Start, and Delete work.
+
+Verification commands:
+
+```bash
+npm run compile
+npm run lint
+```
+
+## Implementation Order
+
+1. Add `WorkerSource`, nullable repo fields, source helpers, and path helpers.
+2. Add directory worker preparation and session-name collision checks.
+3. Extract `launchPreparedWorker()` from the existing repo worker create path.
+4. Route repo worker creation through the shared launch helper with no behavior
+   changes.
+5. Implement `createDirectoryWorker()`.
+6. Update delete/start/restore/sync behavior for directory workers.
+7. Update CLI create/delete/list/whoami/share behavior.
+8. Update VS Code create-worker flow.
+9. Update sidebar grouping and context values.
+10. Update context menu text and package menu conditions.
+11. Update docs and copilot onboarding.
+12. Add smoke tests and run compile/lint.
+
+## Risks and Mitigations
+
+### Risk: accidental user file deletion
+
+Mitigation:
+
+- `managedWorkdir` gates file deletion.
+- `--delete-files` rejects unmanaged task workers.
+- Default delete keeps files for all task workers.
+
+### Risk: task workers inherit git UI because their folder is a repo
+
+Mitigation:
+
+- Sidebar and menu behavior branches on `source`, not `isGitInitialized()`.
+- Task workers do not call PR or git status helpers.
+
+### Risk: agent hook injection mutates arbitrary user folders
+
+Mitigation:
+
+- Only inject completion hooks when notification is enabled.
+- Preserve `--no-notify-copilot`.
+- Do not run instruction import rewriting for directory workers.
+
+### Risk: session name collisions
+
+Mitigation:
+
+- Task worker create fails on collisions.
+- Error message asks user to choose another `--name` or manage the existing
+  worker.
+
+### Risk: broad refactor destabilizes copilots
+
+Mitigation:
+
+- Extract only worker launch code needed for this feature.
+- Leave copilot lifecycle refactors out of scope unless a helper is already
+  shared safely.
+
+### Risk: backward compatibility gaps in archived workers
+
+Mitigation:
+
+- Treat missing `source` as repo.
+- Add restore tests for old repo-shaped workers and new task workers.

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
       },
       {
         "command": "tmux.openWorktree",
-        "title": "Open in New Window"
+        "title": "Open Folder in New Window"
       },
       {
         "command": "tmux.reviewChanges",
@@ -217,7 +217,7 @@
         "tmuxWorktree.baseBranch": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Override the base branch used when creating new task worktrees (e.g. `master`, `origin/master`). Leave empty to auto-detect from `origin/main`, `main`, `origin/master`, `master`."
+          "markdownDescription": "Legacy setting: override the base branch used when creating new code-worker worktrees (e.g. `master`, `origin/master`). Leave empty to auto-detect from `origin/main`, `main`, `origin/master`, `master`."
         },
         "hydra.baseBranch": {
           "type": "string",
@@ -274,22 +274,22 @@
         },
         {
           "command": "tmux.openWorktree",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem')",
           "group": "1_open@2"
         },
         {
           "command": "tmux.attach",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'copilotItem')",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
           "group": "1_open@3"
         },
         {
           "command": "tmux.copyPath",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem')",
           "group": "2_copy"
         },
         {
           "command": "tmux.removeTask",
-          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'copilotItem')",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
           "group": "9_danger"
         }
       ]
@@ -331,6 +331,8 @@
     "smoke:copilot-env-e2e": "node out/smoke/copilotEnvE2eSmoke.js",
     "smoke:codex-bypass": "node out/smoke/codexBypassSmoke.js",
     "smoke:completion-hook": "node out/smoke/completionHookSmoke.js",
+    "smoke:task-worker": "node out/smoke/taskWorkerSmoke.js",
+    "smoke:task-worker-cli-e2e": "node out/smoke/taskWorkerCliE2eSmoke.js",
     "smoke:worker-delete": "node out/smoke/workerDeleteFailClosedSmoke.js",
     "smoke:telemetry": "node out/smoke/telemetrySmoke.js",
     "smoke:telemetry-e2e": "node out/smoke/telemetryE2eSmoke.js",
@@ -341,7 +343,7 @@
     "smoke:cli-config": "node out/smoke/cliConfigSmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:share && npm run smoke:repo-registry"
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:share && npm run smoke:repo-registry"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/skills/hydra/SKILL.md
+++ b/skills/hydra/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: hydra
-description: Use when you need to create a Hydra worker from natural language by resolving a repo, branch, and agent, then launching the corresponding worker session.
+description: Use when you need to create a Hydra code worker or task worker from natural language by resolving a repo/branch or folder/name and agent, then launching the corresponding worker session.
 ---
 
 # Skill: hydra
 
-Create and manage Hydra workers (git worktree + tmux session + AI agent) from natural language.
+Create and manage Hydra workers (tmux session + AI agent in a workdir) from natural language. Code workers use git worktrees and branches; task workers use plain folders.
 
 ## Prerequisites
 
@@ -34,22 +34,34 @@ Only copilots create workers. If you are running inside a Hydra worker workdir a
 1. **Parse the user's request** to extract:
    - **repo**: A path or short name (e.g., "sudocode", "hydra", "~/code/foo")
    - **branch**: The git branch to create (e.g., "feat/auth", "fix/bug-123")
+   - **folder/name** for task workers: a local folder or a temp task-worker name
    - **agent** (optional): Agent type — uses `hydra config get default-agent` when omitted
    - **task** (optional): A task description or prompt for the agent
 
-2. **Resolve repo name to path** if not an absolute path:
+2. **Choose the worker type**:
+   - Use a **code worker** when the task changes a git repo and needs a branch.
+   - Use a **task worker** for research, writing, analysis, or any non-git folder task.
+   - If running in a git repo, `hydra worker create` needs `--branch` for code workers; use `--dir` or `--temp` for task workers.
+   - If running outside a git repo with no `--repo`, `--dir`, or `--temp`, Hydra defaults to a task worker in the current directory.
+
+3. **Resolve repo name to path** for code workers if not an absolute path:
    - Search in `~/code/<name>` first, then `~/code/*/<name>` (e.g. `~/code/org/myproject`)
    - Then try the current working directory if it matches
    - If ambiguous, ask the user
 
-3. **Run the command**:
+4. **Run the command**:
    ```bash
    hydra worker create --repo <resolved_path> --branch <branch> --agent <agent> [--task "<task>"] [--task-file <path>]
+   hydra worker create --dir <folder> --name <name> --agent <agent> [--task "<task>"] [--task-file <path>]
+   hydra worker create --temp --name <name> --agent <agent> [--task "<task>"] [--task-file <path>]
    ```
 
    Available options:
-   - `--repo <path>` — Path to the repository (required)
-   - `--branch <name>` — Branch name to create (required)
+   - `--repo <path>` — Path to the repository for a code worker
+   - `--branch <name>` — Branch name to create for a code worker
+   - `--dir <path>` — Folder for a task worker; `--name` defaults to the folder basename
+   - `--temp` — Create a Hydra-managed task folder under `~/.hydra/tasks`; requires `--name`
+   - `--name <name>` — Task worker name
    - `--agent <type>` — Agent type override: `claude`, `codex`, `gemini`, `sudocode`, `custom`
    - `--base <branch>` — Base branch override (defaults to main/master)
    - `--task <prompt>` — Task prompt for the agent
@@ -70,7 +82,7 @@ hydra worker logs <session> --lines 200
 
 ### Reviewing changes
 
-Worker worktrees live at `<repo>/.hydra/worktrees/<slug>/`.
+Code worker worktrees live under `~/.hydra/worktrees/<repo-id>/<slug>/`. Task workers do not have git review or PR workflows.
 
 ```bash
 git -C <worktree_path> diff --stat
@@ -115,9 +127,10 @@ When the user asks to clean up, delete, or remove workers:
 - `hydra worker logs <session> [--lines N]` — Read worker terminal output (default: 50 lines)
 - `hydra worker send <session> <message>` — Send a message to a worker (reliable double-Enter)
 - `hydra worker send --all <message>` — Broadcast to all running workers
-- `hydra worker stop <session>` — Stop a worker (kill tmux session, keep worktree)
+- `hydra worker stop <session>` — Stop a worker (kill tmux session, keep workdir)
 - `hydra worker start <session>` — Start a stopped worker
-- `hydra worker delete <session>` — Delete a worker (kill session + remove worktree + delete branch)
+- `hydra worker delete <session>` — Delete a worker. Code workers remove worktree + branch; task workers keep files by default.
+- `hydra worker delete <session> --delete-files` — Also delete files for Hydra-managed temp task workers.
 
 ## Copilot role
 
@@ -136,7 +149,7 @@ When acting as a **copilot** (orchestrating multiple workers), follow this workf
 - Be specific in task prompts — include file paths, function names, and acceptance criteria
 - Parallelize independent work — two non-conflicting tasks = two workers
 - Review before shipping — always read the full diff before creating a PR
-- One branch per worker — don't reuse sessions for unrelated tasks
+- One branch per code worker — don't reuse sessions for unrelated tasks
 
 ## Examples
 
@@ -145,6 +158,9 @@ User: "create a worker for feat/auth on sudocode"
 
 User: "new worker with task 'refactor the API layer'"
 → `hydra worker create --repo $(pwd) --branch task/refactor-api --task "refactor the API layer"`
+
+User: "research competitors in this folder"
+→ `hydra worker create --dir "$(pwd)" --name competitor-research --task "research competitors"`
 
 User: "clean up old workers"
 → Run `hydra list`, cross-reference with merged PRs, ask user, then delete confirmed ones one at a time.

--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -1,25 +1,29 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
-import { SessionManager, ArchivedSessionInfo } from '../../core/sessionManager';
+import { isDirectoryWorker, SessionManager, ArchivedSessionInfo, type WorkerInfo } from '../../core/sessionManager';
 import { outputResult, outputError, type OutputOpts } from '../output';
 
 function formatEntry(entry: ArchivedSessionInfo): Record<string, unknown> {
+  const worker = entry.type === 'worker' ? entry.data as WorkerInfo : null;
   return {
     sessionName: entry.sessionName,
     type: entry.type,
+    workerType: worker ? (isDirectoryWorker(worker) ? 'task' : 'code') : null,
     agentSessionId: entry.agentSessionId,
     agentSessionFile: entry.agentSessionFile || null,
     archivedAt: entry.archivedAt,
     agent: entry.data.agent,
-    branch: entry.type === 'worker' ? (entry.data as { branch?: string }).branch || null : null,
+    branch: worker?.branch || null,
+    name: worker ? worker.displayName || worker.slug || null : null,
   };
 }
 
 function printEntry(entry: ArchivedSessionInfo): void {
-  const branch = entry.type === 'worker'
-    ? ` (${(entry.data as { branch?: string }).branch || 'unknown'})`
+  const worker = entry.type === 'worker' ? entry.data as WorkerInfo : null;
+  const label = worker
+    ? ` (${isDirectoryWorker(worker) ? (worker.displayName || worker.slug || 'task') : (worker.branch || 'unknown')})`
     : '';
-  console.log(`  [${entry.type}] ${entry.sessionName}${branch}`);
+  console.log(`  [${entry.type}] ${entry.sessionName}${label}`);
   console.log(`    Agent:      ${entry.data.agent}`);
   console.log(`    Session ID: ${entry.agentSessionId || 'none'}`);
   if (entry.agentSessionFile) console.log(`    Session file: ${entry.agentSessionFile}`);
@@ -125,12 +129,15 @@ export function registerArchiveCommands(program: Command): void {
 
         if (entry.type === 'worker') {
           const { workerInfo, postCreatePromise } = await sm.restoreWorker(sessionName);
+          const workerType = isDirectoryWorker(workerInfo) ? 'task' : 'code';
           outputResult(
             {
               status: 'restored',
               type: 'worker',
+              workerType,
               session: workerInfo.sessionName,
               branch: workerInfo.branch,
+              name: workerInfo.displayName || workerInfo.slug,
               agent: workerInfo.agent,
               workdir: workerInfo.workdir,
               agentSessionId: workerInfo.sessionId,
@@ -138,7 +145,12 @@ export function registerArchiveCommands(program: Command): void {
             globalOpts,
             () => {
               console.log(`Restored worker: ${workerInfo.sessionName}`);
-              console.log(`  Branch:     ${workerInfo.branch}`);
+              console.log(`  Type:       ${workerType}`);
+              if (workerType === 'task') {
+                console.log(`  Name:       ${workerInfo.displayName || workerInfo.slug}`);
+              } else {
+                console.log(`  Branch:     ${workerInfo.branch}`);
+              }
               console.log(`  Agent:      ${workerInfo.agent}`);
               console.log(`  Workdir:    ${workerInfo.workdir}`);
               console.log(`  Session ID: ${workerInfo.sessionId || 'none'}`);

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
-import { SessionManager } from '../../core/sessionManager';
+import { isDirectoryWorker, isRepoWorker, SessionManager } from '../../core/sessionManager';
 import { resolveAgentSessionFile } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 
@@ -36,6 +36,7 @@ export function registerListCommand(program: Command): void {
           workers: workers.map(w => ({
             number: w.workerId,
             name: w.displayName || w.slug || w.sessionName || w.tmuxSession,
+            type: isDirectoryWorker(w) ? 'task' : 'code',
             session: w.sessionName || w.tmuxSession,
             repo: w.repo || null,
             branch: w.branch || null,
@@ -43,6 +44,7 @@ export function registerListCommand(program: Command): void {
             status: w.status,
             attached: w.attached,
             workdir: w.workdir || null,
+            managedWorkdir: w.managedWorkdir === true,
             copilotSessionName: w.copilotSessionName || null,
             sessionId: w.sessionId,
             sessionFile: resolveAgentSessionFile(w.agent, w.workdir, w.sessionId, w.agentSessionFile),
@@ -82,9 +84,12 @@ export function registerListCommand(program: Command): void {
             console.log('\nWorkers:');
             if (isTTY) console.log('\u2500'.repeat(60));
 
+            const codeWorkers = workers.filter(isRepoWorker);
+            const taskWorkers = workers.filter(isDirectoryWorker);
+
             // Group by repo
-            const byRepo = new Map<string, typeof workers>();
-            for (const w of workers) {
+            const byRepo = new Map<string, typeof codeWorkers>();
+            for (const w of codeWorkers) {
               const key = w.repo || 'unknown';
               const group = byRepo.get(key) || [];
               group.push(w);
@@ -106,6 +111,23 @@ export function registerListCommand(program: Command): void {
                 const name = w.displayName || w.slug || w.sessionName || w.tmuxSession;
                 const num = w.workerId != null ? `#${w.workerId} ` : '';
                 console.log(`    ${statusIcon} ${num}${name}${branch}  [${w.agent}]${attached}`);
+                if (w.workdir) console.log(`      workdir: ${w.workdir}`);
+              }
+            }
+
+            if (taskWorkers.length > 0) {
+              const sortedTasks = taskWorkers
+                .sort((a, b) => (a.sessionName || a.tmuxSession).localeCompare(b.sessionName || b.tmuxSession));
+              console.log('  Local Tasks:');
+              for (const w of sortedTasks) {
+                const statusIcon = isTTY
+                  ? (w.status === 'running' ? '\x1b[32m\u25CF\x1b[0m' : '\u25CB')
+                  : `[${w.status}]`;
+                const attached = w.attached ? ' (attached)' : '';
+                const name = w.displayName || w.slug || w.sessionName || w.tmuxSession;
+                const num = w.workerId != null ? `#${w.workerId} ` : '';
+                const managed = w.managedWorkdir ? ' managed' : '';
+                console.log(`    ${statusIcon} ${num}${name}  [${w.agent}]${managed}${attached}`);
                 if (w.workdir) console.log(`      workdir: ${w.workdir}`);
               }
             }

--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
-import { SessionManager, type CopilotInfo, type WorkerInfo } from '../../core/sessionManager';
+import { isDirectoryWorker, SessionManager, type CopilotInfo, type WorkerInfo } from '../../core/sessionManager';
 import {
   branchNameToSlug,
   ensureWorktreesDir,
@@ -277,6 +277,7 @@ function buildImportedWorkerInfo(
 ): WorkerInfo {
   const now = new Date().toISOString();
   return {
+    source: 'repo',
     sessionName,
     displayName: bundleSession.displayName || slug,
     workerId: source.workerId,
@@ -288,6 +289,7 @@ function buildImportedWorkerInfo(
     attached: false,
     agent: 'codex',
     workdir,
+    managedWorkdir: false,
     tmuxSession: sessionName,
     createdAt: now,
     lastSeenAt: now,
@@ -467,6 +469,9 @@ export function registerShareCommands(program: Command): void {
         const session = findShareableSession(state, sessionName);
         if (!session) {
           throw new Error(`Session "${sessionName}" not found`);
+        }
+        if (session.type === 'worker' && isDirectoryWorker(session.data)) {
+          throw new Error('Task workers cannot be shared yet. Share currently supports copilots and code workers only.');
         }
 
         if (opts.stop) {

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -6,6 +6,7 @@ import { TmuxBackendCore } from '../../core/tmux';
 
 interface WhoamiResult {
   role: 'worker';
+  type: 'code' | 'task';
   sessionName: string;
   displayName: string;
   agent: string;
@@ -14,8 +15,9 @@ interface WhoamiResult {
   status: string;
   // Worker-specific
   workerId?: number;
-  branch?: string;
-  repo?: string;
+  branch?: string | null;
+  repo?: string | null;
+  managedWorkdir?: boolean;
   copilotSessionName?: string | null;
 }
 
@@ -36,6 +38,7 @@ export function registerWhoamiCommand(program: Command): void {
         if (cwd === resolve(worker.workdir) || cwd.startsWith(resolve(worker.workdir) + '/')) {
           const data: WhoamiResult = {
             role: 'worker',
+            type: worker.source === 'directory' ? 'task' : 'code',
             sessionName: worker.sessionName,
             displayName: worker.displayName,
             agent: worker.agent,
@@ -45,6 +48,7 @@ export function registerWhoamiCommand(program: Command): void {
             workerId: worker.workerId,
             branch: worker.branch,
             repo: worker.repo,
+            managedWorkdir: worker.managedWorkdir === true,
             copilotSessionName: worker.copilotSessionName,
           };
 
@@ -67,14 +71,22 @@ export function registerWhoamiCommand(program: Command): void {
 function prettyPrintWorker(worker: WorkerInfo): void {
   console.log('');
   console.log(`  Role:        worker`);
+  console.log(`  Type:        ${worker.source === 'directory' ? 'task' : 'code'}`);
   console.log(`  Session:     ${worker.sessionName}`);
   console.log(`  Worker #:    ${worker.workerId}`);
-  console.log(`  Branch:      ${worker.branch}`);
-  console.log(`  Repo:        ${worker.repo}`);
+  if (worker.source === 'directory') {
+    console.log(`  Name:        ${worker.displayName || worker.slug}`);
+  } else {
+    console.log(`  Branch:      ${worker.branch}`);
+    console.log(`  Repo:        ${worker.repo}`);
+  }
   console.log(`  Agent:       ${worker.agent}`);
   console.log(`  Session ID:  ${worker.sessionId ?? '(none)'}`);
   console.log(`  Copilot:     ${worker.copilotSessionName ?? '(none)'}`);
   console.log(`  Workdir:     ${worker.workdir}`);
+  if (worker.source === 'directory') {
+    console.log(`  Managed:     ${worker.managedWorkdir === true ? 'yes' : 'no'}`);
+  }
   console.log(`  Status:      ${worker.status}`);
   console.log('');
 }

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -1,14 +1,112 @@
 import { Command } from 'commander';
+import * as path from 'path';
 import { TmuxBackendCore } from '../../core/tmux';
-import { SessionManager } from '../../core/sessionManager';
+import { isDirectoryWorker, SessionManager, type WorkerInfo } from '../../core/sessionManager';
 import { getRepoRootFromPath, localBranchExists } from '../../core/git';
-import { resolveAgentSessionFile } from '../../core/path';
+import { expandAndResolvePath, resolveAgentSessionFile } from '../../core/path';
 import { resolveRepoInput } from '../../core/repoRegistry';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import { detectCurrentTmuxIdentity, detectIdentity, getWorkerCreationBlockedMessage } from '../identity';
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
 import { agentSupportsCompletionNotification } from '../../core/agentConfig';
 import { getHydraGlobalDefaultAgent } from '../../core/hydraGlobalConfig';
+
+type WorkerCreateCliOpts = {
+  repo?: string;
+  branch?: string;
+  dir?: string;
+  temp?: boolean;
+  name?: string;
+  base?: string;
+};
+
+type ResolvedCreateMode =
+  | { type: 'code'; repo: string; branch: string }
+  | { type: 'task'; workdir?: string; name?: string; managedWorkdir: boolean };
+
+function getDirectoryName(inputPath: string): string {
+  return path.basename(inputPath.replace(/[\\/]+$/, '')) || 'task';
+}
+
+async function tryGetCurrentRepoRoot(): Promise<string | null> {
+  try {
+    return await getRepoRootFromPath(process.cwd());
+  } catch {
+    return null;
+  }
+}
+
+async function resolveCreateMode(opts: WorkerCreateCliOpts): Promise<ResolvedCreateMode> {
+  const taskModeRequested = !!opts.dir || opts.temp === true;
+
+  if (opts.repo && taskModeRequested) {
+    throw new Error('--repo cannot be used with --dir or --temp.');
+  }
+  if (opts.dir && opts.temp) {
+    throw new Error('--dir and --temp are mutually exclusive.');
+  }
+
+  if (taskModeRequested) {
+    if (opts.branch) {
+      throw new Error('--branch is only valid for code workers.');
+    }
+    if (opts.base) {
+      throw new Error('--base is only valid for code workers.');
+    }
+    if (opts.temp) {
+      if (!opts.name?.trim()) {
+        throw new Error('--name is required when using --temp.');
+      }
+      return { type: 'task', name: opts.name.trim(), managedWorkdir: true };
+    }
+
+    const workdir = expandAndResolvePath(opts.dir!);
+    return {
+      type: 'task',
+      workdir,
+      name: opts.name?.trim() || getDirectoryName(workdir),
+      managedWorkdir: false,
+    };
+  }
+
+  if (opts.repo) {
+    if (!opts.branch?.trim()) {
+      throw new Error('--branch is required when using --repo.');
+    }
+    if (opts.name) {
+      throw new Error('--name is only valid for task workers.');
+    }
+    return { type: 'code', repo: opts.repo, branch: opts.branch.trim() };
+  }
+
+  const currentRepoRoot = await tryGetCurrentRepoRoot();
+  if (currentRepoRoot) {
+    if (!opts.branch?.trim()) {
+      throw new Error(
+        'Current directory is a git repository. --branch is required to create a code worker; use --dir or --temp to create a task worker.',
+      );
+    }
+    if (opts.name) {
+      throw new Error('--name is only valid for task workers.');
+    }
+    return { type: 'code', repo: currentRepoRoot, branch: opts.branch.trim() };
+  }
+
+  if (opts.branch?.trim()) {
+    throw new Error('--branch requires --repo or a current directory inside a git repository.');
+  }
+  if (opts.base) {
+    throw new Error('--base is only valid for code workers.');
+  }
+
+  const workdir = expandAndResolvePath(process.cwd());
+  return {
+    type: 'task',
+    workdir,
+    name: opts.name?.trim() || getDirectoryName(workdir),
+    managedWorkdir: false,
+  };
+}
 
 export function registerWorkerCommands(program: Command): void {
   const worker = program
@@ -18,8 +116,11 @@ export function registerWorkerCommands(program: Command): void {
   worker
     .command('create')
     .description('Create a new worker')
-    .requiredOption('--repo <path>', 'Path to the repository')
-    .requiredOption('--branch <name>', 'Branch name')
+    .option('--repo <path>', 'Path to the repository for a code worker')
+    .option('--branch <name>', 'Branch name for a code worker')
+    .option('--dir <path>', 'Directory for a task worker')
+    .option('--temp', 'Create a Hydra-managed task worker folder')
+    .option('--name <name>', 'Task worker name')
     .option('--agent <type>', 'Agent type override (claude, codex, gemini, sudocode, custom)')
     .option('--base <branch>', 'Base branch override')
     .option('--task <prompt>', 'Task prompt for the agent')
@@ -28,8 +129,11 @@ export function registerWorkerCommands(program: Command): void {
     .option('--notify-copilot', 'Notify parent copilot when worker completes (default: true)', true)
     .option('--no-notify-copilot', 'Disable completion notification to parent copilot')
     .action(async (opts: {
-      repo: string;
-      branch: string;
+      repo?: string;
+      branch?: string;
+      dir?: string;
+      temp?: boolean;
+      name?: string;
       agent?: string;
       base?: string;
       task?: string;
@@ -44,16 +148,6 @@ export function registerWorkerCommands(program: Command): void {
           throw new Error(getWorkerCreationBlockedMessage(identity));
         }
 
-        // Single dispatch helper: handles short-form, abs paths, and explicit
-        // relative paths (`.`, `./foo`, `../foo`). Decides managed-ness against
-        // the resolved (pre-rev-parse) path so the macOS /var → /private/var
-        // realpath flip in `git rev-parse --show-toplevel` doesn't defeat the
-        // comparison against ~/.hydra/repos/.
-        const { path: repoPath, isManaged: isManagedRepo } = resolveRepoInput(opts.repo);
-        const repoRoot = await getRepoRootFromPath(repoPath);
-
-        // Check if branch exists before create to detect resume
-        const branchExisted = await localBranchExists(repoRoot, opts.branch);
         const agentType = opts.agent || getHydraGlobalDefaultAgent().agent;
 
         const backend = new TmuxBackendCore();
@@ -67,38 +161,78 @@ export function registerWorkerCommands(program: Command): void {
           }
         }
 
-        const { workerInfo, postCreatePromise } = await sm.createWorker({
-          repoRoot,
-          branchName: opts.branch,
-          agentType,
-          baseBranchOverride: opts.base,
-          task: opts.task,
-          taskFile: opts.taskFile,
-          copilotSessionName,
-          notifyCopilot: opts.notifyCopilot,
-          fetchMode: isManagedRepo ? 'required' : 'best-effort',
-        });
+        const mode = await resolveCreateMode(opts);
+        let workerInfo: WorkerInfo;
+        let postCreatePromise: Promise<void>;
+        let status = 'created';
 
-        const status = branchExisted ? 'exists' : 'created';
+        if (mode.type === 'code') {
+          // Single dispatch helper: handles short-form, abs paths, and explicit
+          // relative paths (`.`, `./foo`, `../foo`). Decides managed-ness against
+          // the resolved (pre-rev-parse) path so the macOS /var → /private/var
+          // realpath flip in `git rev-parse --show-toplevel` doesn't defeat the
+          // comparison against ~/.hydra/repos/.
+          const { path: repoPath, isManaged: isManagedRepo } = resolveRepoInput(mode.repo);
+          const repoRoot = await getRepoRootFromPath(repoPath);
+          const branchExisted = await localBranchExists(repoRoot, mode.branch);
+
+          const result = await sm.createWorker({
+            repoRoot,
+            branchName: mode.branch,
+            agentType,
+            baseBranchOverride: opts.base,
+            task: opts.task,
+            taskFile: opts.taskFile,
+            copilotSessionName,
+            notifyCopilot: opts.notifyCopilot,
+            fetchMode: isManagedRepo ? 'required' : 'best-effort',
+          });
+          workerInfo = result.workerInfo;
+          postCreatePromise = result.postCreatePromise;
+          status = branchExisted ? 'exists' : 'created';
+        } else {
+          const result = await sm.createDirectoryWorker({
+            workdir: mode.workdir,
+            name: mode.name,
+            managedWorkdir: mode.managedWorkdir,
+            agentType,
+            task: opts.task,
+            taskFile: opts.taskFile,
+            copilotSessionName,
+            notifyCopilot: opts.notifyCopilot,
+          });
+          workerInfo = result.workerInfo;
+          postCreatePromise = result.postCreatePromise;
+        }
+
+        const type = isDirectoryWorker(workerInfo) ? 'task' : 'code';
 
         getTelemetry().capture(
-          branchExisted ? 'worker_resumed' : 'worker_created',
-          { agent: normalizeAgentForTelemetry(workerInfo.agent) },
+          status === 'exists' ? 'worker_resumed' : 'worker_created',
+          { agent: normalizeAgentForTelemetry(workerInfo.agent), workerType: type },
         );
 
         outputResult(
           {
             status,
+            type,
             session: workerInfo.sessionName,
             branch: workerInfo.branch,
+            name: workerInfo.displayName || workerInfo.slug,
             agent: workerInfo.agent,
             workdir: workerInfo.workdir,
+            managedWorkdir: workerInfo.managedWorkdir === true,
           },
           globalOpts,
           () => {
-            const label = branchExisted ? 'Worker resumed' : 'Worker created';
+            const label = status === 'exists' ? 'Worker resumed' : 'Worker created';
             console.log(`${label}: ${workerInfo.sessionName}`);
-            console.log(`  Branch:   ${workerInfo.branch}`);
+            console.log(`  Type:     ${type}`);
+            if (type === 'task') {
+              console.log(`  Name:     ${workerInfo.displayName || workerInfo.slug}`);
+            } else {
+              console.log(`  Branch:   ${workerInfo.branch}`);
+            }
             console.log(`  Agent:    ${workerInfo.agent}`);
             console.log(`  Workdir:  ${workerInfo.workdir}`);
             console.log(`  Session:  ${workerInfo.tmuxSession}`);
@@ -114,18 +248,24 @@ export function registerWorkerCommands(program: Command): void {
 
   worker
     .command('delete <session>')
-    .description('Delete a worker (kill session + remove worktree + delete branch)')
-    .action(async (sessionName: string) => {
+    .description('Delete a worker')
+    .option('--delete-files', 'Delete files for Hydra-managed temp task worker folders')
+    .action(async (sessionName: string, opts: { deleteFiles?: boolean }) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
         const backend = new TmuxBackendCore();
         const sm = new SessionManager(backend);
-        await sm.deleteWorker(sessionName);
+        const workerInfo = await sm.getWorker(sessionName);
+        const workerType = workerInfo ? (isDirectoryWorker(workerInfo) ? 'task' : 'code') : undefined;
+        await sm.deleteWorker(sessionName, { deleteFiles: opts.deleteFiles === true });
 
-        getTelemetry().capture('worker_deleted');
+        getTelemetry().capture('worker_deleted', {
+          workerType,
+          deleteFiles: opts.deleteFiles === true,
+        });
 
         outputResult(
-          { status: 'deleted', session: sessionName },
+          { status: 'deleted', session: sessionName, deleteFiles: opts.deleteFiles === true },
           globalOpts,
           () => console.log(`Deleted worker: ${sessionName}`),
         );
@@ -136,7 +276,7 @@ export function registerWorkerCommands(program: Command): void {
 
   worker
     .command('stop <session>')
-    .description('Stop a worker (kill tmux session, keep worktree)')
+    .description('Stop a worker (kill tmux session, keep workdir)')
     .action(async (sessionName: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -188,7 +328,7 @@ export function registerWorkerCommands(program: Command): void {
 
   worker
     .command('rename <session> <new-branch>')
-    .description('Rename a worker (branch, worktree, and session)')
+    .description('Rename a code worker (branch, worktree, and session)')
     .action(async (sessionName: string, newBranch: string) => {
       const globalOpts = program.opts() as OutputOpts;
       try {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -69,6 +69,12 @@ export function classifyError(message: string): number {
     lower.includes('missing required') ||
     lower.includes('unknown config key') ||
     lower.includes('workers cannot create other workers') ||
+    lower.includes('cannot be used with') ||
+    lower.includes('mutually exclusive') ||
+    lower.includes('only valid') ||
+    lower.includes('only supported') ||
+    lower.includes('requires --') ||
+    lower.includes('is required') ||
     lower.includes('validation')
   ) {
     return EXIT_VALIDATION;

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -36,18 +36,18 @@ function getRoleFromItem(item?: TmuxItem): HydraRole | undefined {
   return undefined;
 }
 
-async function ensureSessionExists(sessionName: string, worktreePath?: string): Promise<void> {
+async function ensureSessionExists(sessionName: string, workdir?: string): Promise<void> {
   const backend = getActiveBackend();
   if (await backend.hasSession(sessionName)) {
     return;
   }
 
-  if (!worktreePath) {
-    throw new Error('Worktree path not found (cannot create session).');
+  if (!workdir) {
+    throw new Error('Workdir not found (cannot create session).');
   }
 
-  await backend.createSession(sessionName, worktreePath);
-  await backend.setSessionWorkdir(sessionName, worktreePath);
+  await backend.createSession(sessionName, workdir);
+  await backend.setSessionWorkdir(sessionName, workdir);
 }
 
 export async function attach(item?: TmuxItem): Promise<void> {
@@ -99,7 +99,7 @@ export async function attachInEditor(item?: TmuxItem): Promise<void> {
 export async function openWorktree(item?: TmuxItem): Promise<void> {
   const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
-    vscode.window.showErrorMessage('Worktree path not found');
+    vscode.window.showErrorMessage('Workdir not found');
     return;
   }
   const worktreeUri = vscode.Uri.file(worktreePath);
@@ -109,7 +109,7 @@ export async function openWorktree(item?: TmuxItem): Promise<void> {
 export async function reviewChanges(item?: TmuxItem): Promise<void> {
   const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
-    vscode.window.showErrorMessage('Worktree path not found');
+    vscode.window.showErrorMessage('Workdir not found');
     return;
   }
 
@@ -123,7 +123,7 @@ export async function reviewChanges(item?: TmuxItem): Promise<void> {
 export async function copyPath(item?: TmuxItem): Promise<void> {
   const worktreePath = await resolveWorktreePath(item);
   if (!worktreePath) {
-    vscode.window.showErrorMessage('Worktree path not found');
+    vscode.window.showErrorMessage('Workdir not found');
     return;
   }
   await vscode.env.clipboard.writeText(worktreePath);

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -14,7 +14,9 @@ Before anything else, run \`hydra --version\`. If the command is not found, the 
 
 ## Key commands
 - \`hydra list --json\`                                   — See all copilots and workers
-- \`hydra worker create --repo <path> --branch <name>\`   — Spawn a worker
+- \`hydra worker create --repo <path> --branch <name>\`   — Spawn a code worker
+- \`hydra worker create --dir <path> --name <name>\`      — Spawn a task worker in a folder
+- \`hydra worker create --temp --name <name>\`            — Spawn a managed temp task worker
 - \`hydra worker logs <session> --lines 50\`              — Read worker output
 - \`hydra worker send <session> "<message>"\`              — Send instructions to a worker
 - \`hydra worker delete <session>\`                        — Clean up a finished worker
@@ -23,9 +25,11 @@ Before anything else, run \`hydra --version\`. If the command is not found, the 
 1. Break the task into independent units of work
 2. Create one worker per unit (\`hydra worker create\`)
 3. Monitor progress (\`hydra worker logs\`)
-4. Review changes (\`git -C <workdir> diff\`)
+4. Review code-worker changes (\`git -C <workdir> diff\`) or task-worker output/logs
 5. Iterate if needed (\`hydra worker send\`)
 6. Ship approved work (push branches and create PRs)
+
+Use code workers for repo changes that need branches. Use task workers for research, writing, analysis, or non-git folders. In a git repo, \`hydra worker create\` requires \`--branch\` for code workers; pass \`--dir\` or \`--temp\` when you intentionally want a task worker.
 
 Workers cannot create other workers directly. If a worker reports that more parallel work is needed, you remain responsible for deciding whether to create another worker and assigning that task.
 

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -1,5 +1,7 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { SessionManager } from '../core/sessionManager';
+import { getRepoRootFromPath } from '../core/git';
 import { TmuxBackendCore } from '../core/tmux';
 import { validateBranchName, localBranchExists, getRepoRoot } from '../utils/git';
 import { pickAgentType } from '../utils/agentConfig';
@@ -17,26 +19,39 @@ function getBaseBranchOverride(): string | undefined {
   return legacyOverride?.trim() || undefined;
 }
 
-export async function newTask(): Promise<void> {
-  const backend = getActiveBackend();
-  if (!await ensureBackendInstalled(backend)) {
-    return;
-  }
-
-  let repoRoot: string;
+async function tryGetWorkspaceGitRoot(workspacePath: string): Promise<string | null> {
   try {
-    repoRoot = getRepoRoot();
-    const identity = detectIdentity(repoRoot);
-    if (identity?.role === 'worker') {
-      vscode.window.showErrorMessage(getWorkerCreationBlockedMessage(identity));
-      return;
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
-    return;
+    return await getRepoRootFromPath(workspacePath);
+  } catch {
+    return null;
   }
+}
 
+function defaultNameForFolder(folderPath: string): string {
+  return path.basename(folderPath.replace(/[\\/]+$/, '')) || 'task';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function refreshHydraViewsBeforeAttach(): Promise<void> {
+  await vscode.commands.executeCommand('tmux.refresh');
+  await delay(500);
+}
+
+async function promptOptionalTask(): Promise<string | null | undefined> {
+  const input = await vscode.window.showInputBox({
+    prompt: 'Task prompt (optional)',
+    placeHolder: 'Leave empty to start without an initial prompt',
+  });
+  if (input === undefined) {
+    return null;
+  }
+  return input?.trim() || undefined;
+}
+
+async function createCodeWorker(repoRoot: string): Promise<void> {
   const branchInput = await vscode.window.showInputBox({
     prompt: 'Enter branch name (e.g. feat/auth, fix/session-cleanup)',
     placeHolder: 'feat/my-task',
@@ -58,27 +73,203 @@ export async function newTask(): Promise<void> {
     return;
   }
 
+  const task = await promptOptionalTask();
+  if (task === null) {
+    return;
+  }
+
+  const branchExisted = await localBranchExists(repoRoot, branchName);
+  const sessionManager = new SessionManager(new TmuxBackendCore());
+  const { workerInfo, postCreatePromise } = await sessionManager.createWorker({
+    repoRoot,
+    branchName,
+    agentType,
+    task,
+    baseBranchOverride: getBaseBranchOverride(),
+  });
+
+  await refreshHydraViewsBeforeAttach();
+  getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+  void postCreatePromise.catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showWarningMessage(
+      `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,
+    );
+  });
+
+  const action = branchExisted ? 'Resumed' : 'Created';
+  vscode.window.showInformationMessage(`${action} code worker: ${workerInfo.sessionName}`);
+  void vscode.commands.executeCommand('tmux.refresh');
+}
+
+async function chooseTaskWorkdir(workspacePath: string, workspaceIsGitRepo: boolean): Promise<{
+  workdir?: string;
+  managedWorkdir: boolean;
+  defaultName: string;
+} | undefined> {
+  if (!workspaceIsGitRepo) {
+    return {
+      workdir: workspacePath,
+      managedWorkdir: false,
+      defaultName: defaultNameForFolder(workspacePath),
+    };
+  }
+
+  const source = await vscode.window.showQuickPick([
+    {
+      label: 'Current Workspace Folder',
+      description: workspacePath,
+      workerSource: 'current' as const,
+    },
+    {
+      label: 'Choose Local Folder',
+      description: 'Use an existing or new local folder',
+      workerSource: 'choose' as const,
+    },
+    {
+      label: 'Hydra-Managed Temp Folder',
+      description: 'Create under ~/.hydra/tasks',
+      workerSource: 'temp' as const,
+    },
+  ], {
+    placeHolder: 'Select task worker folder',
+  });
+
+  if (!source) {
+    return undefined;
+  }
+
+  if (source.workerSource === 'temp') {
+    return {
+      managedWorkdir: true,
+      defaultName: '',
+    };
+  }
+
+  if (source.workerSource === 'choose') {
+    const selected = await vscode.window.showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      openLabel: 'Use Folder',
+    });
+    const folder = selected?.[0]?.fsPath;
+    if (!folder) {
+      return undefined;
+    }
+    return {
+      workdir: folder,
+      managedWorkdir: false,
+      defaultName: defaultNameForFolder(folder),
+    };
+  }
+
+  return {
+    workdir: workspacePath,
+    managedWorkdir: false,
+    defaultName: defaultNameForFolder(workspacePath),
+  };
+}
+
+async function createTaskWorker(workspacePath: string, workspaceIsGitRepo: boolean): Promise<void> {
+  const workdirChoice = await chooseTaskWorkdir(workspacePath, workspaceIsGitRepo);
+  if (!workdirChoice) {
+    return;
+  }
+
+  const nameInput = await vscode.window.showInputBox({
+    prompt: workdirChoice.managedWorkdir ? 'Task worker name' : 'Task worker name (defaults to folder name)',
+    value: workdirChoice.defaultName,
+    placeHolder: 'market-research',
+    validateInput: (value) => value.trim() ? undefined : 'Task worker name is required.',
+  });
+  if (!nameInput) {
+    return;
+  }
+
+  const agentType = await pickAgentType();
+  if (!agentType) {
+    return;
+  }
+
+  const task = await promptOptionalTask();
+  if (task === null) {
+    return;
+  }
+
+  const sessionManager = new SessionManager(new TmuxBackendCore());
+  const { workerInfo, postCreatePromise } = await sessionManager.createDirectoryWorker({
+    workdir: workdirChoice.workdir,
+    managedWorkdir: workdirChoice.managedWorkdir,
+    name: nameInput.trim(),
+    agentType,
+    task,
+  });
+
+  await refreshHydraViewsBeforeAttach();
+  getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+  void postCreatePromise.catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showWarningMessage(
+      `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,
+    );
+  });
+
+  vscode.window.showInformationMessage(`Created task worker: ${workerInfo.sessionName}`);
+  void vscode.commands.executeCommand('tmux.refresh');
+}
+
+export async function newTask(): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await ensureBackendInstalled(backend)) {
+    return;
+  }
+
+  let workspacePath: string;
+  let repoRoot: string | null;
   try {
-    const branchExisted = await localBranchExists(repoRoot, branchName);
-    const sessionManager = new SessionManager(new TmuxBackendCore());
-    const { workerInfo, postCreatePromise } = await sessionManager.createWorker({
-      repoRoot,
-      branchName,
-      agentType,
-      baseBranchOverride: getBaseBranchOverride(),
-    });
+    workspacePath = getRepoRoot();
+    repoRoot = await tryGetWorkspaceGitRoot(workspacePath);
+    const identity = detectIdentity(repoRoot || workspacePath);
+    if (identity?.role === 'worker') {
+      vscode.window.showErrorMessage(getWorkerCreationBlockedMessage(identity));
+      return;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+    return;
+  }
 
-    backend.attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
-    void postCreatePromise.catch((error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showWarningMessage(
-        `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,
-      );
-    });
+  try {
+    if (repoRoot) {
+      const workerType = await vscode.window.showQuickPick([
+        {
+          label: 'Code Worker',
+          description: 'Create a git worktree and branch',
+          workerType: 'code' as const,
+        },
+        {
+          label: 'Task Worker',
+          description: 'Run in a folder without creating a branch',
+          workerType: 'task' as const,
+        },
+      ], {
+        placeHolder: 'Select worker type',
+      });
 
-    const action = branchExisted ? 'Resumed' : 'Created';
-    vscode.window.showInformationMessage(`${action} worker: ${workerInfo.sessionName}`);
-    void vscode.commands.executeCommand('tmux.refresh');
+      if (!workerType) {
+        return;
+      }
+
+      if (workerType.workerType === 'code') {
+        await createCodeWorker(repoRoot);
+      } else {
+        await createTaskWorker(workspacePath, true);
+      }
+    } else {
+      await createTaskWorker(workspacePath, false);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showErrorMessage(`Failed to create worker: ${message}`);

--- a/src/commands/removeTask.ts
+++ b/src/commands/removeTask.ts
@@ -9,7 +9,7 @@ import {
   GitStatusItem,
   CopilotItem,
 } from "../providers/tmuxSessionProvider";
-import { SessionManager } from "../core/sessionManager";
+import { isDirectoryWorker, SessionManager } from "../core/sessionManager";
 import { TmuxBackendCore } from "../core/tmux";
 import { resolveSessionKind, resolveSessionName } from "./treeItemResolver";
 
@@ -24,7 +24,12 @@ function isMainWorktreeItem(item: TmuxItem): boolean {
 function isOrphanItem(item: TmuxItem): boolean {
   if (item instanceof TmuxSessionItem) return item.session.status.classification === 'orphan';
   if (item instanceof TmuxDetailItem && item.session) return item.session.status.classification === 'orphan';
-  if (item instanceof WorktreeItem) return !item.hasGit;
+  if (item instanceof WorktreeItem) {
+    if (item.contextValue === 'taskWorkerItem' || item.contextValue === 'inactiveTaskWorkerItem') {
+      return false;
+    }
+    return !item.hasGit;
+  }
   return false;
 }
 
@@ -86,6 +91,36 @@ export async function removeTask(item?: TmuxItem): Promise<void> {
     if (confirm !== "Kill Session") return;
 
     await sm.deleteWorker(sessionName);
+    vscode.commands.executeCommand("tmux.refresh");
+    return;
+  }
+
+  const worker = await sm.getWorker(sessionName);
+  if (worker && isDirectoryWorker(worker)) {
+    if (worker.managedWorkdir) {
+      const confirm = await vscode.window.showWarningMessage(
+        `Delete task worker "${sessionName}"? Files are kept unless you choose to delete them.`,
+        { modal: true },
+        "Delete Worker",
+        "Delete Worker & Files",
+      );
+      if (!confirm) return;
+
+      await sm.deleteWorker(sessionName, { deleteFiles: confirm === "Delete Worker & Files" });
+      vscode.window.showInformationMessage(`Removed task worker: ${sessionName}`);
+      vscode.commands.executeCommand("tmux.refresh");
+      return;
+    }
+
+    const confirm = await vscode.window.showWarningMessage(
+      `Delete task worker "${sessionName}"? The folder will be kept.`,
+      { modal: true },
+      "Delete Worker",
+    );
+    if (confirm !== "Delete Worker") return;
+
+    await sm.deleteWorker(sessionName);
+    vscode.window.showInformationMessage(`Removed task worker: ${sessionName}`);
     vscode.commands.executeCommand("tmux.refresh");
     return;
   }

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -11,11 +11,15 @@ function expandHomeDir(targetPath: string): string {
   return targetPath;
 }
 
-export function toCanonicalPath(targetPath?: string): string | undefined {
+export function toCanonicalPath(targetPath?: string | null): string | undefined {
   if (!targetPath) return undefined;
 
   const expanded = expandHomeDir(targetPath.trim());
   return path.normalize(path.resolve(expanded));
+}
+
+export function expandAndResolvePath(targetPath: string): string {
+  return path.normalize(path.resolve(expandHomeDir(targetPath.trim())));
 }
 
 /**
@@ -293,6 +297,7 @@ export interface HydraResolvedPaths {
   hydraArchiveFile: string;
   hydraWorktreesRoot: string;
   hydraReposRoot: string;
+  hydraTasksRoot: string;
 }
 
 export function getDefaultHydraHome(): string {
@@ -366,6 +371,7 @@ export function getHydraPaths(): HydraResolvedPaths {
     hydraArchiveFile: path.join(hydraHome, 'archive.json'),
     hydraWorktreesRoot: path.join(hydraHome, 'worktrees'),
     hydraReposRoot: path.join(hydraHome, 'repos'),
+    hydraTasksRoot: path.join(hydraHome, 'tasks'),
   };
 }
 
@@ -405,6 +411,10 @@ export function getHydraWorktreesRoot(): string {
 
 export function getHydraReposRoot(): string {
   return getHydraPaths().hydraReposRoot;
+}
+
+export function getHydraTasksRoot(): string {
+  return getHydraPaths().hydraTasksRoot;
 }
 
 export function getIsolatedEnv(): Record<string, string | undefined> {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -7,7 +7,7 @@ import { ensureHydraGlobalConfig, getHydraGlobalAgentCommand, getHydraGlobalDefa
 import { buildAgentLaunchCommand, buildAgentResumePlan, DEFAULT_AGENT_COMMANDS, AGENT_SESSION_CAPTURE, CLAUDE_READY_DELAY_MS, AGENT_READY_PATTERNS, AGENT_READY_TIMEOUT_MS, AGENT_READY_POLL_INTERVAL_MS, CLAUDE_TRUST_PROMPT_PATTERN, CODEX_RESUME_CWD_PROMPT_PATTERN, CODEX_TRUST_PROMPT_PATTERN, CODEX_HOOK_REVIEW_PROMPT_PATTERN, GEMINI_TRUST_PROMPT_PATTERN, SUDOCODE_BROAD_DIRECTORY_PROMPT_PATTERN, agentSupportsCompletionNotification, agentSupportsCopilotMode, getUnsupportedCopilotModeMessage, type AgentCommandOptions } from './agentConfig';
 import { HYDRA_COPILOT_SESSION_ENV } from './env';
 import { exec, resolveCommandPath } from './exec';
-import { getHydraArchiveFile, getHydraHome, getHydraSessionsFile, resolveAgentSessionFile, toCanonicalPath } from './path';
+import { expandAndResolvePath, getHydraArchiveFile, getHydraHome, getHydraSessionsFile, getHydraTasksRoot, resolveAgentSessionFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
 
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 75000;
@@ -106,19 +106,24 @@ export function lookupWorkerId(sessionName: string): number | undefined {
 
 // ── Types ──
 
+export type WorkerSource = 'repo' | 'directory';
+
 export interface WorkerInfo {
+  source?: WorkerSource;
   sessionName: string;
-  /** Human-friendly name for display (the branch slug without the hash prefix). */
+  /** Human-friendly name for display (branch slug or task name). */
   displayName: string;
   workerId: number;
-  repo: string;
-  repoRoot: string;
-  branch: string;
+  repo: string | null;
+  repoRoot: string | null;
+  branch: string | null;
   slug: string;
   status: 'running' | 'stopped';
   attached: boolean;
   agent: string;
   workdir: string;
+  /** True only for Hydra-owned task worker folders under ~/.hydra/tasks. */
+  managedWorkdir?: boolean;
   tmuxSession: string;
   createdAt: string;
   lastSeenAt: string;
@@ -171,7 +176,7 @@ interface SavedWorkerMatch {
   stateKey?: string;
 }
 
-export interface CreateWorkerOpts {
+export interface CreateRepoWorkerOpts {
   repoRoot: string;
   branchName: string;
   agentType?: string;
@@ -193,8 +198,65 @@ export interface CreateWorkerOpts {
    * Pre-create fetch behaviour:
    *   'best-effort' — default, swallow errors (used for ad-hoc abs-path repos)
    *   'required'    — error out if fetch fails (used for ~/.hydra/repos/-managed repos)
-   */
+  */
   fetchMode?: 'best-effort' | 'required';
+}
+
+export type CreateWorkerOpts = CreateRepoWorkerOpts;
+
+export interface CreateDirectoryWorkerOpts {
+  workdir?: string;
+  name?: string;
+  managedWorkdir?: boolean;
+  agentType?: string;
+  task?: string;
+  taskFile?: string;
+  agentCommand?: string;
+  /** When set, launch the agent with --resume instead of a fresh session. */
+  resumeSessionId?: string;
+  /** Native session file to use for agents whose resume command accepts paths. */
+  resumeSessionFile?: string | null;
+  /** Session name of the copilot that spawned this worker. */
+  copilotSessionName?: string;
+  /** Whether to notify the parent copilot when the worker completes (default: true). */
+  notifyCopilot?: boolean;
+  /** Existing persisted identity to preserve when restoring an archived worker. */
+  preservedWorkerInfo?: WorkerInfo;
+}
+
+export interface DeleteWorkerOpts {
+  deleteFiles?: boolean;
+}
+
+interface PreparedWorkerLaunch {
+  source: WorkerSource;
+  sessionName: string;
+  displayName: string;
+  slug: string;
+  workdir: string;
+  repo: string | null;
+  repoRoot: string | null;
+  branch: string | null;
+  managedWorkdir: boolean;
+  agentType: string;
+  agentCommand: string;
+  task?: string;
+  resumeSessionId?: string;
+  resumeSessionFile?: string | null;
+  copilotSessionName?: string;
+  notifyCopilot: boolean;
+  preservedWorkerInfo?: WorkerInfo;
+  preservedStateKey?: string;
+}
+
+interface WorkerNotificationInfo {
+  copilotSessionName: string;
+  sessionName: string;
+  workerId: number;
+  displayName: string;
+  source: WorkerSource;
+  branch?: string | null;
+  workdir: string;
 }
 
 export interface CreateCopilotOpts {
@@ -229,6 +291,19 @@ export interface CreateCopilotResult {
 // mutator actually changed anything. Callers that don't set it keep the legacy
 // unconditional-write semantics.
 const SESSION_STATE_DIRTY_KEY = '__hydraDirty';
+const TASK_WORKER_SESSION_NAMESPACE = 'task';
+
+export function getWorkerSource(worker: WorkerInfo): WorkerSource {
+  return worker.source === 'directory' ? 'directory' : 'repo';
+}
+
+export function isRepoWorker(worker: WorkerInfo): boolean {
+  return getWorkerSource(worker) === 'repo';
+}
+
+export function isDirectoryWorker(worker: WorkerInfo): boolean {
+  return getWorkerSource(worker) === 'directory';
+}
 
 function markSessionStateDirty(state: SessionState, dirty: boolean): void {
   Object.defineProperty(state, SESSION_STATE_DIRTY_KEY, {
@@ -291,9 +366,18 @@ export class SessionManager {
       // lastSeenAt is deliberately NOT bumped on every sidebar read; the real mutation
       // paths (createWorker, startWorker, persistCopilotSessionId, etc.) already refresh it.
       for (const [key, worker] of Object.entries(state.workers)) {
+        const source = getWorkerSource(worker);
         // Backfill workerId for workers created before this feature
         if (worker.workerId == null) {
           worker.workerId = state.nextWorkerId++;
+          dirty = true;
+        }
+        if (worker.source !== source) {
+          worker.source = source;
+          dirty = true;
+        }
+        if (worker.managedWorkdir == null) {
+          worker.managedWorkdir = false;
           dirty = true;
         }
         const live = liveSessionMap.get(worker.sessionName);
@@ -301,6 +385,9 @@ export class SessionManager {
           if (worker.status !== 'running') { worker.status = 'running'; dirty = true; }
           if (worker.attached !== live.attached) { worker.attached = live.attached; dirty = true; }
         } else if (worker.workdir && fs.existsSync(worker.workdir)) {
+          if (worker.status !== 'stopped') { worker.status = 'stopped'; dirty = true; }
+          if (worker.attached !== false) { worker.attached = false; dirty = true; }
+        } else if (source === 'directory') {
           if (worker.status !== 'stopped') { worker.status = 'stopped'; dirty = true; }
           if (worker.attached !== false) { worker.attached = false; dirty = true; }
         } else {
@@ -344,18 +431,21 @@ export class SessionManager {
             repoRoot = coreGit.resolveRepoRootFromWorktreePath(discovered.workdir) || '';
           }
           const slug = this.extractSlugFromSessionName(session.name);
+          const source: WorkerSource = repoRoot ? 'repo' : 'directory';
           state.workers[session.name] = {
+            source,
             sessionName: session.name,
             displayName: slug,
             workerId: state.nextWorkerId++,
-            repo: repoRoot ? path.basename(repoRoot) : 'unknown',
-            repoRoot,
-            branch: '',
+            repo: repoRoot ? path.basename(repoRoot) : null,
+            repoRoot: repoRoot || null,
+            branch: null,
             slug,
             status: 'running',
             attached: session.attached,
             agent: discovered.agent,
             workdir: discovered.workdir,
+            managedWorkdir: false,
             tmuxSession: session.name,
             createdAt: now,
             lastSeenAt: now,
@@ -394,7 +484,7 @@ export class SessionManager {
     const workers = Object.values(state.workers);
     if (!repoRoot) return workers;
     const canonical = path.resolve(repoRoot);
-    return workers.filter(w => path.resolve(w.repoRoot) === canonical);
+    return workers.filter(w => isRepoWorker(w) && w.repoRoot && path.resolve(w.repoRoot) === canonical);
   }
 
   async listCopilots(repoRoot?: string): Promise<CopilotInfo[]> {
@@ -424,6 +514,10 @@ export class SessionManager {
   // ── Worker Lifecycle ──
 
   async createWorker(opts: CreateWorkerOpts): Promise<CreateWorkerResult> {
+    return this.createRepoWorker(opts);
+  }
+
+  async createRepoWorker(opts: CreateRepoWorkerOpts): Promise<CreateWorkerResult> {
     ensureHydraGlobalConfig();
 
     const { repoRoot, branchName } = opts;
@@ -501,141 +595,225 @@ export class SessionManager {
     // Replace them with NTFS junctions so they work without admin privileges.
     fixWindowsSymlinks(worktreePath);
 
-    let taskFilename: string | undefined;
-    if (taskFile) {
-      const absTaskFile = path.isAbsolute(taskFile) ? taskFile : path.resolve(taskFile);
-      if (fs.existsSync(absTaskFile)) {
-        taskFilename = path.basename(absTaskFile);
-        const targetTaskFile = path.join(worktreePath, taskFilename);
-        fs.copyFileSync(absTaskFile, targetTaskFile);
-
-        // If no task prompt given, instruct agent to read the file
-        if (!task) {
-          task = `Read the task in \`${taskFilename}\` and implement it.`;
-        }
-      }
-    }
+    task = this.prepareTaskFile(worktreePath, task, taskFile, 'repo', 'implement').task;
 
     // Resolve @imports in instruction files
     this.resolveImports(path.join(worktreePath, 'CLAUDE.md'), repoRoot);
     this.resolveImports(path.join(worktreePath, 'AGENTS.md'), repoRoot);
     this.resolveImports(path.join(worktreePath, 'GEMINI.md'), repoRoot);
 
-    // Create tmux session + set metadata
     const sessionName = preservedWorker?.worker.sessionName && preservedWorker.worker.slug === finalSlug
       ? preservedWorker.worker.sessionName
       : this.backend.buildSessionName(repoSessionNamespace, finalSlug);
-    const copilotSessionName = opts.copilotSessionName;
-    const shouldNotifyCopilot = agentSupportsCompletionNotification(agentType) &&
-      opts.notifyCopilot !== false &&
-      !!copilotSessionName &&
-      !!(task || taskFile);
-    if (shouldNotifyCopilot) {
+    return this.launchPreparedWorker({
+      source: 'repo',
+      sessionName,
+      displayName: finalSlug,
+      slug: finalSlug,
+      workdir: worktreePath,
+      repo: coreGit.getRepoName(repoRoot),
+      repoRoot,
+      branch: branchName,
+      managedWorkdir: false,
+      agentType,
+      agentCommand,
+      task,
+      resumeSessionId: opts.resumeSessionId,
+      resumeSessionFile: opts.resumeSessionFile,
+      copilotSessionName: opts.copilotSessionName,
+      notifyCopilot: opts.notifyCopilot !== false,
+      preservedWorkerInfo: preservedWorker?.worker,
+      preservedStateKey: preservedWorker?.stateKey,
+    });
+  }
+
+  async createDirectoryWorker(opts: CreateDirectoryWorkerOpts): Promise<CreateWorkerResult> {
+    ensureHydraGlobalConfig();
+
+    let workdir = opts.workdir ? expandAndResolvePath(opts.workdir) : '';
+    const managedWorkdir = opts.managedWorkdir === true;
+    const preservedWorker = opts.preservedWorkerInfo;
+    const nameInput = opts.name || preservedWorker?.displayName || preservedWorker?.slug ||
+      (workdir ? path.basename(workdir) : undefined);
+    const slug = preservedWorker?.slug || this.normalizeTaskWorkerName(nameInput || '');
+
+    if (managedWorkdir && !opts.name && !preservedWorker) {
+      throw new Error('Task worker name is required for --temp.');
+    }
+
+    if (!workdir) {
+      workdir = path.join(getHydraTasksRoot(), slug);
+    }
+
+    if (!preservedWorker) {
+      if (managedWorkdir && fs.existsSync(workdir)) {
+        throw new Error(`Task worker folder already exists: ${workdir}. Use a different --name or remove it first.`);
+      }
+      await this.assertDirectoryWorkerSessionAvailable(slug);
+    }
+
+    this.ensureDirectoryWorkdir(workdir);
+
+    const task = this.prepareTaskFile(workdir, opts.task, opts.taskFile, 'directory', 'complete').task;
+    const agentType = opts.agentType || getHydraGlobalDefaultAgent().agent;
+    const agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
+    const sessionName = preservedWorker?.sessionName || this.backend.buildSessionName(TASK_WORKER_SESSION_NAMESPACE, slug);
+
+    return this.launchPreparedWorker({
+      source: 'directory',
+      sessionName,
+      displayName: preservedWorker?.displayName || slug,
+      slug,
+      workdir,
+      repo: null,
+      repoRoot: null,
+      branch: null,
+      managedWorkdir,
+      agentType,
+      agentCommand,
+      task,
+      resumeSessionId: opts.resumeSessionId,
+      resumeSessionFile: opts.resumeSessionFile,
+      copilotSessionName: opts.copilotSessionName,
+      notifyCopilot: opts.notifyCopilot !== false,
+      preservedWorkerInfo: preservedWorker,
+    });
+  }
+
+  private async launchPreparedWorker(prepared: PreparedWorkerLaunch): Promise<CreateWorkerResult> {
+    let agentCommand = prepared.agentCommand;
+    const shouldNotifyCopilot = agentSupportsCompletionNotification(prepared.agentType) &&
+      prepared.notifyCopilot &&
+      !!prepared.copilotSessionName &&
+      !!prepared.task;
+
+    if (shouldNotifyCopilot && prepared.copilotSessionName) {
       const peekState = this.readSessionState();
-      const workerId = peekState.workers[sessionName]?.workerId ??
-        preservedWorker?.worker.workerId ??
+      const workerId = peekState.workers[prepared.sessionName]?.workerId ??
+        prepared.preservedWorkerInfo?.workerId ??
         peekState.nextWorkerId;
-      this.injectCompletionHook(worktreePath, agentType, {
-        copilotSessionName,
-        sessionName,
+      this.injectCompletionHook(prepared.workdir, prepared.agentType, {
+        copilotSessionName: prepared.copilotSessionName,
+        sessionName: prepared.sessionName,
         workerId,
-        displayName: finalSlug,
-        branch: branchName,
+        displayName: prepared.displayName,
+        source: prepared.source,
+        branch: prepared.branch,
+        workdir: prepared.workdir,
       });
-      if (agentType === 'codex') {
-        const scriptPath = path.join(getHydraHome(), 'hooks', `notify-${sessionName}.sh`);
-        agentCommand = this.withCodexCompletionHookOverrides(agentCommand, repoRoot, worktreePath, scriptPath);
+      if (prepared.agentType === 'codex') {
+        const scriptPath = path.join(getHydraHome(), 'hooks', `notify-${prepared.sessionName}.sh`);
+        const trustRoots = prepared.repoRoot ? [prepared.repoRoot, prepared.workdir] : [prepared.workdir];
+        agentCommand = this.withCodexCompletionHookOverrides(agentCommand, trustRoots, scriptPath);
       }
     }
 
-    await this.backend.createSession(sessionName, worktreePath);
-    await this.backend.setSessionWorkdir(sessionName, worktreePath);
-    await this.backend.setSessionRole(sessionName, 'worker');
-    await this.backend.setSessionAgent(sessionName, agentType);
+    await this.backend.createSession(prepared.sessionName, prepared.workdir);
+    await this.backend.setSessionWorkdir(prepared.sessionName, prepared.workdir);
+    await this.backend.setSessionRole(prepared.sessionName, 'worker');
+    await this.backend.setSessionAgent(prepared.sessionName, prepared.agentType);
 
-    // ── Launch agent ──
-    //
-    // Two distinct paths — resume (from archive) vs fresh create:
-    //
-    // Resume: session ID already known, launch with --resume, skip Phase 1.
-    // Fresh: supported agents converge to sessionId stored in sessions.json:
-    //   - Claude: pre-assigned via --session-id flag (known immediately)
-    //   - Codex:  launch → wait for ready → send /status → parse session ID
-    //   - Gemini: launch → wait for ready → send /stats → parse session ID
-    //   - Sudo Code: launch → wait for ready → parse startup banner or /status
-    const isResume = !!opts.resumeSessionId;
+    const isResume = !!prepared.resumeSessionId;
     let sessionId: string | null;
     let launchStartedAt: number | undefined;
 
     if (isResume) {
-      sessionId = opts.resumeSessionId!;
-      await this.launchAgentResume(sessionName, agentType, agentCommand, sessionId, worktreePath, opts.resumeSessionFile);
+      sessionId = prepared.resumeSessionId!;
+      await this.launchAgentResume(
+        prepared.sessionName,
+        prepared.agentType,
+        agentCommand,
+        sessionId,
+        prepared.workdir,
+        prepared.resumeSessionFile,
+      );
     } else {
-      sessionId = agentType === 'claude' ? randomUUID() : null;
-      const launchCmd = buildAgentLaunchCommand(agentType, agentCommand, undefined, sessionId ?? undefined);
+      sessionId = prepared.agentType === 'claude' ? randomUUID() : null;
+      const launchCmd = buildAgentLaunchCommand(prepared.agentType, agentCommand, undefined, sessionId ?? undefined);
       launchStartedAt = Date.now();
-      await this.backend.sendKeys(sessionName, launchCmd);
+      await this.backend.sendKeys(prepared.sessionName, launchCmd);
     }
 
-    // Write initial state to sessions.json
-    // (sessionId may be null for Codex/Gemini until Phase 1 capture completes)
     const workerInfo = await this.updateSessionState((state) => {
       const now = new Date().toISOString();
-      if (preservedWorker?.stateKey && preservedWorker.stateKey !== sessionName) {
-        delete state.workers[preservedWorker.stateKey];
+      if (prepared.preservedStateKey && prepared.preservedStateKey !== prepared.sessionName) {
+        delete state.workers[prepared.preservedStateKey];
       }
 
-      const existingWorker = state.workers[sessionName] || preservedWorker?.worker;
+      const existingWorker = state.workers[prepared.sessionName] || prepared.preservedWorkerInfo;
       const workerId = existingWorker?.workerId ?? state.nextWorkerId++;
 
       const nextWorker: WorkerInfo = {
-        sessionName,
-        displayName: finalSlug,
+        source: prepared.source,
+        sessionName: prepared.sessionName,
+        displayName: prepared.displayName,
         workerId,
-        repo: coreGit.getRepoName(repoRoot),
-        repoRoot,
-        branch: branchName,
-        slug: finalSlug,
+        repo: prepared.repo,
+        repoRoot: prepared.repoRoot,
+        branch: prepared.branch,
+        slug: prepared.slug,
         status: 'running',
         attached: false,
-        agent: agentType,
-        workdir: worktreePath,
-        tmuxSession: sessionName,
+        agent: prepared.agentType,
+        workdir: prepared.workdir,
+        managedWorkdir: prepared.managedWorkdir,
+        tmuxSession: prepared.sessionName,
         createdAt: existingWorker?.createdAt ?? now,
         lastSeenAt: now,
         sessionId: sessionId ?? existingWorker?.sessionId ?? null,
-        agentSessionFile: opts.resumeSessionFile ?? existingWorker?.agentSessionFile ?? null,
-        copilotSessionName: opts.copilotSessionName ?? existingWorker?.copilotSessionName ?? null,
+        agentSessionFile: prepared.resumeSessionFile ?? existingWorker?.agentSessionFile ?? null,
+        copilotSessionName: prepared.copilotSessionName ?? existingWorker?.copilotSessionName ?? null,
       };
 
-      state.workers[sessionName] = nextWorker;
+      state.workers[prepared.sessionName] = nextWorker;
       state.updatedAt = now;
       return nextWorker;
     });
 
-    // Async post-create
     const postCreatePromise = this.withPostCreateTimeout((async () => {
       if (isResume) {
-        // Resume: skip Phase 1 (sessionId already known), just wait for readiness
-        await this.waitForAgentReady(sessionName, agentType);
+        await this.waitForAgentReady(prepared.sessionName, prepared.agentType);
       } else {
-        // Phase 1: Wait for readiness & capture session ID into sessions.json
-        await this.waitForReadyAndCaptureSessionId(sessionName, agentType, sessionId, worktreePath, launchStartedAt);
+        await this.waitForReadyAndCaptureSessionId(
+          prepared.sessionName,
+          prepared.agentType,
+          sessionId,
+          prepared.workdir,
+          launchStartedAt,
+        );
       }
-      // Phase 2: Send task prompt (only after sessions.json is up to date)
-      await this.sendInitialPrompt(sessionName, task, shouldNotifyCopilot);
-    })(), sessionName, 'worker startup');
+      await this.sendInitialPrompt(prepared.sessionName, prepared.task, shouldNotifyCopilot);
+    })(), prepared.sessionName, 'worker startup');
 
     return { workerInfo, postCreatePromise };
   }
 
-  async deleteWorker(sessionName: string): Promise<void> {
+  async deleteWorker(sessionName: string, opts: DeleteWorkerOpts = {}): Promise<void> {
+    const worker = this.readSessionState().workers[sessionName];
+    if (worker && isDirectoryWorker(worker) && opts.deleteFiles && !worker.managedWorkdir) {
+      throw new Error(`Worker "${sessionName}" uses a user-provided directory. --delete-files is only supported for Hydra-managed task workers.`);
+    }
+
     await this.killSessionOrConfirmAbsent(sessionName);
 
-    const worker = this.readSessionState().workers[sessionName];
     const archivedWorker = worker ? this.prepareArchivedSessionData(worker) as WorkerInfo : undefined;
 
-    if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
+    if (worker && isDirectoryWorker(worker)) {
+      if (opts.deleteFiles && worker.managedWorkdir && worker.workdir && fs.existsSync(worker.workdir)) {
+        try {
+          fs.rmSync(worker.workdir, { recursive: true, force: true });
+        } catch (error) {
+          await this.updateSessionState((state) => {
+            if (state.workers[sessionName]) {
+              state.workers[sessionName].status = 'stopped';
+              state.workers[sessionName].attached = false;
+              state.updatedAt = new Date().toISOString();
+            }
+          });
+          throw error;
+        }
+      }
+    } else if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
       try {
         await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
       } catch (error) {
@@ -690,7 +868,7 @@ export class SessionManager {
     }
 
     if (!existingWorker.workdir || !fs.existsSync(existingWorker.workdir)) {
-      throw new Error(`Worktree "${existingWorker.workdir}" does not exist`);
+      throw new Error(`Workdir "${existingWorker.workdir}" does not exist`);
     }
 
     const agent = agentType || existingWorker.agent || getHydraGlobalDefaultAgent().agent;
@@ -976,6 +1154,10 @@ export class SessionManager {
       throw new Error(`Worker "${oldSessionName}" not found`);
     }
 
+    if (isDirectoryWorker(worker)) {
+      throw new Error(`Worker "${oldSessionName}" is a task worker. Branch rename is only available for code workers.`);
+    }
+
     if (!worker.repoRoot) {
       throw new Error(`Worker "${oldSessionName}" has no associated repository`);
     }
@@ -1234,6 +1416,28 @@ export class SessionManager {
     }
 
     const worker = entry.data as WorkerInfo;
+    if (isDirectoryWorker(worker)) {
+      const workdir = worker.workdir;
+      if (!workdir) {
+        throw new Error(`Archived task worker "${sessionName}" is missing a workdir`);
+      }
+      if (!fs.existsSync(workdir) && !worker.managedWorkdir) {
+        throw new Error(`Task worker workdir "${workdir}" does not exist`);
+      }
+      return this.createDirectoryWorker({
+        workdir,
+        name: worker.displayName || worker.slug,
+        managedWorkdir: worker.managedWorkdir === true,
+        agentType: worker.agent,
+        resumeSessionId: entry.agentSessionId || undefined,
+        resumeSessionFile: entry.agentSessionFile || worker.agentSessionFile || undefined,
+        preservedWorkerInfo: worker,
+      });
+    }
+
+    if (!worker.repoRoot || !worker.branch) {
+      throw new Error(`Archived worker "${sessionName}" is missing repository metadata`);
+    }
     return this.createWorker({
       repoRoot: worker.repoRoot,
       branchName: worker.branch,
@@ -1294,6 +1498,68 @@ export class SessionManager {
         },
       );
     });
+  }
+
+  private normalizeTaskWorkerName(name: string): string {
+    const slug = this.backend.sanitizeSessionName(name.trim());
+    if (!slug) {
+      throw new Error('Task worker name is required.');
+    }
+    return slug;
+  }
+
+  private async assertDirectoryWorkerSessionAvailable(slug: string): Promise<void> {
+    const sessionName = this.backend.buildSessionName(TASK_WORKER_SESSION_NAMESPACE, slug);
+    const state = this.readSessionState();
+    const liveExists = await this.backend.hasSession(sessionName);
+    if (state.workers[sessionName] || state.copilots[sessionName] || liveExists) {
+      throw new Error(`Task worker "${slug}" already exists. Use a different --name or start/delete the existing worker.`);
+    }
+  }
+
+  private ensureDirectoryWorkdir(workdir: string): void {
+    if (fs.existsSync(workdir)) {
+      if (!fs.statSync(workdir).isDirectory()) {
+        throw new Error(`Task worker path is not a directory: ${workdir}`);
+      }
+      return;
+    }
+    fs.mkdirSync(workdir, { recursive: true });
+  }
+
+  private prepareTaskFile(
+    workdir: string,
+    task: string | undefined,
+    taskFile: string | undefined,
+    source: WorkerSource,
+    defaultPromptVerb: 'implement' | 'complete',
+  ): { task?: string; taskFilename?: string } {
+    if (!taskFile) {
+      return { task };
+    }
+
+    const absTaskFile = path.isAbsolute(taskFile) ? taskFile : path.resolve(taskFile);
+    if (!fs.existsSync(absTaskFile)) {
+      if (source === 'directory') {
+        throw new Error(`Task file "${absTaskFile}" not found`);
+      }
+      return { task };
+    }
+
+    const taskFilename = path.basename(absTaskFile);
+    const targetTaskFile = path.join(workdir, taskFilename);
+    if (toCanonicalPath(absTaskFile) !== toCanonicalPath(targetTaskFile)) {
+      fs.copyFileSync(absTaskFile, targetTaskFile);
+    }
+
+    if (!task) {
+      return {
+        task: `Read the task in \`${taskFilename}\` and ${defaultPromptVerb} it.`,
+        taskFilename,
+      };
+    }
+
+    return { task, taskFilename };
   }
 
   private async killSessionOrConfirmAbsent(sessionName: string): Promise<void> {
@@ -1393,9 +1659,21 @@ export class SessionManager {
         };
         // Backward compat: ensure sessionId and displayName fields exist for legacy entries
         for (const w of Object.values(state.workers)) {
+          const source = getWorkerSource(w);
+          w.source ??= source;
           w.sessionId ??= null;
           w.agentSessionFile ??= null;
           w.displayName ??= w.slug || this.extractSlugFromSessionName(w.sessionName);
+          w.managedWorkdir ??= false;
+          if (source === 'directory') {
+            w.repo ??= null;
+            w.repoRoot ??= null;
+            w.branch ??= null;
+          } else {
+            w.repo ??= '';
+            w.repoRoot ??= '';
+            w.branch ??= '';
+          }
         }
         for (const c of Object.values(state.copilots)) {
           c.sessionId ??= null;
@@ -1626,13 +1904,7 @@ export class SessionManager {
   private injectCompletionHook(
     worktreePath: string,
     agentType: string,
-    info: {
-      copilotSessionName: string;
-      sessionName: string;
-      workerId: number;
-      displayName: string;
-      branch: string;
-    },
+    info: WorkerNotificationInfo,
   ): void {
     if (!agentSupportsCompletionNotification(agentType)) {
       return;
@@ -1774,12 +2046,11 @@ export class SessionManager {
 
   private withCodexCompletionHookOverrides(
     agentCommand: string,
-    repoRoot: string,
-    worktreePath: string,
+    trustRootPaths: string[],
     scriptPath: string,
   ): string {
-    const trustRoots = new Set([repoRoot, worktreePath]);
-    for (const trustPath of [repoRoot, worktreePath]) {
+    const trustRoots = new Set(trustRootPaths);
+    for (const trustPath of trustRootPaths) {
       try {
         trustRoots.add(fs.realpathSync(trustPath));
       } catch {
@@ -1809,15 +2080,12 @@ export class SessionManager {
     ].join(' ');
   }
 
-  private buildNotifyScript(info: {
-    copilotSessionName: string;
-    sessionName: string;
-    workerId: number;
-    displayName: string;
-    branch: string;
-  }): string {
+  private buildNotifyScript(info: WorkerNotificationInfo): string {
     const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
     const pendingPath = this.getNotifyPendingPath(info.sessionName);
+    const message = info.source === 'directory'
+      ? 'MSG="Task worker #${WORKER_ID} (${NAME}) has completed. Workdir: ${WORKDIR}. Use \\`hydra worker logs ${SESSION}\\` to review output."'
+      : 'MSG="Worker #${WORKER_ID} (${NAME}) has completed. Branch: ${BRANCH}. Use \\`hydra worker logs ${SESSION}\\` to review output."';
     return [
       '#!/bin/sh',
       '# Auto-generated by Hydra: parent copilot completion notification.',
@@ -1826,7 +2094,8 @@ export class SessionManager {
       `SESSION=${sq(info.sessionName)}`,
       `WORKER_ID=${sq(String(info.workerId))}`,
       `NAME=${sq(info.displayName)}`,
-      `BRANCH=${sq(info.branch)}`,
+      `BRANCH=${sq(info.branch || '')}`,
+      `WORKDIR=${sq(info.workdir)}`,
       `PENDING=${sq(pendingPath)}`,
       'LOCKDIR="${PENDING}.lock"',
       '',
@@ -1851,7 +2120,7 @@ export class SessionManager {
       '# Only notify if copilot session still exists',
       '$t has-session -t "$COPILOT" 2>/dev/null || exit 0',
       '',
-      'MSG="Worker #${WORKER_ID} (${NAME}) has completed. Branch: ${BRANCH}. Use \\`hydra worker logs ${SESSION}\\` to review output."',
+      message,
       '',
       '# Use load-buffer/paste-buffer to avoid the Enter-swallow issue (see PR #122)',
       'f=$(mktemp) || exit 0',
@@ -2348,10 +2617,13 @@ export class SessionManager {
     const repoSessionNamespace = coreGit.getRepoSessionNamespace(repoRoot, this.backend);
     return {
       ...worker,
+      source: 'repo',
       repoRoot: worker.repoRoot || repoRoot,
+      repo: worker.repo || coreGit.getRepoName(repoRoot),
       branch: worker.branch || branchName,
       slug,
       displayName: worker.displayName || slug,
+      managedWorkdir: false,
       sessionName: worker.sessionName || this.backend.buildSessionName(repoSessionNamespace, slug),
       tmuxSession: worker.tmuxSession || worker.sessionName || this.backend.buildSessionName(repoSessionNamespace, slug),
       sessionId: worker.sessionId ?? null,
@@ -2360,11 +2632,11 @@ export class SessionManager {
   }
 
   private workerMatchesRepoBranch(worker: WorkerInfo, repoRoot: string, branchName: string): boolean {
-    if (!worker || worker.branch !== branchName) return false;
+    if (!worker || !isRepoWorker(worker) || worker.branch !== branchName) return false;
     return this.samePath(worker.repoRoot, repoRoot);
   }
 
-  private samePath(left?: string, right?: string): boolean {
+  private samePath(left?: string | null, right?: string | null): boolean {
     const canonicalLeft = toCanonicalPath(left);
     const canonicalRight = toCanonicalPath(right);
     return !!canonicalLeft && !!canonicalRight && canonicalLeft === canonicalRight;
@@ -2469,6 +2741,7 @@ export class SessionManager {
         const existingWorker = state.workers[sessionName] || savedWorker;
         const workerId = existingWorker?.workerId ?? state.nextWorkerId++;
         const nextWorker: WorkerInfo = {
+          source: 'repo',
           sessionName,
           displayName: existingWorker?.displayName || slug,
           workerId,
@@ -2480,6 +2753,7 @@ export class SessionManager {
           attached: false,
           agent,
           workdir,
+          managedWorkdir: false,
           tmuxSession: sessionName,
           createdAt: existingWorker?.createdAt ?? now,
           lastSeenAt: now,
@@ -2580,6 +2854,7 @@ export class SessionManager {
         const currentWorker = state.workers[sessionName] || savedWorker;
         const workerId = currentWorker?.workerId ?? state.nextWorkerId++;
         const nextWorker: WorkerInfo = {
+          source: 'repo',
           sessionName,
           displayName: currentWorker?.displayName || slug,
           workerId,
@@ -2591,6 +2866,7 @@ export class SessionManager {
           attached: false,
           agent: agentType,
           workdir: worktreePath,
+          managedWorkdir: false,
           tmuxSession: sessionName,
           createdAt: currentWorker?.createdAt ?? now,
           lastSeenAt: now,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,10 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.window.onDidChangeActiveTerminal((terminal) => {
       if (!terminal) return;
-      revealSidebarItem(terminal, copilotProvider, workerProvider, copilotView, workerView).then(undefined, () => {});
+      refreshAll();
+      delay(750)
+        .then(() => revealSidebarItem(terminal, copilotProvider, workerProvider, copilotView, workerView))
+        .then(undefined, () => {});
     })
   );
 

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -3,9 +3,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { exec } from '../utils/exec';
 import { getRepoRoot, getBaseBranch } from '../utils/git';
+import { getRepoIdentifier } from '../core/git';
 import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multiplexer';
 import { toCanonicalPath } from '../utils/path';
-import { SessionManager, WorkerInfo } from '../core/sessionManager';
+import { isDirectoryWorker, isRepoWorker, SessionManager, WorkerInfo } from '../core/sessionManager';
 import { CopilotMode, Worktree } from '../core/types';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
@@ -356,13 +357,32 @@ export class RepoGroupItem extends TmuxItem {
     baseBranch?: string
   ) {
     super(repoName, vscode.TreeItemCollapsibleState.Expanded, repoName);
-    this.id = repoRoot;
+    this.id = `repo:${getRepoIdentifier(repoRoot)}`;
     this.contextValue = 'repoGroup';
     this.iconPath = new vscode.ThemeIcon('repo');
     if (baseBranch) {
       const shortName = baseBranch.replace(/^origin\//, '');
       this.description = `[base: ${shortName}]`;
     }
+  }
+
+  updateBaseBranch(baseBranch?: string): void {
+    if (baseBranch) {
+      const shortName = baseBranch.replace(/^origin\//, '');
+      this.description = `[base: ${shortName}]`;
+    } else {
+      this.description = undefined;
+    }
+  }
+}
+
+export class TaskGroupItem extends TmuxItem {
+  constructor() {
+    super('Local Tasks', vscode.TreeItemCollapsibleState.Expanded, 'Local Tasks');
+    this.id = 'hydra-local-tasks';
+    this.contextValue = 'taskGroup';
+    this.iconPath = new vscode.ThemeIcon('folder');
+    this.description = 'folder workers';
   }
 }
 
@@ -391,9 +411,12 @@ export class WorktreeItem extends TmuxItem {
     hasGit: boolean;
     hasTmux: boolean;
     isMainWorktree?: boolean;
+    isTaskWorker?: boolean;
   }) {
     const displayLabel = opts.displayName || opts.branchLabel;
-    const description = opts.isCurrentWorkspace ? 'This project' : undefined;
+    const description = opts.isCurrentWorkspace
+      ? (opts.isTaskWorker ? 'This folder' : 'This project')
+      : undefined;
     super(displayLabel, vscode.TreeItemCollapsibleState.Expanded, opts.repoName, opts.sessionName);
 
     this.isCurrentWorkspace = opts.isCurrentWorkspace;
@@ -405,14 +428,18 @@ export class WorktreeItem extends TmuxItem {
     this.id = opts.sessionName;
     this.description = description;
 
-    this.contextValue = 'workerItem';
+    this.contextValue = opts.isTaskWorker ? 'taskWorkerItem' : 'workerItem';
     this.command = {
       command: 'tmux.attachCreate',
       title: 'Open Session',
       arguments: [this]
     };
 
-    if (!opts.hasGit) {
+    if (opts.isTaskWorker) {
+      this.iconPath = opts.hasTmux
+        ? new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.green'))
+        : new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.green'));
+    } else if (!opts.hasGit) {
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
     } else if (opts.hasTmux) {
       this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.green'));
@@ -556,7 +583,8 @@ export class TmuxSessionItem extends WorktreeItem {
     agentType?: string,
     repoRoot?: string,
     workerId?: number,
-    displayName?: string
+    displayName?: string,
+    isTaskWorker?: boolean
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -571,7 +599,8 @@ export class TmuxSessionItem extends WorktreeItem {
       isCurrentWorkspace,
       hasGit,
       hasTmux: session.status.classification !== 'stopped',
-      isMainWorktree: isRoot
+      isMainWorktree: isRoot,
+      isTaskWorker
     });
 
     this.session = session;
@@ -607,7 +636,8 @@ export class InactiveWorktreeItem extends WorktreeItem {
     branchLabelOverride?: string,
     gitStatusOverride?: SessionStatus,
     repoRoot?: string,
-    displayName?: string
+    displayName?: string,
+    isTaskWorker?: boolean
   ) {
     const branchLabel = branchLabelOverride || worktree.branch || (worktree.isMain ? 'main' : path.basename(worktree.path));
 
@@ -621,10 +651,11 @@ export class InactiveWorktreeItem extends WorktreeItem {
       isCurrentWorkspace,
       hasGit,
       hasTmux: false,
-      isMainWorktree: worktree.isMain
+      isMainWorktree: worktree.isMain,
+      isTaskWorker
     });
 
-    this.contextValue = 'inactiveWorkerItem';
+    this.contextValue = isTaskWorker ? 'inactiveTaskWorkerItem' : 'inactiveWorkerItem';
     this.worktree = worktree;
     this.targetSessionName = targetSessionName;
     this.detailItem = new InactiveDetailItem(worktree, repoName, targetSessionName, extensionUri);
@@ -718,7 +749,6 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
 
   async refreshAndGetCopilotItems(): Promise<CopilotItem[]> {
     await this.getChildren(undefined);
-    this._onDidChangeTreeData.fire(undefined);
     return this._copilotItems;
   }
 
@@ -795,18 +825,29 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private _extensionUri: vscode.Uri | undefined;
   private _repoGroups: RepoGroupItem[] = [];
+  private _repoGroupByRoot = new Map<string, RepoGroupItem>();
+  private _taskGroup: TaskGroupItem | undefined;
   private _workerItemsByRepo = new Map<string, TmuxItem[]>();
+  private _taskWorkerItems: TmuxItem[] = [];
 
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
   refresh(): void {
     this._workerItemsByRepo.clear();
+    this._taskWorkerItems = [];
     this._onDidChangeTreeData.fire(undefined);
   }
   getTreeItem(element: TmuxItem): vscode.TreeItem { return element; }
   getParent(element: TmuxItem): TmuxItem | undefined {
     if (element instanceof RepoGroupItem) return undefined;
+    if (element instanceof TaskGroupItem) return undefined;
     // WorktreeItem/TmuxSessionItem/InactiveWorktreeItem are children of a RepoGroupItem
     if (element instanceof WorktreeItem || element instanceof InactiveWorktreeItem) {
+      if (element.contextValue === 'taskWorkerItem' || element.contextValue === 'inactiveTaskWorkerItem') {
+        return this._taskGroup;
+      }
+      if (element.repoRoot) {
+        return this._repoGroupByRoot.get(element.repoRoot);
+      }
       return this._repoGroups.find(g => g.repoName === element.repoName);
     }
     // Detail items (TmuxDetailItem, GitStatusItem) are children of a WorktreeItem
@@ -820,15 +861,23 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         }
       }
     }
+    for (const item of this._taskWorkerItems) {
+      if (item instanceof TmuxSessionItem) {
+        if (item.detailItem === element || item.gitStatusItem === element) return item;
+      }
+      if (item instanceof InactiveWorktreeItem) {
+        if (item.detailItem === element || item.gitStatusItem === element) return item;
+      }
+    }
     return undefined;
   }
 
   async refreshAndGetWorkerItems(): Promise<TmuxItem[]> {
     const groups = await this.getChildren(undefined);
     await Promise.all(groups.map(g => this.getChildren(g)));
-    this._onDidChangeTreeData.fire(undefined);
     const all: TmuxItem[] = [];
     for (const items of this._workerItemsByRepo.values()) all.push(...items);
+    all.push(...this._taskWorkerItems);
     return all;
   }
 
@@ -840,16 +889,21 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
     if (missingGroups.length > 0) {
       await Promise.all(missingGroups.map(g => this.getRepoGroupChildren(g)));
     }
+    if (this._taskGroup && this._taskWorkerItems.length === 0) {
+      await this.getTaskGroupChildren();
+    }
     const all: TmuxItem[] = [];
     for (const items of this._workerItemsByRepo.values()) {
       all.push(...items);
     }
+    all.push(...this._taskWorkerItems);
     return all;
   }
 
   async getChildren(element?: TmuxItem): Promise<TmuxItem[]> {
     if (!element) return this.getRootItems();
     if (element instanceof RepoGroupItem) return this.getRepoGroupChildren(element);
+    if (element instanceof TaskGroupItem) return this.getTaskGroupChildren();
     if (element instanceof TmuxSessionItem) {
       const children: TmuxItem[] = [element.detailItem];
       if (element.gitStatusItem) children.push(element.gitStatusItem);
@@ -871,17 +925,24 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
 
       if (workers.length === 0) {
         this._repoGroups = [];
+        this._repoGroupByRoot.clear();
+        this._taskGroup = undefined;
         this._workerItemsByRepo.clear();
+        this._taskWorkerItems = [];
         const hint = new TmuxItem('No workers', vscode.TreeItemCollapsibleState.None);
         hint.iconPath = new vscode.ThemeIcon('info');
         hint.description = 'Ask your copilot to create a worker';
         return [hint];
       }
 
+      const repoWorkers = workers.filter(isRepoWorker);
+      const taskWorkers = workers.filter(isDirectoryWorker);
+
       // Group by repo
       const byRepo = new Map<string, { repoRoot: string; repoName: string; workers: WorkerInfo[] }>();
-      for (const w of workers) {
-        const key = w.repoRoot || 'unknown';
+      for (const w of repoWorkers) {
+        if (!w.repoRoot) continue;
+        const key = w.repoRoot;
         let group = byRepo.get(key);
         if (!group) {
           group = { repoRoot: w.repoRoot, repoName: w.repo || 'unknown', workers: [] };
@@ -891,17 +952,38 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
 
       // Always show RepoGroupItem per repo
-      const items: RepoGroupItem[] = [];
+      const items: TmuxItem[] = [];
+      const repoGroupItems: RepoGroupItem[] = [];
       for (const group of byRepo.values()) {
         let baseBranch: string | undefined;
         try { baseBranch = await getBaseBranch(group.repoRoot); } catch { /* */ }
-        items.push(new RepoGroupItem(group.repoName, group.repoRoot, baseBranch));
+        const item = this._repoGroupByRoot.get(group.repoRoot) ||
+          new RepoGroupItem(group.repoName, group.repoRoot, baseBranch);
+        item.updateBaseBranch(baseBranch);
+        this._repoGroupByRoot.set(group.repoRoot, item);
+        repoGroupItems.push(item);
+        items.push(item);
       }
-      this._repoGroups = items;
+      for (const key of this._repoGroupByRoot.keys()) {
+        if (!byRepo.has(key)) {
+          this._repoGroupByRoot.delete(key);
+        }
+      }
+      this._repoGroups = repoGroupItems;
+      this._taskGroup = taskWorkers.length > 0
+        ? (this._taskGroup || new TaskGroupItem())
+        : undefined;
+      this._taskWorkerItems = [];
+      if (this._taskGroup) {
+        items.push(this._taskGroup);
+      }
       return items;
     } catch {
       this._repoGroups = [];
+      this._repoGroupByRoot.clear();
+      this._taskGroup = undefined;
       this._workerItemsByRepo.clear();
+      this._taskWorkerItems = [];
       return [];
     }
   }
@@ -913,6 +995,19 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       const workers = await sm.listWorkers(group.repoRoot);
       const items = await this.buildWorkerItems(workers, group.repoName, group.repoRoot);
       this._workerItemsByRepo.set(group.repoRoot, items);
+      return items;
+    } catch {
+      return [];
+    }
+  }
+
+  private async getTaskGroupChildren(): Promise<TmuxItem[]> {
+    try {
+      const backend = getActiveBackend();
+      const sm = new SessionManager(backend);
+      const workers = (await sm.listWorkers()).filter(isDirectoryWorker);
+      const items = await this.buildTaskWorkerItems(workers);
+      this._taskWorkerItems = items;
       return items;
     } catch {
       return [];
@@ -932,6 +1027,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       const branchLabel = hasGit && w.workdir
         ? await getWorktreeBranchLabel(w.workdir, w.branch || w.slug)
         : (w.branch || w.slug);
+      const worktreeBranch = w.branch || branchLabel;
 
       const pr = prMap.get(branchLabel);
 
@@ -951,13 +1047,13 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           hydraRole: 'worker',
           hydraAgent: w.agent,
         };
-        const worktree: Worktree = { path: w.workdir, branch: w.branch, isMain: false };
+        const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
         items.push(new TmuxSessionItem(
           session, repoName, worktree, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName
         ));
       } else {
-        const worktree: Worktree = { path: w.workdir, branch: w.branch, isMain: false };
+        const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
         const gitStatus = hasGit && w.workdir ? await getWorktreeGitStatus(w.workdir) : undefined;
         let stoppedStatus: SessionStatus | undefined = gitStatus ? {
           attached: false, panes: 0, lastActive: 0, classification: 'stopped', cpuUsage: 0,
@@ -976,6 +1072,58 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         items.push(new InactiveWorktreeItem(
           worktree, repoName, w.sessionName, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, stoppedStatus, repoRoot, w.displayName
+        ));
+      }
+    }
+
+    return sortItems(items);
+  }
+
+  private async buildTaskWorkerItems(workers: WorkerInfo[]): Promise<TmuxItem[]> {
+    const activePath = getActiveWorkspacePath();
+    const repoName = 'Local Tasks';
+    const items: TmuxItem[] = [];
+
+    for (const w of workers) {
+      const isCurrentWs = activePath
+        ? isCurrentWorkspacePath(w.workdir, activePath)
+        : false;
+      const label = w.displayName || w.slug || path.basename(w.workdir);
+      const worktree: Worktree = { path: w.workdir, branch: label, isMain: false };
+
+      if (w.status === 'running') {
+        const status = await getSessionStatus(w.sessionName);
+        const session: SessionWithStatus = {
+          name: w.sessionName,
+          windows: 1,
+          attached: w.attached,
+          status,
+          worktreePath: w.workdir,
+          slug: w.slug,
+          hydraRole: 'worker',
+          hydraAgent: w.agent,
+        };
+        items.push(new TmuxSessionItem(
+          session, repoName, worktree, isCurrentWs, false,
+          this._extensionUri, label, w.agent, undefined, w.workerId, w.displayName, true
+        ));
+      } else {
+        const stoppedStatus: SessionStatus = {
+          attached: false,
+          panes: 0,
+          lastActive: 0,
+          classification: 'stopped',
+          cpuUsage: 0,
+          gitDirty: 0,
+          gitModified: 0,
+          gitAdded: 0,
+          gitDeleted: 0,
+          gitUntracked: 0,
+          commitsAhead: 0,
+        };
+        items.push(new InactiveWorktreeItem(
+          worktree, repoName, w.sessionName, isCurrentWs, false,
+          this._extensionUri, label, stoppedStatus, undefined, w.displayName, true
         ));
       }
     }

--- a/src/share/bundle.ts
+++ b/src/share/bundle.ts
@@ -2,7 +2,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { resolveAgentSessionFile } from '../core/path';
-import type { CopilotInfo, WorkerInfo } from '../core/sessionManager';
+import { isDirectoryWorker, type CopilotInfo, type WorkerInfo } from '../core/sessionManager';
 import { exportCodexNativeSession } from './codexAdapter';
 import { collectRepoInfo } from './repo';
 import type { HydraShareBundle, ShareHydraSessionInfo } from './types';
@@ -41,6 +41,13 @@ function buildHydraSessionInfo(session: ShareableSession, sessionId: string): Sh
     };
   }
 
+  if (isDirectoryWorker(session.data)) {
+    throw new Error('Task workers cannot be shared yet. Share currently supports copilots and code workers only.');
+  }
+  if (!session.data.repo || !session.data.repoRoot || !session.data.branch) {
+    throw new Error(`Code worker "${session.data.sessionName}" is missing repository metadata and cannot be shared.`);
+  }
+
   return {
     type: 'worker',
     sessionName: session.data.sessionName,
@@ -63,6 +70,9 @@ export async function createShareBundle(
   session: ShareableSession,
   shareId = generateShareId(),
 ): Promise<HydraShareBundle> {
+  if (session.type === 'worker' && isDirectoryWorker(session.data)) {
+    throw new Error('Task workers cannot be shared yet. Share currently supports copilots and code workers only.');
+  }
   const sessionId = assertCodexSession(session);
   const repo = await collectRepoInfo(session.data.workdir);
 

--- a/src/smoke/completionHookSmoke.ts
+++ b/src/smoke/completionHookSmoke.ts
@@ -115,7 +115,9 @@ async function main(): Promise<void> {
     sessionName: 'repo_feat-auth',
     workerId: 7,
     displayName: 'feat-auth',
+    source: 'repo',
     branch: 'feat/auth',
+    workdir: fakeWorktree,
   };
 
   // ── Part 1: Verify hook config files for each agent ──
@@ -184,8 +186,7 @@ async function main(): Promise<void> {
 
   const codexLaunch = sm['withCodexCompletionHookOverrides'](
     'codex',
-    '/tmp/hydra-primary-repo',
-    '/tmp/hydra-worker-worktree',
+    ['/tmp/hydra-primary-repo', '/tmp/hydra-worker-worktree'],
     scriptPath,
   );
   assert.ok(codexLaunch.includes('"/tmp/hydra-primary-repo"={trust_level="trusted"}'));
@@ -261,6 +262,7 @@ async function main(): Promise<void> {
         workerId: 71,
         displayName: 'feat-auth-claude',
         branch: 'feat/auth-claude',
+        workdir: runtimeWorktree,
       },
       codex: {
         ...hookInfo,
@@ -269,6 +271,7 @@ async function main(): Promise<void> {
         workerId: 72,
         displayName: 'feat-auth-codex',
         branch: 'feat/auth-codex',
+        workdir: runtimeWorktree,
       },
       gemini: {
         ...hookInfo,
@@ -277,6 +280,7 @@ async function main(): Promise<void> {
         workerId: 73,
         displayName: 'feat-auth-gemini',
         branch: 'feat/auth-gemini',
+        workdir: runtimeWorktree,
       },
     };
     sm['injectCompletionHook'](runtimeWorktree, 'claude', runtimeInfos.claude);

--- a/src/smoke/taskWorkerCliE2eSmoke.ts
+++ b/src/smoke/taskWorkerCliE2eSmoke.ts
@@ -1,0 +1,331 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const cliPath = path.resolve(__dirname, '..', 'cli', 'index.js');
+
+function tmuxAvailable(): boolean {
+  const result = spawnSync('tmux', ['-V'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+function run(
+  args: string[],
+  env: Record<string, string | undefined>,
+  cwd: string,
+  expectSuccess = true,
+): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (expectSuccess && result.status !== 0) {
+    throw new Error(
+      `Command failed: hydra ${args.join(' ')}\nstatus=${result.status}\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+    );
+  }
+
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status,
+  };
+}
+
+function runJson<T>(args: string[], env: Record<string, string | undefined>, cwd: string): T {
+  const result = run(['--json', ...args], env, cwd);
+  return JSON.parse(result.stdout) as T;
+}
+
+function runGit(repoRoot: string, args: string[], env: Record<string, string | undefined>): string {
+  return execFileSync('git', args, { cwd: repoRoot, env, encoding: 'utf-8' }).trim();
+}
+
+function localBranchListed(repoRoot: string, branchName: string, env: Record<string, string | undefined>): boolean {
+  return runGit(repoRoot, ['branch', '--list', branchName], env)
+    .split(/\r?\n/)
+    .map(line => line.replace(/^[*+]\s*/, '').trim())
+    .includes(branchName);
+}
+
+function writeExecutable(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createRepo(repoRoot: string, env: Record<string, string | undefined>): void {
+  fs.mkdirSync(repoRoot, { recursive: true });
+  runGit(repoRoot, ['init', '-b', 'main'], env);
+  runGit(repoRoot, ['config', 'user.email', 'hydra@example.com'], env);
+  runGit(repoRoot, ['config', 'user.name', 'Hydra Smoke'], env);
+  fs.writeFileSync(path.join(repoRoot, 'README.md'), 'initial\n', 'utf-8');
+  runGit(repoRoot, ['add', 'README.md'], env);
+  runGit(repoRoot, ['commit', '-m', 'initial'], env);
+}
+
+function readSessions(hydraHome: string): {
+  workers?: Record<string, {
+    source?: string;
+    repoRoot?: string | null;
+    branch?: string | null;
+    workdir?: string;
+    managedWorkdir?: boolean;
+    status?: string;
+  }>;
+} {
+  return JSON.parse(fs.readFileSync(path.join(hydraHome, 'sessions.json'), 'utf-8'));
+}
+
+function canonicalFsPath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function assertSameFsPath(actual: string, expected: string, message: string): void {
+  assert.equal(canonicalFsPath(actual), canonicalFsPath(expected), message);
+}
+
+function killTmuxServer(socket: string): void {
+  spawnSync('tmux', ['-S', socket, 'kill-server'], { stdio: 'ignore' });
+}
+
+async function main(): Promise<void> {
+  if (!tmuxAvailable()) {
+    console.log('taskWorkerCliE2eSmoke: skipped (tmux not on PATH)');
+    return;
+  }
+  if (!fs.existsSync(cliPath)) {
+    console.log(`taskWorkerCliE2eSmoke: skipped (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-task-cli-e2e-'));
+  const home = path.join(root, 'home');
+  const hydraHome = path.join(root, 'hydra');
+  const configPath = path.join(root, 'config.json');
+  const fakeAgentLog = path.join(root, 'fake-agent.log');
+  const fakeAgent = path.join(root, 'bin', 'fake-agent');
+  const tmuxSocket = path.join(root, 'tmux.sock');
+  const nonGitDir = path.join(root, 'plain-folder');
+  const explicitTaskDir = path.join(root, 'explicit-task');
+  const repoRoot = path.join(root, 'repo');
+
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(hydraHome, { recursive: true });
+  fs.mkdirSync(nonGitDir, { recursive: true });
+  fs.mkdirSync(explicitTaskDir, { recursive: true });
+
+  writeExecutable(fakeAgent, [
+    '#!/bin/sh',
+    `LOG=${JSON.stringify(fakeAgentLog)}`,
+    'printf "START cwd=%s\\n" "$PWD" >> "$LOG"',
+    'while IFS= read -r line; do',
+    '  printf "INPUT cwd=%s line=%s\\n" "$PWD" "$line" >> "$LOG"',
+    '  printf "fake-agent:%s\\n" "$line"',
+    'done',
+    '',
+  ].join('\n'));
+
+  fs.writeFileSync(configPath, JSON.stringify({
+    defaultAgent: 'custom',
+    agentCommands: {
+      custom: fakeAgent,
+    },
+  }, null, 2));
+
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    HYDRA_HOME: hydraHome,
+    HYDRA_CONFIG_PATH: configPath,
+    HYDRA_TMUX_SOCKET: tmuxSocket,
+    HYDRA_TELEMETRY: '0',
+  };
+
+  try {
+    createRepo(repoRoot, env);
+
+    const missingBranch = run(['--json', 'worker', 'create'], env, repoRoot, false);
+    assert.equal(missingBranch.status, 2, 'git repo default create should be a validation error');
+    const missingBranchError = JSON.parse(missingBranch.stderr) as { error: { message: string } };
+    assert.match(missingBranchError.error.message, /--branch is required/, 'missing branch error should guide code worker creation');
+
+    const defaultTask = runJson<{
+      status: string;
+      type: string;
+      name: string;
+      session: string;
+      workdir: string;
+      managedWorkdir: boolean;
+    }>(['worker', 'create', '--task', 'default task prompt'], env, nonGitDir);
+    assert.equal(defaultTask.status, 'created');
+    assert.equal(defaultTask.type, 'task');
+    assert.equal(defaultTask.name, path.basename(nonGitDir));
+    assertSameFsPath(defaultTask.workdir, nonGitDir, 'default task should use current non-git directory');
+    assert.equal(defaultTask.managedWorkdir, false);
+
+    let sessions = readSessions(hydraHome);
+    assert.equal(sessions.workers?.[defaultTask.session]?.source, 'directory');
+    assert.equal(sessions.workers?.[defaultTask.session]?.branch, null);
+    assert.equal(sessions.workers?.[defaultTask.session]?.repoRoot, null);
+
+    const listAfterDefault = runJson<{
+      workers: Array<{ session: string; type: string; name: string; managedWorkdir: boolean }>;
+    }>(['list'], env, root);
+    const listedDefault = listAfterDefault.workers.find(worker => worker.session === defaultTask.session);
+    assert.equal(listedDefault?.type, 'task');
+    assert.equal(listedDefault?.managedWorkdir, false);
+
+    const sendResult = runJson<{ status: string }>([
+      'worker', 'send', defaultTask.session, 'follow-up from e2e',
+    ], env, root);
+    assert.equal(sendResult.status, 'sent');
+    await sleep(300);
+    const logs = runJson<{ output: string }>([
+      'worker', 'logs', defaultTask.session, '--lines', '80',
+    ], env, root);
+    assert.match(logs.output, /follow-up from e2e/, 'worker logs should include sent follow-up');
+
+    const stopResult = runJson<{ status: string }>(['worker', 'stop', defaultTask.session], env, root);
+    assert.equal(stopResult.status, 'stopped');
+    sessions = readSessions(hydraHome);
+    assert.equal(sessions.workers?.[defaultTask.session]?.status, 'stopped');
+
+    const startResult = runJson<{ status: string; session: string; workdir: string }>([
+      'worker', 'start', defaultTask.session,
+    ], env, root);
+    assert.equal(startResult.status, 'started');
+    assertSameFsPath(startResult.workdir, nonGitDir, 'started task should use saved workdir');
+
+    const unmanagedDeleteFiles = run([
+      '--json', 'worker', 'delete', defaultTask.session, '--delete-files',
+    ], env, root, false);
+    assert.equal(unmanagedDeleteFiles.status, 2, 'unmanaged task delete-files should be validation error');
+    assert.ok(fs.existsSync(nonGitDir), 'unmanaged task directory must survive rejected delete-files');
+
+    const deleteDefault = runJson<{ status: string }>(['worker', 'delete', defaultTask.session], env, root);
+    assert.equal(deleteDefault.status, 'deleted');
+    assert.ok(fs.existsSync(nonGitDir), 'unmanaged task directory must survive normal delete');
+
+    const explicitTask = runJson<{
+      type: string;
+      session: string;
+      name: string;
+      workdir: string;
+      managedWorkdir: boolean;
+    }>([
+      'worker', 'create', '--dir', explicitTaskDir, '--name', 'explicit-task', '--task', 'explicit prompt',
+    ], env, repoRoot);
+    assert.equal(explicitTask.type, 'task');
+    assert.equal(explicitTask.name, 'explicit-task');
+    assertSameFsPath(explicitTask.workdir, explicitTaskDir, 'explicit task should use --dir path');
+    assert.equal(explicitTask.managedWorkdir, false);
+
+    const deleteExplicit = runJson<{ status: string }>(['worker', 'delete', explicitTask.session], env, root);
+    assert.equal(deleteExplicit.status, 'deleted');
+    assert.ok(fs.existsSync(explicitTaskDir), 'explicit task directory should survive delete before restore');
+
+    const restoredExplicit = runJson<{
+      status: string;
+      type: string;
+      workerType: string;
+      session: string;
+      name: string;
+      workdir: string;
+    }>(['archive', 'restore', explicitTask.session], env, root);
+    assert.equal(restoredExplicit.status, 'restored');
+    assert.equal(restoredExplicit.type, 'worker');
+    assert.equal(restoredExplicit.workerType, 'task');
+    assert.equal(restoredExplicit.session, explicitTask.session);
+    assert.equal(restoredExplicit.name, 'explicit-task');
+    assertSameFsPath(restoredExplicit.workdir, explicitTaskDir, 'restored explicit task should use original --dir path');
+
+    sessions = readSessions(hydraHome);
+    assert.equal(sessions.workers?.[explicitTask.session]?.source, 'directory');
+    assert.equal(sessions.workers?.[explicitTask.session]?.managedWorkdir, false);
+
+    const deleteRestoredExplicit = runJson<{ status: string }>(['worker', 'delete', explicitTask.session], env, root);
+    assert.equal(deleteRestoredExplicit.status, 'deleted');
+    assert.ok(fs.existsSync(explicitTaskDir), 'explicit task directory should survive delete after restore');
+
+    const managedTask = runJson<{
+      type: string;
+      session: string;
+      workdir: string;
+      managedWorkdir: boolean;
+    }>([
+      'worker', 'create', '--temp', '--name', 'managed-e2e', '--task', 'managed prompt',
+    ], env, root);
+    assert.equal(managedTask.type, 'task');
+    assert.equal(managedTask.managedWorkdir, true);
+    assert.equal(managedTask.workdir, path.join(hydraHome, 'tasks', 'managed-e2e'));
+    assert.ok(fs.existsSync(managedTask.workdir), 'managed task workdir should exist');
+
+    const managedKeep = runJson<{ status: string }>(['worker', 'delete', managedTask.session], env, root);
+    assert.equal(managedKeep.status, 'deleted');
+    assert.ok(fs.existsSync(managedTask.workdir), 'managed task workdir should survive default delete');
+
+    const managedTaskForDelete = runJson<{
+      session: string;
+      workdir: string;
+    }>([
+      'worker', 'create', '--temp', '--name', 'managed-delete-e2e',
+    ], env, root);
+    assert.ok(fs.existsSync(managedTaskForDelete.workdir), 'managed delete workdir should exist before delete');
+    const managedDelete = runJson<{ status: string; deleteFiles: boolean }>([
+      'worker', 'delete', managedTaskForDelete.session, '--delete-files',
+    ], env, root);
+    assert.equal(managedDelete.status, 'deleted');
+    assert.equal(managedDelete.deleteFiles, true);
+    assert.equal(fs.existsSync(managedTaskForDelete.workdir), false, 'managed delete-files should remove workdir');
+
+    const codeWorker = runJson<{
+      status: string;
+      type: string;
+      session: string;
+      branch: string;
+      workdir: string;
+    }>([
+      'worker', 'create', '--branch', 'feat/e2e-code-worker', '--task', 'code worker prompt',
+    ], env, repoRoot);
+    assert.equal(codeWorker.status, 'created');
+    assert.equal(codeWorker.type, 'code');
+    assert.equal(codeWorker.branch, 'feat/e2e-code-worker');
+    assert.ok(fs.existsSync(codeWorker.workdir), 'code worker worktree should exist');
+    assert.equal(localBranchListed(repoRoot, 'feat/e2e-code-worker', env), true);
+
+    sessions = readSessions(hydraHome);
+    assert.equal(sessions.workers?.[codeWorker.session]?.source, 'repo');
+    assertSameFsPath(sessions.workers?.[codeWorker.session]?.repoRoot || '', repoRoot, 'code worker should persist repo root');
+    assert.equal(sessions.workers?.[codeWorker.session]?.branch, 'feat/e2e-code-worker');
+
+    const codeDelete = runJson<{ status: string }>(['worker', 'delete', codeWorker.session], env, root);
+    assert.equal(codeDelete.status, 'deleted');
+    assert.equal(fs.existsSync(codeWorker.workdir), false, 'code worker delete should remove worktree');
+    assert.equal(localBranchListed(repoRoot, 'feat/e2e-code-worker', env), false);
+
+    console.log('taskWorkerCliE2eSmoke: ok');
+  } finally {
+    killTmuxServer(tmuxSocket);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/smoke/taskWorkerSmoke.ts
+++ b/src/smoke/taskWorkerSmoke.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  HydraRole,
+  MultiplexerBackendCore,
+  MultiplexerSession,
+  SessionStatusInfo,
+} from '../core/types';
+
+class TaskWorkerBackend implements MultiplexerBackendCore {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'fake-tmux';
+  readonly installHint = 'not needed';
+
+  readonly sessions = new Set<string>();
+  readonly workdirs = new Map<string, string>();
+  readonly roles = new Map<string, HydraRole>();
+  readonly agents = new Map<string, string>();
+  readonly keys: Array<{ sessionName: string; keys: string }> = [];
+  readonly messages: Array<{ sessionName: string; message: string }> = [];
+  readonly killed: string[] = [];
+
+  async isInstalled(): Promise<boolean> {
+    return true;
+  }
+
+  async listSessions(): Promise<MultiplexerSession[]> {
+    return [...this.sessions].map(name => ({
+      name,
+      windows: 1,
+      attached: false,
+      workdir: this.workdirs.get(name),
+      slug: name,
+    }));
+  }
+
+  async createSession(sessionName: string, workdir: string): Promise<void> {
+    this.sessions.add(sessionName);
+    this.workdirs.set(sessionName, workdir);
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    this.sessions.delete(sessionName);
+    this.killed.push(sessionName);
+  }
+
+  async renameSession(oldName: string, newName: string): Promise<void> {
+    if (!this.sessions.delete(oldName)) return;
+    this.sessions.add(newName);
+    const workdir = this.workdirs.get(oldName);
+    if (workdir) this.workdirs.set(newName, workdir);
+  }
+
+  async hasSession(sessionName: string): Promise<boolean> {
+    return this.sessions.has(sessionName);
+  }
+
+  async getSessionWorkdir(sessionName: string): Promise<string | undefined> {
+    return this.workdirs.get(sessionName);
+  }
+
+  async setSessionWorkdir(sessionName: string, workdir: string): Promise<void> {
+    this.workdirs.set(sessionName, workdir);
+  }
+
+  async getSessionRole(sessionName: string): Promise<HydraRole | undefined> {
+    return this.roles.get(sessionName);
+  }
+
+  async setSessionRole(sessionName: string, role: HydraRole): Promise<void> {
+    this.roles.set(sessionName, role);
+  }
+
+  async getSessionAgent(sessionName: string): Promise<string | undefined> {
+    return this.agents.get(sessionName);
+  }
+
+  async setSessionAgent(sessionName: string, agent: string): Promise<void> {
+    this.agents.set(sessionName, agent);
+  }
+
+  async sendKeys(sessionName: string, keys: string): Promise<void> {
+    this.keys.push({ sessionName, keys });
+  }
+
+  async capturePane(): Promise<string> {
+    return '⏵';
+  }
+
+  async sendMessage(sessionName: string, message: string): Promise<void> {
+    this.messages.push({ sessionName, message });
+  }
+
+  async getSessionInfo(): Promise<SessionStatusInfo> {
+    return { attached: false, lastActive: Math.floor(Date.now() / 1000) };
+  }
+
+  async getSessionPaneCount(): Promise<number> {
+    return 1;
+  }
+
+  async getSessionPanePids(): Promise<string[]> {
+    return [];
+  }
+
+  async splitPane(): Promise<void> {
+    return;
+  }
+
+  async newWindow(): Promise<void> {
+    return;
+  }
+
+  buildSessionName(namespace: string, slug: string): string {
+    return `${namespace}_${slug}`;
+  }
+
+  sanitizeSessionName(name: string): string {
+    return name.trim().replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+}
+
+async function main(): Promise<void> {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-task-worker-'));
+  process.env.HOME = tempHome;
+  process.env.HYDRA_HOME = path.join(tempHome, '.hydra');
+  delete process.env.HYDRA_CONFIG_PATH;
+
+  const { SessionManager } = await import('../core/sessionManager');
+  const { getHydraArchiveFile, getHydraSessionsFile, getHydraTasksRoot } = await import('../core/path');
+
+  const backend = new TaskWorkerBackend();
+  const sm = new SessionManager(backend);
+  const userDir = path.join(tempHome, 'research notes');
+  fs.mkdirSync(userDir, { recursive: true });
+
+  const unmanaged = await sm.createDirectoryWorker({
+    workdir: userDir,
+    agentType: 'claude',
+    task: 'summarize the notes',
+  });
+  await unmanaged.postCreatePromise;
+
+  assert.equal(unmanaged.workerInfo.source, 'directory');
+  assert.equal(unmanaged.workerInfo.displayName, 'research-notes');
+  assert.equal(unmanaged.workerInfo.repoRoot, null);
+  assert.equal(unmanaged.workerInfo.branch, null);
+  assert.equal(unmanaged.workerInfo.managedWorkdir, false);
+  assert.equal(unmanaged.workerInfo.workdir, userDir);
+  assert.equal(backend.messages.at(-1)?.message, 'summarize the notes');
+
+  await assert.rejects(
+    () => sm.deleteWorker(unmanaged.workerInfo.sessionName, { deleteFiles: true }),
+    /user-provided directory/,
+  );
+  assert.ok(fs.existsSync(userDir), 'unmanaged directory should survive rejected delete');
+  assert.equal(backend.killed.includes(unmanaged.workerInfo.sessionName), false);
+
+  await sm.deleteWorker(unmanaged.workerInfo.sessionName);
+  assert.ok(fs.existsSync(userDir), 'unmanaged directory should survive normal delete');
+  const stateAfterDelete = readJson<{ workers: Record<string, unknown> }>(getHydraSessionsFile());
+  assert.equal(stateAfterDelete.workers[unmanaged.workerInfo.sessionName], undefined);
+
+  const archive = readJson<{ entries: Array<{ sessionName: string; data: { source?: string } }> }>(getHydraArchiveFile());
+  const archived = archive.entries.find(entry => entry.sessionName === unmanaged.workerInfo.sessionName);
+  assert.equal(archived?.data.source, 'directory');
+
+  const managed = await sm.createDirectoryWorker({
+    managedWorkdir: true,
+    name: 'temp-report',
+    agentType: 'claude',
+  });
+  await managed.postCreatePromise;
+
+  assert.equal(managed.workerInfo.managedWorkdir, true);
+  assert.equal(managed.workerInfo.workdir, path.join(getHydraTasksRoot(), 'temp-report'));
+  assert.ok(fs.existsSync(managed.workerInfo.workdir), 'managed task directory should be created');
+
+  await sm.deleteWorker(managed.workerInfo.sessionName);
+  assert.ok(fs.existsSync(managed.workerInfo.workdir), 'managed task directory should survive default delete');
+
+  const managedDeleteFiles = await sm.createDirectoryWorker({
+    managedWorkdir: true,
+    name: 'temp-delete-files',
+    agentType: 'claude',
+  });
+  await managedDeleteFiles.postCreatePromise;
+  const managedDeletePath = managedDeleteFiles.workerInfo.workdir;
+  await sm.deleteWorker(managedDeleteFiles.workerInfo.sessionName, { deleteFiles: true });
+  assert.equal(fs.existsSync(managedDeletePath), false, 'managed task directory should be deleted with deleteFiles');
+
+  fs.rmSync(tempHome, { recursive: true, force: true });
+  console.log('taskWorkerSmoke: ok');
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds first-class Task Worker support alongside existing Code Workers for issue #191.

- Introduces directory-backed task workers with `--dir`, `--temp`, and `--name` CLI flows.
- Keeps git-backed code workers explicit: git repos require `--branch`; non-git directories default to a task worker.
- Updates lifecycle behavior, archive restore, list/whoami output, sidebar grouping under `Local Tasks`, UI create flow, and docs.
- Preserves conservative cleanup: task worker files are kept by default; only Hydra-managed temp folders can be removed with `--delete-files`.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:task-worker-cli-e2e`
- `npm test`
- `git diff --check`
- Manual VS Code Extension Development Host testing with real UI flows for git task worker, git code worker, and non-git task worker.
