### PR TITLE
chore: release v0.3.2026060300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026060300] - 2026-06-03
+
+### Fixed
+- Treat silent psmux `has-session` failures as missing sessions so Hydra can recover cleanly when checking tmux session state
+
 ## [0.3.2026060100] - 2026-06-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026060100",
+  "version": "0.3.2026060300",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026060100",
+      "version": "0.3.2026060300",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026060100",
+  "version": "0.3.2026060300",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026060300.

## Changes

- Fixes psmux `has-session` handling so silent failures are treated as missing sessions and Hydra can recover cleanly while checking tmux session state.

## Validation

- `npm ci`
- `npm run compile`
- `npm run lint`
- `git diff --check`

After this PR merges, the auto-tag workflow should create `v0.3.2026060300` and trigger publishing.
