### PR TITLE
docs(AGENTS): clarify Copilot is a cross-repo orchestrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,18 @@ hydra archive --help
 
 Prefer `--json` when scripting or when another agent will parse the output.
 
+## Copilot vs repos
+
+A Copilot is **not bound to a single repo**. It is a cross-repo command center: one Copilot can create workers in many different repos and orchestrate them from one place. Its own `workdir` is just the shell starting directory for the Copilot's own terminal — not its "scope" of work. By default a new Copilot starts in `$HOME` precisely to avoid the impression that it belongs to whatever repo happens to be open in VS Code.
+
+Implications:
+
+- A Copilot can spawn `hydra worker create --repo <owner>/<name> --branch <name>` workers across any number of registered repos.
+- The "current VS Code workspace" is not the Copilot's working set — its workers are.
+- UI surfaces about a Copilot should describe its **managed workers and the repos they touch**, not the Copilot's own `workdir`.
+
+If you want a per-repo assistant rather than a cross-repo orchestrator, create a worker instead — workers *are* repo-scoped (code workers) or folder-scoped (task workers).
+
 ## Copilot workflow
 
 When orchestrating multiple workers, follow this loop:


### PR DESCRIPTION
## Summary

Adds a short "Copilot vs repos" section to `AGENTS.md` clarifying that a Copilot is **not** bound to a single repo — it is a cross-repo command center, and its own `workdir` is just the shell starting directory for its terminal, not the scope of repos it operates on.

## Why

We have recurring user reports based on the opposite mental model:

- #207 — "新建 Copilot 工作目录不是当前 VS Code project 目录"
- #210 P2 — proposes defaulting Copilot workdir to the current VS Code workspace
- #210 P3 — proposes showing the Copilot's `workdir` in the tree

All three assume Copilot ⇒ one repo. Implementing them would reinforce the wrong model. The right fix is to write the design intent down so users (and agents) can find it, and so future UI surfaces describe a Copilot by its managed workers, not its workdir.

## Test plan

- [ ] Read the new section in `AGENTS.md` and verify it matches the maintainer's intent
- [ ] No code changes — nothing to build or test

🤖 Generated with [Claude Code](https://claude.com/claude-code)