### PR TITLE
feat: UX improvements for copilot creation and display (fixes #210)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,28 +81,36 @@
       },
       {
         "view": "hydraCopilots",
-        "contents": "[Start Copilot (Claude)](command:hydra.startCopilotClaude)",
+        "contents": "[Create Copilot (Claude)](command:hydra.startCopilotClaude)",
         "when": "hydra.claudeAvailable"
       },
       {
         "view": "hydraCopilots",
-        "contents": "[Start Copilot (Codex)](command:hydra.startCopilotCodex)",
+        "contents": "[Create Copilot (Codex)](command:hydra.startCopilotCodex)",
         "when": "hydra.codexAvailable"
       },
       {
         "view": "hydraCopilots",
-        "contents": "[Start Copilot (Gemini)](command:hydra.startCopilotGemini)",
+        "contents": "[Create Copilot (Gemini)](command:hydra.startCopilotGemini)",
         "when": "hydra.geminiAvailable"
       },
       {
         "view": "hydraCopilots",
-        "contents": "[Start Copilot (Sudo Code)](command:hydra.startCopilotSudoCode)",
+        "contents": "[Create Copilot (Sudo Code)](command:hydra.startCopilotSudoCode)",
         "when": "hydra.sudocodeAvailable"
       },
       {
         "view": "hydraCopilots",
         "contents": "No supported agents found on PATH.\nInstall [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or Sudo Code.",
         "when": "hydra.noAgentsAvailable"
+      },
+      {
+        "view": "hydraWorkers",
+        "contents": "No workers running."
+      },
+      {
+        "view": "hydraWorkers",
+        "contents": "Ask a copilot to create workers with `hydra worker create`."
       }
     ],
     "commands": [
@@ -171,7 +179,7 @@
       {
         "command": "hydra.createCopilot",
         "title": "Hydra: Create Copilot",
-        "icon": "$(hubot)"
+        "icon": "$(add)"
       },
       {
         "command": "hydra.startPlanCopilot",

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -77,6 +77,81 @@ function agentSupportsPlanner(agentType: AgentType): boolean {
   return agentType === 'claude' || agentType === 'codex';
 }
 
+/**
+ * Get the default working directory for a copilot.
+ * Priority: workspace folder (if git repo) > home directory
+ */
+function getDefaultWorkdir(): string {
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    // Return workspace folder (may or may not be a git repo)
+    return folders[0].uri.fsPath;
+  }
+  return os.homedir();
+}
+
+interface WorkdirOption {
+  label: string;
+  description: string;
+  detail?: string;
+  value: string;
+}
+
+/**
+ * Prompt user to select working directory for copilot.
+ * Returns undefined if user cancels.
+ */
+async function pickWorkdir(defaultDir: string): Promise<string | undefined> {
+  const homeDir = os.homedir();
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+  const options: WorkdirOption[] = [
+    {
+      label: '$(folder) Default',
+      description: defaultDir === homeDir ? 'Home directory' : 'Current workspace',
+      detail: defaultDir,
+      value: defaultDir,
+    },
+  ];
+
+  if (workspaceFolder && workspaceFolder !== defaultDir) {
+    options.push({
+      label: '$(home) Home',
+      description: 'Home directory',
+      detail: homeDir,
+      value: homeDir,
+    });
+  }
+
+  options.push({
+    label: '$(file-directory) Browse...',
+    description: 'Choose a custom directory',
+    detail: 'Open folder picker to select a different working directory',
+    value: '__browse__',
+  });
+
+  const picked = await vscode.window.showQuickPick(options, {
+    placeHolder: 'Select working directory for copilot',
+  });
+
+  if (!picked) {
+    return undefined;
+  }
+
+  if (picked.value === '__browse__') {
+    const uri = await vscode.window.showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      defaultUri: vscode.Uri.file(defaultDir),
+      openLabel: 'Select Working Directory',
+    });
+    return uri?.[0]?.fsPath;
+  }
+
+  return picked.value;
+}
+
 async function pickModeForAgent(agentType: AgentType): Promise<CopilotMode | undefined> {
   if (!agentSupportsPlanner(agentType)) {
     return 'normal';
@@ -132,10 +207,15 @@ export async function createCopilotWithAgent(agentType: AgentType, copilotMode?:
     return;
   }
 
+  // Prompt for working directory
+  const defaultWorkdir = getDefaultWorkdir();
+  const workdir = await pickWorkdir(defaultWorkdir);
+  if (!workdir) return;
+
   try {
     const sm = new SessionManager(new TmuxBackendCore());
     const copilotInfo = await sm.createCopilotAndFinalize({
-      workdir: os.homedir(),
+      workdir,
       agentType,
       copilotMode: resolvedMode,
       sessionName,
@@ -197,10 +277,15 @@ export async function createCopilot(): Promise<void> {
     return;
   }
 
+  // Prompt for working directory
+  const defaultWorkdir = getDefaultWorkdir();
+  const workdir = await pickWorkdir(defaultWorkdir);
+  if (!workdir) return;
+
   try {
     const sm = new SessionManager(new TmuxBackendCore());
     const copilotInfo = await sm.createCopilotAndFinalize({
-      workdir: os.homedir(),
+      workdir,
       agentType,
       copilotMode,
       sessionName,

--- a/src/providers/buttonItem.ts
+++ b/src/providers/buttonItem.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import { TmuxItem } from './tmuxSessionProvider';
+
+/**
+ * Fixed button item for creating new copilots/workers.
+ * These items appear at the end of the tree view when there are existing items,
+ * providing a quick way to create new sessions without scrolling back to the top.
+ */
+export class CreateButtonItem extends TmuxItem {
+  constructor(
+    public readonly commandId: string,
+    label: string,
+    itemDescription?: string,
+    itemTooltip?: string
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = 'createButtonItem';
+    this.description = itemDescription;
+    this.tooltip = itemTooltip || label;
+    this.iconPath = new vscode.ThemeIcon('add');
+    this.command = {
+      command: commandId,
+      title: label,
+    };
+  }
+}
+
+/**
+ * Create button for copilots - shows available agent options.
+ */
+export class CreateCopilotButtonItem extends CreateButtonItem {
+  constructor(agentType?: string) {
+    if (agentType) {
+      super(
+        `hydra.startCopilot${agentType.charAt(0).toUpperCase() + agentType.slice(1)}`,
+        `Create ${agentType} Copilot`,
+        undefined,
+        `Create a new ${agentType} copilot session`
+      );
+    } else {
+      super(
+        'hydra.createCopilot',
+        'Create Copilot...',
+        undefined,
+        'Create a new copilot session'
+      );
+    }
+  }
+}
+
+/**
+ * Create button for workers.
+ */
+export class CreateWorkerButtonItem extends CreateButtonItem {
+  constructor() {
+    super(
+      'hydra.createWorker',
+      'Create Worker...',
+      undefined,
+      'Create a new worker session'
+    );
+  }
+}

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { exec } from '../utils/exec';
 import { getRepoRoot, getBaseBranch } from '../utils/git';
@@ -8,6 +9,7 @@ import { getActiveBackend, MultiplexerSession, HydraRole } from '../utils/multip
 import { toCanonicalPath } from '../utils/path';
 import { isDirectoryWorker, isRepoWorker, SessionManager, WorkerInfo } from '../core/sessionManager';
 import { CopilotMode, Worktree } from '../core/types';
+import { CreateCopilotButtonItem, CreateWorkerButtonItem } from './buttonItem';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
 
@@ -42,6 +44,47 @@ function isCurrentWorkspacePath(targetPath: string | undefined, activeWorkspaceP
 }
 
 // ─── Utility ──────────────────────────────────────────────
+
+/**
+ * Shorten a path for display, showing more context.
+ * Examples:
+ *   /Users/bgd/projects/hydra → ~/projects/hydra
+ *   /Users/bgd → ~
+ *   /Users/bgd/.hydra/worktrees/xxx/branch → ~/.hydra/.../branch
+ */
+export function shortenPath(fullPath: string): string {
+  const homeDir = os.homedir();
+  let shortPath = fullPath;
+
+  // Replace home directory with ~
+  if (shortPath.startsWith(homeDir)) {
+    shortPath = '~' + shortPath.slice(homeDir.length);
+  }
+
+  // For hydra worktrees, show abbreviated form
+  if (shortPath.includes('.hydra/worktrees/')) {
+    const parts = shortPath.split('/');
+    const worktreesIdx = parts.findIndex(p => p === '.hydra' && parts[parts.indexOf(p) + 1] === 'worktrees');
+    if (worktreesIdx !== -1 && parts.length > worktreesIdx + 3) {
+      // Show ~/.hydra/.../repo-identifier/branch
+      const repoId = parts[worktreesIdx + 2];
+      const branch = parts[parts.length - 1];
+      shortPath = `~/.hydra/.../${repoId}/${branch}`;
+    }
+  }
+
+  // For hydra tasks, show abbreviated form
+  if (shortPath.includes('.hydra/tasks/')) {
+    const parts = shortPath.split('/');
+    const tasksIdx = parts.findIndex(p => p === '.hydra' && parts[parts.indexOf(p) + 1] === 'tasks');
+    if (tasksIdx !== -1 && parts.length > tasksIdx + 2) {
+      const taskSlug = parts[tasksIdx + 2];
+      shortPath = `~/.hydra/tasks/${taskSlug}`;
+    }
+  }
+
+  return shortPath;
+}
 
 export function formatLastActive(sessionActivity: number): string {
   if (sessionActivity === 0) return '-';
@@ -319,9 +362,12 @@ export class CopilotItem extends TmuxItem {
   }) {
     const label = opts.displayName || opts.sessionName;
     const copilotMode = opts.copilotMode || 'normal';
-    const description = copilotMode === 'plan'
-      ? `[${opts.agentType}] [planner]`
-      : `[${opts.agentType}]`;
+    const modeLabel = copilotMode === 'plan' ? 'planner' : 'copilot';
+    const descParts = [opts.agentType, modeLabel];
+    if (opts.worktreePath) {
+      descParts.push(shortenPath(opts.worktreePath));
+    }
+    const description = `[${descParts.join(' | ')}]`;
     super(label, vscode.TreeItemCollapsibleState.Expanded, undefined, opts.sessionName);
 
     this.worktreePath = opts.worktreePath;
@@ -336,6 +382,18 @@ export class CopilotItem extends TmuxItem {
       title: 'Open Session',
       arguments: [this]
     };
+
+    // Build detailed tooltip
+    const tooltipParts = [
+      `Session: ${opts.sessionName}`,
+      `Agent: ${opts.agentType}`,
+      `Mode: ${modeLabel}`,
+    ];
+    if (opts.worktreePath) {
+      tooltipParts.push(`Working directory: ${opts.worktreePath}`);
+    }
+    tooltipParts.push(`Status: ${opts.classification}`);
+    this.tooltip = tooltipParts.join('\n');
 
     // Blue circle: filled=attached, outline=idle
     if (opts.classification === 'attached') {
@@ -414,9 +472,13 @@ export class WorktreeItem extends TmuxItem {
     isTaskWorker?: boolean;
   }) {
     const displayLabel = opts.displayName || opts.branchLabel;
-    const description = opts.isCurrentWorkspace
-      ? (opts.isTaskWorker ? 'This folder' : 'This project')
-      : undefined;
+    // Build description: show workdir for non-current workspace items
+    let description: string | undefined;
+    if (opts.isCurrentWorkspace) {
+      description = opts.isTaskWorker ? 'This folder' : 'This project';
+    } else if (opts.worktreePath) {
+      description = shortenPath(opts.worktreePath);
+    }
     super(displayLabel, vscode.TreeItemCollapsibleState.Expanded, opts.repoName, opts.sessionName);
 
     this.isCurrentWorkspace = opts.isCurrentWorkspace;
@@ -434,6 +496,18 @@ export class WorktreeItem extends TmuxItem {
       title: 'Open Session',
       arguments: [this]
     };
+
+    // Build detailed tooltip
+    const tooltipParts: string[] = [];
+    tooltipParts.push(`Branch: ${opts.branchLabel}`);
+    if (opts.worktreePath) {
+      tooltipParts.push(`Working directory: ${opts.worktreePath}`);
+    }
+    if (opts.repoRoot) {
+      tooltipParts.push(`Repository: ${opts.repoRoot}`);
+    }
+    tooltipParts.push(`Status: ${opts.hasTmux ? 'running' : 'stopped'}`);
+    this.tooltip = tooltipParts.join('\n');
 
     if (opts.isTaskWorker) {
       this.iconPath = opts.hasTmux
@@ -790,7 +864,10 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
 
       this._copilotItems = items;
-      return items;
+
+      // Add fixed button item when there are existing copilots
+      const buttonItem = new CreateCopilotButtonItem();
+      return [...items, buttonItem];
     } catch {
       this._copilotItems = [];
       return [];
@@ -977,6 +1054,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       if (this._taskGroup) {
         items.push(this._taskGroup);
       }
+      // Add fixed button item when there are existing workers
+      const buttonItem = new CreateWorkerButtonItem();
+      items.push(buttonItem);
       return items;
     } catch {
       this._repoGroups = [];


### PR DESCRIPTION
## Summary

Implements UX improvements for copilot creation and display as described in issue #210.

### Changes

1. **Create Copilot Button Visibility**
   - Added viewsWelcome for Workers view with helpful empty state message
   - Changed button text from "Start Copilot" to "Create Copilot"
   - Changed icon from `$(hubot)` to `$(add)`

2. **Fixed Button Items**
   - Created `CreateButtonItem` base class for tree view button items
   - Created `CreateCopilotButtonItem` for copilot creation button
   - Created `CreateWorkerButtonItem` for worker creation button
   - Buttons appear at end of lists when items exist

3. **Workdir Selection**
   - Added `getDefaultWorkdir()` function that returns workspace folder or home directory
   - Added `pickWorkdir()` function with Quick Pick options:
     - Default (workspace folder or home)
     - Home directory
     - Browse... (opens folder picker)

4. **Workdir Display**
   - Added `shortenPath()` function to show abbreviated paths (e.g., `~/projects/hydra`, `~/.hydra/.../repo/branch`)
   - Updated CopilotItem to show workdir in description: `[claude | copilot | ~/path]`
   - Added detailed tooltips showing session name, agent, mode, workdir, and status
   - Updated WorktreeItem to show workdir in description for non-current workspace items

### Testing

- [x] Compilation passes (`npm run compile`)
- [x] Lint passes (`npm run lint`)

Fixes #210