### PR TITLE
chore: release v0.3.2026060100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026060100] - 2026-06-01
+
+### Added
+- Add first-class Task Workers for folder-based AI work without a git repo, including CLI create/delete flows, VS Code create-worker UX, Local Tasks sidebar grouping, archive restore, docs, and smoke/e2e coverage
+
 ## [0.3.2026052800] - 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026052800",
+  "version": "0.3.2026060100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026052800",
+      "version": "0.3.2026060100",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026052800",
+  "version": "0.3.2026060100",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026060100.

## Changes

- Adds first-class Task Workers for folder-based AI work without a git repo.
- Includes CLI create/delete flows, VS Code create-worker UX, Local Tasks sidebar grouping, archive restore, documentation, and smoke/e2e coverage.

## Validation

- `npm run compile`
- `npm run lint`
- `git diff --check`

After this PR merges, the auto-tag workflow should create `v0.3.2026060100` and trigger publishing.
