### PR TITLE
fix(tmux): treat silent psmux has-session failure as missing session (#195)

### DIFF
--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -10,6 +10,7 @@ import { MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo, HydraRol
 interface ExecFailure extends Error {
   stderr?: string;
   stdout?: string;
+  code?: number | string;
 }
 
 const TMUX_ENV_KEYS_TO_STRIP = [
@@ -140,6 +141,21 @@ function isTmuxMissingSessionError(error: unknown): boolean {
     || text.includes('session not found');
 }
 
+// psmux (the Windows tmux port) exits non-zero with empty stderr when
+// `has-session` finds no match, so the keyword-based detectors above can't
+// recognize the "missing session" signal there. Silent non-zero exits with no
+// diagnostic output are reserved by tmux/psmux for "the command ran, the
+// answer is no" — real failures (binary not found, socket errors, permission
+// issues) always produce stderr, so they still bubble up as TmuxUnavailableError.
+function isSilentExecFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const failure = error as ExecFailure;
+  if (typeof failure.code !== 'number' || failure.code === 0) return false;
+  const stderr = (failure.stderr ?? '').trim();
+  const stdout = (failure.stdout ?? '').trim();
+  return stderr === '' && stdout === '';
+}
+
 export class TmuxUnavailableError extends Error {
   constructor(message: string) {
     super(message);
@@ -205,7 +221,11 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
       await exec(`${tmuxCommand} has-session -t ${shellQuote(sessionName)}`);
       return true;
     } catch (error) {
-      if (isTmuxNoServerError(error) || isTmuxMissingSessionError(error)) {
+      if (
+        isTmuxNoServerError(error)
+        || isTmuxMissingSessionError(error)
+        || isSilentExecFailure(error)
+      ) {
         return false;
       }
       throw new TmuxUnavailableError(`Unable to inspect tmux session "${sessionName}": ${getExecFailureText(error)}`);

--- a/src/smoke/workerDeleteFailClosedSmoke.ts
+++ b/src/smoke/workerDeleteFailClosedSmoke.ts
@@ -12,6 +12,7 @@ import type {
 type ExecFailure = Error & {
   stderr?: string;
   stdout?: string;
+  code?: number | string;
 };
 
 type WorkerRecord = {
@@ -148,10 +149,13 @@ class DeleteWorkerBackend implements MultiplexerBackendCore {
   }
 }
 
-function makeExecError(message: string, stderr?: string, stdout?: string): ExecFailure {
+function makeExecError(message: string, stderr?: string, stdout?: string, code?: number | string): ExecFailure {
   const error = new Error(message) as ExecFailure;
   error.stderr = stderr;
   error.stdout = stdout;
+  if (code !== undefined) {
+    error.code = code;
+  }
   return error;
 }
 
@@ -401,6 +405,29 @@ async function main(): Promise<void> {
           return true;
         },
       );
+    } finally {
+      restoreExec();
+    }
+  }
+
+  // Regression for issue #195: psmux on Windows exits non-zero with empty
+  // stderr when has-session finds no match. The keyword detectors don't
+  // recognize that, so the silent-exit branch must treat it as "missing".
+  {
+    const restoreExec = patchModule(coreExec, {
+      exec: async () => {
+        throw makeExecError(
+          'Command failed: psmux has-session -t "hydra-copilot-codex"',
+          '',
+          '',
+          1,
+        );
+      },
+    });
+
+    try {
+      const backend = new TmuxBackendCore();
+      assert.equal(await backend.hasSession('hydra-copilot-codex'), false);
     } finally {
       restoreExec();
     }


### PR DESCRIPTION
## Summary

Fix issue #195: on Windows, `hydra.createCopilot` fails with `Unable to inspect tmux session "hydra-copilot-codex": Command failed: psmux has-session -t ...`, even though psmux is installed and working.

## Root cause

`TmuxBackendCore.hasSession()` recognizes "session does not exist" purely via two keyword-based stderr detectors:

- `isTmuxNoServerError` — matches `no server running` / `error connecting to ... no such file or directory`
- `isTmuxMissingSessionError` — matches `can't find session` / `no such session` / `session not found`

psmux (the Windows tmux port) exits with **code 1 and an empty stderr/stdout** when `has-session` finds no match — there is no diagnostic text to keyword-match. Both detectors miss, the catch falls through, and `hasSession()` throws `TmuxUnavailableError`, which `createCopilot` surfaces as the user-visible error.

Per psmux's documented protocol, `has-session` uses the exit code (0/non-zero) to signal existence, with no stderr in either case. So a silent non-zero exit is a contract for "not found", not a real failure.

## Fix

Add a third detector, `isSilentExecFailure`, that returns `true` only when:

- `error.code` is a **number** (excludes `'ENOENT'`-style string codes for "binary not found")
- `error.code !== 0`
- both `stderr` and `stdout` are empty after trim

This is added only inside `hasSession()`'s catch — not as a global replacement of the existing detectors, and not pushed down into the shared `getExecFailureText` helper. Real failures (binary missing, socket errors, permission issues) still produce stderr and continue to throw `TmuxUnavailableError`. macOS/Linux tmux has stderr when missing a session, so the new branch never fires there — zero behavior change on non-Windows.

## Test

- New regression case in `src/smoke/workerDeleteFailClosedSmoke.ts` that simulates psmux's silent non-zero exit (`code: 1`, empty stderr/stdout) and asserts `hasSession()` returns `false`.
- `npm run compile && npm run lint && npm run smoke:worker-delete` all pass.
- Other smoke tests pass; the unrelated `smoke:codex-bypass` failure already exists on `main` in this local env (`/Applications/Codex.app` overrides the mocked PATH) and is not affected by this change.

## Known gap

Could not reproduce end-to-end on Windows from a macOS host — the fix is driven by psmux's documented `has-session` semantics + the error text in #195 + Node `child_process` error shape. Windows verification by the issue reporter would be appreciated.

Closes #195