### PR TITLE
feat: add global context configuration for Hydra VS Code extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,14 @@
         {
           "id": "hydraWorkers",
           "name": "Workers"
+        },
+        {
+          "id": "hydraProjects",
+          "name": "Projects"
+        },
+        {
+          "id": "hydraPreferences",
+          "name": "Preferences"
         }
       ]
     },
@@ -192,6 +200,26 @@
       {
         "command": "hydra.startCopilotSudoCode",
         "title": "Hydra: Start Copilot (Sudo Code)"
+      },
+      {
+        "command": "hydra.addProject",
+        "title": "Hydra: Add Project"
+      },
+      {
+        "command": "hydra.editProject",
+        "title": "Hydra: Edit Project"
+      },
+      {
+        "command": "hydra.removeProject",
+        "title": "Hydra: Remove Project"
+      },
+      {
+        "command": "hydra.editGlobalPrompt",
+        "title": "Hydra: Edit Global Prompt"
+      },
+      {
+        "command": "hydra.previewPrompt",
+        "title": "Hydra: Preview Generated Prompt"
       }
     ],
     "keybindings": [
@@ -250,6 +278,62 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Automatically notify the parent copilot when a worker finishes its task. The notification is sent as a message to the copilot's tmux session."
+        },
+        "hydra.globalPrompt": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Global prompt injected into all new copilots and workers. Use this to define coding standards, preferred libraries, or project-wide conventions."
+        },
+        "hydra.projects": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Project name"
+              },
+              "path": {
+                "type": "string",
+                "description": "Absolute path to the project directory"
+              },
+              "description": {
+                "type": "string",
+                "description": "Project description or purpose"
+              },
+              "techStack": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of technologies used in this project"
+              },
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Names of related projects"
+              },
+              "notes": {
+                "type": "string",
+                "description": "Additional notes or context"
+              }
+            },
+            "required": ["name", "path"]
+          },
+          "markdownDescription": "List of projects with metadata. Each project can have a name, path, description, tech stack, related projects, and notes."
+        },
+        "hydra.injectOnCopilotCreate": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Automatically inject the global prompt when creating a new copilot."
+        },
+        "hydra.injectOnWorkerCreate": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Automatically inject project-level context when creating a new worker."
         }
       }
     },
@@ -264,9 +348,24 @@
           "command": "hydra.createCopilot",
           "when": "view == hydraCopilots",
           "group": "navigation"
+        },
+        {
+          "command": "hydra.addProject",
+          "when": "view == hydraProjects",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
+        {
+          "command": "hydra.editProject",
+          "when": "view == hydraProjects && viewItem == 'projectItem'",
+          "group": "1_edit@1"
+        },
+        {
+          "command": "hydra.removeProject",
+          "when": "view == hydraProjects && viewItem == 'projectItem'",
+          "group": "9_danger"
+        },
         {
           "command": "tmux.reviewChanges",
           "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
@@ -297,6 +396,9 @@
   },
   "activationEvents": [
     "onView:hydraCopilots",
+    "onView:hydraWorkers",
+    "onView:hydraProjects",
+    "onView:hydraPreferences",
     "onCommand:tmux.attachCreate",
     "onCommand:hydra.createWorker",
     "onCommand:tmux.removeTask",
@@ -317,7 +419,12 @@
     "onCommand:hydra.startCopilotClaude",
     "onCommand:hydra.startCopilotCodex",
     "onCommand:hydra.startCopilotGemini",
-    "onCommand:hydra.startCopilotSudoCode"
+    "onCommand:hydra.startCopilotSudoCode",
+    "onCommand:hydra.addProject",
+    "onCommand:hydra.editProject",
+    "onCommand:hydra.removeProject",
+    "onCommand:hydra.editGlobalPrompt",
+    "onCommand:hydra.previewPrompt"
   ],
   "scripts": {
     "compile": "tsc -p ./ && node scripts/postcompile.js",

--- a/src/commands/addProject.ts
+++ b/src/commands/addProject.ts
@@ -1,0 +1,260 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { ProjectInfo, getProjects } from '../core/contextPrompt';
+
+/**
+ * Add a new project to the projects configuration.
+ */
+export async function addProject(): Promise<void> {
+  // Step 1: Choose project folder
+  const folderUris = await vscode.window.showOpenDialog({
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    openLabel: 'Select Project Folder'
+  });
+
+  if (!folderUris || folderUris.length === 0) {
+    return;
+  }
+
+  const projectPath = folderUris[0].fsPath;
+
+  // Step 2: Enter project name (default to folder name)
+  const defaultName = path.basename(projectPath);
+  const nameInput = await vscode.window.showInputBox({
+    prompt: 'Project name',
+    value: defaultName,
+    placeHolder: defaultName,
+    validateInput: (value) => {
+      if (!value.trim()) {
+        return 'Project name is required';
+      }
+      const existing = getProjects().find(p => p.name === value.trim());
+      if (existing) {
+        return `Project "${value.trim()}" already exists`;
+      }
+      return undefined;
+    }
+  });
+
+  if (!nameInput) {
+    return;
+  }
+
+  const name = nameInput.trim();
+
+  // Step 3: Optional description
+  const description = await vscode.window.showInputBox({
+    prompt: 'Project description (optional)',
+    placeHolder: 'Brief description of the project purpose'
+  });
+
+  // Step 4: Optional tech stack
+  const techStackInput = await vscode.window.showInputBox({
+    prompt: 'Tech stack (optional, comma-separated)',
+    placeHolder: 'TypeScript, React, Node.js'
+  });
+
+  const techStack = techStackInput
+    ? techStackInput.split(',').map(t => t.trim()).filter(t => t)
+    : undefined;
+
+  // Step 5: Optional notes
+  const notes = await vscode.window.showInputBox({
+    prompt: 'Additional notes (optional)',
+    placeHolder: 'Any extra context for AI workers'
+  });
+
+  // Create the project entry
+  const newProject: ProjectInfo = {
+    name,
+    path: projectPath,
+    description: description?.trim() || undefined,
+    techStack,
+    notes: notes?.trim() || undefined
+  };
+
+  // Save to settings
+  const config = vscode.workspace.getConfiguration('hydra');
+  const existingProjects = config.get<ProjectInfo[]>('projects') || [];
+  existingProjects.push(newProject);
+
+  await config.update('projects', existingProjects, vscode.ConfigurationTarget.Global);
+
+  vscode.window.showInformationMessage(`Project "${name}" added successfully`);
+  vscode.commands.executeCommand('tmux.refresh');
+}
+
+/**
+ * Edit an existing project.
+ */
+export async function editProject(item: unknown): Promise<void> {
+  // Resolve the project from the tree item argument or pick from list
+  let project: ProjectInfo | undefined;
+
+  if (item && typeof item === 'object' && 'project' in item) {
+    project = (item as { project: ProjectInfo }).project;
+  }
+
+  if (!project) {
+    const projects = getProjects();
+    if (projects.length === 0) {
+      vscode.window.showWarningMessage('No projects configured');
+      return;
+    }
+
+    const picked = await vscode.window.showQuickPick(
+      projects.map(p => ({
+        label: p.name,
+        description: p.path,
+        project: p
+      })),
+      { placeHolder: 'Select project to edit' }
+    );
+
+    if (!picked) {
+      return;
+    }
+
+    project = picked.project;
+  }
+
+  // Edit name
+  const nameInput = await vscode.window.showInputBox({
+    prompt: 'Project name',
+    value: project.name,
+    validateInput: (value) => {
+      if (!value.trim()) {
+        return 'Project name is required';
+      }
+      const existing = getProjects().find(p => p.name === value.trim() && p.path !== project!.path);
+      if (existing) {
+        return `Project "${value.trim()}" already exists`;
+      }
+      return undefined;
+    }
+  });
+
+  if (!nameInput) {
+    return;
+  }
+
+  const newName = nameInput.trim();
+
+  // Edit description
+  const description = await vscode.window.showInputBox({
+    prompt: 'Project description (optional)',
+    value: project.description || '',
+    placeHolder: 'Brief description of the project purpose'
+  });
+
+  // Edit tech stack
+  const techStackInput = await vscode.window.showInputBox({
+    prompt: 'Tech stack (optional, comma-separated)',
+    value: project.techStack?.join(', ') || '',
+    placeHolder: 'TypeScript, React, Node.js'
+  });
+
+  const techStack = techStackInput
+    ? techStackInput.split(',').map(t => t.trim()).filter(t => t)
+    : undefined;
+
+  // Edit related projects
+  const allProjects = getProjects().filter(p => p.path !== project!.path);
+  const relatedPicks = await vscode.window.showQuickPick(
+    allProjects.map(p => ({
+      label: p.name,
+      picked: project!.related?.includes(p.name) ?? false
+    })),
+    {
+      placeHolder: 'Select related projects (optional)',
+      canPickMany: true
+    }
+  );
+
+  const related = relatedPicks?.map(p => p.label);
+
+  // Edit notes
+  const notes = await vscode.window.showInputBox({
+    prompt: 'Additional notes (optional)',
+    value: project.notes || '',
+    placeHolder: 'Any extra context for AI workers'
+  });
+
+  // Update the project in settings
+  const config = vscode.workspace.getConfiguration('hydra');
+  const existingProjects = config.get<ProjectInfo[]>('projects') || [];
+  const index = existingProjects.findIndex(p => p.path === project!.path);
+
+  if (index >= 0) {
+    existingProjects[index] = {
+      ...project!,
+      name: newName,
+      description: description?.trim() || undefined,
+      techStack,
+      related: related && related.length > 0 ? related : undefined,
+      notes: notes?.trim() || undefined
+    };
+
+    await config.update('projects', existingProjects, vscode.ConfigurationTarget.Global);
+    vscode.window.showInformationMessage(`Project "${newName}" updated`);
+    vscode.commands.executeCommand('tmux.refresh');
+  }
+}
+
+/**
+ * Remove a project from the configuration.
+ */
+export async function removeProject(item: unknown): Promise<void> {
+  // Resolve the project from the tree item argument or pick from list
+  let project: ProjectInfo | undefined;
+
+  if (item && typeof item === 'object' && 'project' in item) {
+    project = (item as { project: ProjectInfo }).project;
+  }
+
+  if (!project) {
+    const projects = getProjects();
+    if (projects.length === 0) {
+      vscode.window.showWarningMessage('No projects configured');
+      return;
+    }
+
+    const picked = await vscode.window.showQuickPick(
+      projects.map(p => ({
+        label: p.name,
+        description: p.path,
+        project: p
+      })),
+      { placeHolder: 'Select project to remove' }
+    );
+
+    if (!picked) {
+      return;
+    }
+
+    project = picked.project;
+  }
+
+  // Confirm deletion
+  const confirm = await vscode.window.showWarningMessage(
+    `Remove project "${project.name}"?`,
+    'Remove',
+    'Cancel'
+  );
+
+  if (confirm !== 'Remove') {
+    return;
+  }
+
+  // Remove from settings
+  const config = vscode.workspace.getConfiguration('hydra');
+  const existingProjects = config.get<ProjectInfo[]>('projects') || [];
+  const filtered = existingProjects.filter(p => p.path !== project!.path);
+
+  await config.update('projects', filtered, vscode.ConfigurationTarget.Global);
+
+  vscode.window.showInformationMessage(`Project "${project.name}" removed`);
+  vscode.commands.executeCommand('tmux.refresh');
+}

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -6,6 +6,7 @@ import { CopilotMode } from '../core/types';
 import { TmuxBackendCore } from '../core/tmux';
 import { SessionManager } from '../core/sessionManager';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
+import { buildCopilotPrompt, shouldInjectOnCopilotCreate } from '../core/contextPrompt';
 
 const ONBOARDING_PROMPT = `You are a Hydra copilot — an AI orchestrator that manages parallel AI workers to complete complex tasks.
 
@@ -54,7 +55,19 @@ export function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: 
   (async () => {
     try {
       await new Promise(resolve => setTimeout(resolve, 8000));
-      await backend.sendMessage(sessionName, getOnboardingPrompt(copilotMode));
+
+      // Build the complete onboarding prompt
+      const parts: string[] = [getOnboardingPrompt(copilotMode)];
+
+      // Add global context if enabled
+      if (shouldInjectOnCopilotCreate()) {
+        const globalContext = buildCopilotPrompt();
+        if (globalContext.trim()) {
+          parts.push('', '---', '', globalContext);
+        }
+      }
+
+      await backend.sendMessage(sessionName, parts.join('\n'));
     } catch {
       // Best-effort — agent may not be ready yet
     }

--- a/src/commands/editGlobalPrompt.ts
+++ b/src/commands/editGlobalPrompt.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import { getGlobalPrompt } from '../core/contextPrompt';
+
+/**
+ * Edit the global prompt in a text editor.
+ */
+export async function editGlobalPrompt(): Promise<void> {
+  const currentPrompt = getGlobalPrompt();
+
+  // Show a quick pick to choose between editing in input box or full editor
+  const choice = await vscode.window.showQuickPick(
+    [
+      {
+        label: 'Edit in Input Box',
+        description: 'Quick edit for short prompts',
+        value: 'input' as const
+      },
+      {
+        label: 'Edit in New File',
+        description: 'Full editor for longer prompts',
+        value: 'file' as const
+      }
+    ],
+    { placeHolder: 'How would you like to edit the global prompt?' }
+  );
+
+  if (!choice) {
+    return;
+  }
+
+  if (choice.value === 'input') {
+    const newPrompt = await vscode.window.showInputBox({
+      prompt: 'Global Prompt',
+      value: currentPrompt,
+      placeHolder: 'Enter global context to inject into all copilots and workers...'
+    });
+
+    if (newPrompt !== undefined) {
+      const config = vscode.workspace.getConfiguration('hydra');
+      await config.update('globalPrompt', newPrompt, vscode.ConfigurationTarget.Global);
+      vscode.window.showInformationMessage('Global prompt updated');
+      vscode.commands.executeCommand('tmux.refresh');
+    }
+  } else {
+    // Create a temporary untitled document for editing
+    const doc = await vscode.workspace.openTextDocument({
+      content: currentPrompt,
+      language: 'markdown'
+    });
+
+    await vscode.window.showTextDocument(doc);
+
+    // Listen for save
+    const disposable = vscode.workspace.onDidSaveTextDocument(async (savedDoc) => {
+      if (savedDoc.uri.toString() === doc.uri.toString()) {
+        const newPrompt = savedDoc.getText();
+        const config = vscode.workspace.getConfiguration('hydra');
+        await config.update('globalPrompt', newPrompt, vscode.ConfigurationTarget.Global);
+        vscode.window.showInformationMessage('Global prompt saved');
+        vscode.commands.executeCommand('tmux.refresh');
+      }
+    });
+
+    // Clean up listener when editor is closed
+    vscode.workspace.onDidCloseTextDocument((closedDoc) => {
+      if (closedDoc.uri.toString() === doc.uri.toString()) {
+        disposable.dispose();
+      }
+    });
+  }
+}
+
+/**
+ * Toggle the injectOnCopilotCreate setting.
+ */
+export async function toggleInjectOnCopilotCreate(): Promise<void> {
+  const config = vscode.workspace.getConfiguration('hydra');
+  const currentValue = config.get<boolean>('injectOnCopilotCreate') ?? true;
+  await config.update('injectOnCopilotCreate', !currentValue, vscode.ConfigurationTarget.Global);
+  vscode.window.showInformationMessage(
+    `Global prompt injection for copilots ${!currentValue ? 'enabled' : 'disabled'}`
+  );
+  vscode.commands.executeCommand('tmux.refresh');
+}
+
+/**
+ * Toggle the injectOnWorkerCreate setting.
+ */
+export async function toggleInjectOnWorkerCreate(): Promise<void> {
+  const config = vscode.workspace.getConfiguration('hydra');
+  const currentValue = config.get<boolean>('injectOnWorkerCreate') ?? true;
+  await config.update('injectOnWorkerCreate', !currentValue, vscode.ConfigurationTarget.Global);
+  vscode.window.showInformationMessage(
+    `Project context injection for workers ${!currentValue ? 'enabled' : 'disabled'}`
+  );
+  vscode.commands.executeCommand('tmux.refresh');
+}

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -8,6 +8,7 @@ import { pickAgentType } from '../utils/agentConfig';
 import { getActiveBackend } from '../utils/multiplexer';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { detectIdentity, getWorkerCreationBlockedMessage } from '../core/sessionIdentity';
+import { buildWorkerPrompt, shouldInjectOnWorkerCreate } from '../core/contextPrompt';
 
 function getBaseBranchOverride(): string | undefined {
   const hydraOverride = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch');
@@ -33,6 +34,29 @@ function defaultNameForFolder(folderPath: string): string {
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Send project-level context to a newly created worker.
+ */
+function sendWorkerContext(backend: ReturnType<typeof getActiveBackend>, sessionName: string, workdir: string): void {
+  if (!shouldInjectOnWorkerCreate()) {
+    return;
+  }
+
+  (async () => {
+    try {
+      // Wait for the agent to be ready (same delay as copilot onboarding)
+      await delay(8000);
+
+      const contextPrompt = buildWorkerPrompt(workdir);
+      if (contextPrompt.trim()) {
+        await backend.sendMessage(sessionName, contextPrompt);
+      }
+    } catch {
+      // Best-effort — agent may not be ready yet
+    }
+  })();
 }
 
 async function refreshHydraViewsBeforeAttach(): Promise<void> {
@@ -89,7 +113,12 @@ async function createCodeWorker(repoRoot: string): Promise<void> {
   });
 
   await refreshHydraViewsBeforeAttach();
-  getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+  const backend = getActiveBackend();
+  backend.attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+
+  // Send project-level context to the worker
+  sendWorkerContext(backend, workerInfo.sessionName, workerInfo.workdir);
+
   void postCreatePromise.catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showWarningMessage(
@@ -207,7 +236,12 @@ async function createTaskWorker(workspacePath: string, workspaceIsGitRepo: boole
   });
 
   await refreshHydraViewsBeforeAttach();
-  getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+  const backend = getActiveBackend();
+  backend.attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
+
+  // Send project-level context to the worker
+  sendWorkerContext(backend, workerInfo.sessionName, workerInfo.workdir);
+
   void postCreatePromise.catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showWarningMessage(

--- a/src/commands/previewPrompt.ts
+++ b/src/commands/previewPrompt.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import { buildCopilotPrompt, buildWorkerPrompt, getProjects } from '../core/contextPrompt';
+
+/**
+ * Preview the generated prompt for copilot or worker context.
+ */
+export async function previewGeneratedPrompt(): Promise<void> {
+  // Ask which context to preview
+  const contextChoice = await vscode.window.showQuickPick(
+    [
+      {
+        label: 'Copilot Prompt',
+        description: 'Global context injected into new copilots',
+        value: 'copilot' as const
+      },
+      {
+        label: 'Worker Prompt',
+        description: 'Project-level context injected into new workers',
+        value: 'worker' as const
+      }
+    ],
+    { placeHolder: 'Select which prompt to preview' }
+  );
+
+  if (!contextChoice) {
+    return;
+  }
+
+  if (contextChoice.value === 'copilot') {
+    const prompt = buildCopilotPrompt();
+    await showPromptPreview('Copilot Global Context', prompt);
+  } else {
+    // For worker prompt, need to select a project or provide a path
+    const projects = getProjects();
+    if (projects.length === 0) {
+      const pathInput = await vscode.window.showInputBox({
+        prompt: 'Enter worker path to preview',
+        placeHolder: '/path/to/project'
+      });
+      if (pathInput) {
+        const prompt = buildWorkerPrompt(pathInput);
+        await showPromptPreview('Worker Context', prompt);
+      }
+    } else {
+      const projectChoice = await vscode.window.showQuickPick(
+        projects.map(p => ({
+          label: p.name,
+          description: p.path,
+          path: p.path
+        })),
+        { placeHolder: 'Select project to preview worker prompt' }
+      );
+
+      if (projectChoice) {
+        const prompt = buildWorkerPrompt(projectChoice.path);
+        await showPromptPreview(`Worker Context for ${projectChoice.label}`, prompt);
+      }
+    }
+  }
+}
+
+/**
+ * Show the prompt preview in a new document.
+ */
+async function showPromptPreview(title: string, prompt: string): Promise<void> {
+  if (!prompt.trim()) {
+    vscode.window.showInformationMessage(`${title}: No prompt configured`);
+    return;
+  }
+
+  // Create a temporary untitled document
+  const content = `# ${title}\n\n---\n\n${prompt}\n\n---\n\n*This is a preview of the prompt that would be injected.*`;
+  const doc = await vscode.workspace.openTextDocument({
+    content,
+    language: 'markdown'
+  });
+
+  await vscode.window.showTextDocument(doc, {
+    preview: true,
+    viewColumn: vscode.ViewColumn.Beside
+  });
+}

--- a/src/core/contextPrompt.ts
+++ b/src/core/contextPrompt.ts
@@ -1,0 +1,182 @@
+import * as vscode from 'vscode';
+
+/**
+ * Project information stored in VS Code settings.
+ */
+export interface ProjectInfo {
+  name: string;
+  path: string;
+  description?: string;
+  techStack?: string[];
+  related?: string[];
+  notes?: string;
+}
+
+/**
+ * Get the global prompt from VS Code settings.
+ */
+export function getGlobalPrompt(): string {
+  const config = vscode.workspace.getConfiguration('hydra');
+  return config.get<string>('globalPrompt') || '';
+}
+
+/**
+ * Get all projects from VS Code settings.
+ */
+export function getProjects(): ProjectInfo[] {
+  const config = vscode.workspace.getConfiguration('hydra');
+  return config.get<ProjectInfo[]>('projects') || [];
+}
+
+/**
+ * Get a project by its path.
+ */
+export function getProjectByPath(projectPath: string): ProjectInfo | undefined {
+  const projects = getProjects();
+  const normalizedPath = projectPath.replace(/[\\/]+$/, '');
+  return projects.find(p => p.path.replace(/[\\/]+$/, '') === normalizedPath);
+}
+
+/**
+ * Get a project by its name.
+ */
+export function getProjectByName(name: string): ProjectInfo | undefined {
+  const projects = getProjects();
+  return projects.find(p => p.name === name);
+}
+
+/**
+ * Check if global prompt injection is enabled for copilots.
+ */
+export function shouldInjectOnCopilotCreate(): boolean {
+  const config = vscode.workspace.getConfiguration('hydra');
+  return config.get<boolean>('injectOnCopilotCreate') ?? true;
+}
+
+/**
+ * Check if project-level context injection is enabled for workers.
+ */
+export function shouldInjectOnWorkerCreate(): boolean {
+  const config = vscode.workspace.getConfiguration('hydra');
+  return config.get<boolean>('injectOnWorkerCreate') ?? true;
+}
+
+/**
+ * Build the global context prompt for a Copilot.
+ * Combines the global prompt with any relevant project context.
+ */
+export function buildCopilotPrompt(): string {
+  const globalPrompt = getGlobalPrompt();
+  if (!globalPrompt.trim()) {
+    return '';
+  }
+
+  const parts: string[] = [
+    '## Global Context',
+    '',
+    globalPrompt.trim(),
+  ];
+
+  // Add project summaries if available
+  const projects = getProjects();
+  if (projects.length > 0) {
+    parts.push('', '## Known Projects', '');
+    for (const project of projects) {
+      parts.push(formatProjectSummary(project));
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Build the project-level context prompt for a Worker.
+ * Finds the matching project and provides detailed context.
+ */
+export function buildWorkerPrompt(workerPath: string): string {
+  if (!shouldInjectOnWorkerCreate()) {
+    return '';
+  }
+
+  const globalPrompt = getGlobalPrompt();
+  const project = getProjectByPath(workerPath);
+
+  const parts: string[] = [];
+
+  // Add global prompt first if present
+  if (globalPrompt.trim() && shouldInjectOnCopilotCreate()) {
+    parts.push('## Global Context', '', globalPrompt.trim(), '');
+  }
+
+  // Add project-specific context if found
+  if (project) {
+    parts.push('## Project Context', '');
+    parts.push(formatProjectDetail(project));
+
+    // Add related projects context
+    if (project.related && project.related.length > 0) {
+      const relatedProjects = getProjects().filter(p => project.related!.includes(p.name));
+      if (relatedProjects.length > 0) {
+        parts.push('', '## Related Projects', '');
+        for (const related of relatedProjects) {
+          parts.push(formatProjectSummary(related));
+        }
+      }
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Format a brief project summary for the copilot prompt.
+ */
+function formatProjectSummary(project: ProjectInfo): string {
+  const lines: string[] = [`- **${project.name}** (${project.path})`];
+  if (project.description) {
+    lines.push(`  ${project.description}`);
+  }
+  if (project.techStack && project.techStack.length > 0) {
+    lines.push(`  Tech: ${project.techStack.join(', ')}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format detailed project information for the worker prompt.
+ */
+function formatProjectDetail(project: ProjectInfo): string {
+  const lines: string[] = [`**Name**: ${project.name}`];
+  lines.push(`**Path**: ${project.path}`);
+
+  if (project.description) {
+    lines.push(`**Description**: ${project.description}`);
+  }
+
+  if (project.techStack && project.techStack.length > 0) {
+    lines.push(`**Tech Stack**: ${project.techStack.join(', ')}`);
+  }
+
+  if (project.related && project.related.length > 0) {
+    lines.push(`**Related Projects**: ${project.related.join(', ')}`);
+  }
+
+  if (project.notes) {
+    lines.push(`**Notes**: ${project.notes}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Preview the generated prompt for a given context.
+ */
+export function previewPrompt(context: 'copilot' | 'worker', workerPath?: string): string {
+  if (context === 'copilot') {
+    return buildCopilotPrompt();
+  }
+  if (context === 'worker' && workerPath) {
+    return buildWorkerPrompt(workerPath);
+  }
+  return '';
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
+import { ProjectsProvider } from './providers/projectsProvider';
+import { PreferencesProvider } from './providers/preferencesProvider';
 import { attachCreate } from './commands/attachCreate';
 import { newTask } from './commands/newTask';
 import { removeTask } from './commands/removeTask';
@@ -19,6 +21,9 @@ import {
 import { terminalSmartPaste, pasteImageForce, cleanupTempImages } from './commands/pasteImage';
 import { createWorktreeFromBranch } from './commands/createWorktreeFromBranch';
 import { createCopilot, createCopilotWithAgent, createPlanCopilot } from './commands/createCopilot';
+import { addProject, editProject, removeProject } from './commands/addProject';
+import { editGlobalPrompt, toggleInjectOnCopilotCreate, toggleInjectOnWorkerCreate } from './commands/editGlobalPrompt';
+import { previewGeneratedPrompt } from './commands/previewPrompt';
 import { ensureHydraGlobalConfig } from './utils/hydraGlobalConfig';
 import { installCli, ensurePathInShellProfile } from './core/cliInstaller';
 import {
@@ -46,9 +51,13 @@ export function activate(context: vscode.ExtensionContext) {
   copilotProvider.setExtensionUri(context.extensionUri);
   const workerProvider = new WorkerProvider();
   workerProvider.setExtensionUri(context.extensionUri);
+  const projectsProvider = new ProjectsProvider();
+  const preferencesProvider = new PreferencesProvider();
 
   const copilotView = vscode.window.createTreeView('hydraCopilots', { treeDataProvider: copilotProvider });
   const workerView = vscode.window.createTreeView('hydraWorkers', { treeDataProvider: workerProvider });
+  const projectsView = vscode.window.createTreeView('hydraProjects', { treeDataProvider: projectsProvider });
+  const preferencesView = vscode.window.createTreeView('hydraPreferences', { treeDataProvider: preferencesProvider });
   let selectedHydraItem: TmuxItem | undefined;
   let selectedHydraItemAt = 0;
   const rememberHydraSelection = (event: vscode.TreeViewSelectionChangeEvent<TmuxItem>) => {
@@ -126,10 +135,12 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     copilotView,
     workerView,
+    projectsView,
+    preferencesView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
     vscode.commands.registerCommand('hydra.createWorker', newTask),
     vscode.commands.registerCommand('tmux.removeTask', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], removeTask, ...args)),
-    vscode.commands.registerCommand('tmux.refresh', () => { copilotProvider.refresh(); workerProvider.refresh(); }),
+    vscode.commands.registerCommand('tmux.refresh', () => { copilotProvider.refresh(); workerProvider.refresh(); projectsProvider.refresh(); preferencesProvider.refresh(); }),
     vscode.commands.registerCommand('tmux.attach', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], attach, ...args)),
     vscode.commands.registerCommand('tmux.attachInEditor', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], attachInEditor, ...args)),
     vscode.commands.registerCommand('tmux.openWorktree', async (...args: unknown[]) => runWithHydraItem(['worker'], openWorktree, ...args)),
@@ -147,6 +158,15 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('hydra.startCopilotCodex', () => createCopilotWithAgent('codex')),
     vscode.commands.registerCommand('hydra.startCopilotGemini', () => createCopilotWithAgent('gemini')),
     vscode.commands.registerCommand('hydra.startCopilotSudoCode', () => createCopilotWithAgent('sudocode')),
+    // Project management commands
+    vscode.commands.registerCommand('hydra.addProject', addProject),
+    vscode.commands.registerCommand('hydra.editProject', editProject),
+    vscode.commands.registerCommand('hydra.removeProject', removeProject),
+    // Global prompt commands
+    vscode.commands.registerCommand('hydra.editGlobalPrompt', editGlobalPrompt),
+    vscode.commands.registerCommand('hydra.previewPrompt', previewGeneratedPrompt),
+    vscode.commands.registerCommand('hydra.toggleInjectOnCopilotCreate', toggleInjectOnCopilotCreate),
+    vscode.commands.registerCommand('hydra.toggleInjectOnWorkerCreate', toggleInjectOnWorkerCreate),
     copilotView.onDidChangeSelection(rememberHydraSelection),
     workerView.onDidChangeSelection(rememberHydraSelection),
   );
@@ -158,7 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
   autoAttachOnStartup();
   detectAndSetAgentContext();
 
-  const refreshAll = () => { copilotProvider.refresh(); workerProvider.refresh(); };
+  const refreshAll = () => { copilotProvider.refresh(); workerProvider.refresh(); projectsProvider.refresh(); preferencesProvider.refresh(); };
   registerSessionFileRefreshWatcher(context, refreshAll);
 
   context.subscriptions.push(

--- a/src/providers/preferencesProvider.ts
+++ b/src/providers/preferencesProvider.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import {
+  getGlobalPrompt,
+  getProjects,
+  shouldInjectOnCopilotCreate,
+  shouldInjectOnWorkerCreate
+} from '../core/contextPrompt';
+
+/**
+ * Tree item for the Preferences view.
+ */
+export class PreferenceItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    value: string | boolean,
+    icon: string,
+    command?: vscode.Command
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = typeof value === 'boolean'
+      ? (value ? 'Enabled' : 'Disabled')
+      : (value || 'Not set');
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.contextValue = 'preferenceItem';
+    if (command) {
+      this.command = command;
+    }
+  }
+}
+
+/**
+ * Tree data provider for the Preferences view.
+ */
+export class PreferencesProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getParent(): vscode.TreeItem | undefined {
+    return undefined;
+  }
+
+  async getChildren(): Promise<vscode.TreeItem[]> {
+    const items: vscode.TreeItem[] = [];
+
+    // Global Prompt
+    const globalPrompt = getGlobalPrompt();
+    const promptPreview = globalPrompt
+      ? globalPrompt.substring(0, 50) + (globalPrompt.length > 50 ? '...' : '')
+      : 'Not set';
+    items.push(new PreferenceItem(
+      'Global Prompt',
+      promptPreview,
+      'note',
+      {
+        command: 'hydra.editGlobalPrompt',
+        title: 'Edit Global Prompt'
+      }
+    ));
+
+    // Projects count
+    const projects = getProjects();
+    items.push(new PreferenceItem(
+      'Projects',
+      `${projects.length} configured`,
+      'folder',
+      {
+        command: 'hydra.addProject',
+        title: 'Add Project'
+      }
+    ));
+
+    // Inject on Copilot Create
+    items.push(new PreferenceItem(
+      'Inject on Copilot Create',
+      shouldInjectOnCopilotCreate(),
+      'hubot',
+      {
+        command: 'hydra.toggleInjectOnCopilotCreate',
+        title: 'Toggle'
+      }
+    ));
+
+    // Inject on Worker Create
+    items.push(new PreferenceItem(
+      'Inject on Worker Create',
+      shouldInjectOnWorkerCreate(),
+      'server-process',
+      {
+        command: 'hydra.toggleInjectOnWorkerCreate',
+        title: 'Toggle'
+      }
+    ));
+
+    // Preview prompt
+    const previewItem = new vscode.TreeItem('Preview Generated Prompt', vscode.TreeItemCollapsibleState.None);
+    previewItem.iconPath = new vscode.ThemeIcon('eye');
+    previewItem.command = {
+      command: 'hydra.previewPrompt',
+      title: 'Preview Generated Prompt'
+    };
+    previewItem.contextValue = 'previewPromptItem';
+    items.push(previewItem);
+
+    return items;
+  }
+}

--- a/src/providers/projectsProvider.ts
+++ b/src/providers/projectsProvider.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode';
+import { ProjectInfo, getProjects } from '../core/contextPrompt';
+
+/**
+ * Tree item representing a project in the Projects view.
+ */
+export class ProjectItem extends vscode.TreeItem {
+  constructor(
+    public readonly project: ProjectInfo,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState
+  ) {
+    super(project.name, collapsibleState);
+    this.id = project.path;
+    this.description = project.description || project.path;
+    this.contextValue = 'projectItem';
+    this.iconPath = new vscode.ThemeIcon('folder');
+    this.tooltip = formatProjectTooltip(project);
+    this.command = {
+      command: 'hydra.editProject',
+      title: 'Edit Project',
+      arguments: [this]
+    };
+  }
+}
+
+/**
+ * Tree item showing project details.
+ */
+export class ProjectDetailItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    value: string | undefined,
+    icon: string
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.description = value || '-';
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.contextValue = 'projectDetailItem';
+  }
+}
+
+function formatProjectTooltip(project: ProjectInfo): string {
+  const parts: string[] = [project.name, project.path];
+  if (project.description) parts.push(project.description);
+  if (project.techStack && project.techStack.length > 0) {
+    parts.push(`Tech: ${project.techStack.join(', ')}`);
+  }
+  if (project.related && project.related.length > 0) {
+    parts.push(`Related: ${project.related.join(', ')}`);
+  }
+  if (project.notes) parts.push(project.notes);
+  return parts.join('\n');
+}
+
+/**
+ * Tree data provider for the Projects view.
+ */
+export class ProjectsProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getParent(_element: vscode.TreeItem): vscode.TreeItem | undefined {
+    return undefined;
+  }
+
+  async getChildren(_element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
+    if (!_element) {
+      return this.getRootItems();
+    }
+
+    if (_element instanceof ProjectItem) {
+      return this.getProjectDetailItems(_element.project);
+    }
+
+    return [];
+  }
+
+  private async getRootItems(): Promise<vscode.TreeItem[]> {
+    const projects = getProjects();
+
+    if (projects.length === 0) {
+      const hint = new vscode.TreeItem('No projects configured');
+      hint.iconPath = new vscode.ThemeIcon('info');
+      hint.description = 'Add a project to provide context to workers';
+      return [hint];
+    }
+
+    return projects.map(p => new ProjectItem(p, vscode.TreeItemCollapsibleState.Collapsed));
+  }
+
+  private async getProjectDetailItems(project: ProjectInfo): Promise<vscode.TreeItem[]> {
+    const items: vscode.TreeItem[] = [];
+
+    items.push(new ProjectDetailItem('Path', project.path, 'folder'));
+    items.push(new ProjectDetailItem('Description', project.description, 'note'));
+
+    if (project.techStack && project.techStack.length > 0) {
+      const techItem = new vscode.TreeItem('Tech Stack', vscode.TreeItemCollapsibleState.None);
+      techItem.description = project.techStack.join(', ');
+      techItem.iconPath = new vscode.ThemeIcon('symbol-keyword');
+      items.push(techItem);
+    }
+
+    if (project.related && project.related.length > 0) {
+      const relatedItem = new vscode.TreeItem('Related', vscode.TreeItemCollapsibleState.None);
+      relatedItem.description = project.related.join(', ');
+      relatedItem.iconPath = new vscode.ThemeIcon('references');
+      items.push(relatedItem);
+    }
+
+    if (project.notes) {
+      const notesItem = new vscode.TreeItem('Notes', vscode.TreeItemCollapsibleState.None);
+      notesItem.description = project.notes;
+      notesItem.iconPath = new vscode.ThemeIcon('comment');
+      items.push(notesItem);
+    }
+
+    return items;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `hydra.globalPrompt` configuration setting for defining coding standards, preferred libraries, or project-wide conventions
- Add `hydra.projects` configuration setting for managing project metadata (name, path, description, tech stack, related projects, notes)
- Add `hydraProjects` and `hydraPreferences` sidebar views for visual management
- Add commands: `addProject`, `editProject`, `removeProject`, `editGlobalPrompt`, `previewPrompt`
- Auto-inject global context on Copilot creation
- Auto-inject project-level context on Worker creation

## Implementation Details

### New Files
- `src/core/contextPrompt.ts` - Prompt generation logic
- `src/providers/projectsProvider.ts` - Projects view data provider
- `src/providers/preferencesProvider.ts` - Preferences view data provider
- `src/commands/addProject.ts` - Add/edit/remove project commands
- `src/commands/editGlobalPrompt.ts` - Edit global prompt and toggle injection
- `src/commands/previewPrompt.ts` - Preview generated prompt

### Modified Files
- `package.json` - Add configuration, views, commands, menus
- `src/extension.ts` - Register new providers and commands
- `src/commands/createCopilot.ts` - Inject global context on Copilot creation
- `src/commands/newTask.ts` - Inject project-level context on Worker creation

## Test Plan
- [ ] Add/remove/edit projects via UI
- [ ] Edit global prompt in editor
- [ ] Preview generated prompt
- [ ] Verify prompt injection on Copilot creation
- [ ] Verify prompt injection on Worker creation
- [ ] Test with different agent types (Claude, Codex, Gemini)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)