### PR TITLE
[codex] Add Hydra diagnostic logging

### DIFF
--- a/docs/hydra-logging-design.md
+++ b/docs/hydra-logging-design.md
@@ -1,0 +1,464 @@
+# Hydra Logging Product and Technical Design
+
+Status: product and technical design for issue #213.
+
+Issue: https://github.com/sudoprivacy/hydra/issues/213
+
+## Summary
+
+Hydra needs a dedicated runtime logging system for extension and CLI failures.
+Today, a failed copilot or worker startup usually leaves the user with only a
+VS Code toast or CLI stderr. If the failure happens before the tmux/psmux
+session and agent process are running, `hydra worker logs` and agent transcript
+files do not exist yet. Debugging then depends on screenshots or VS Code
+Extension Host logs, which are hard for users to find and do not consistently
+capture Hydra-specific context.
+
+The first implementation should add a small, always-on diagnostic log that is
+easy to find, safe to share, and cheap enough to use in every normal Hydra
+session.
+
+## Goals
+
+- Give users one Hydra-owned log file they can send after startup failures.
+- Mirror important log entries into a VS Code Output channel named `Hydra`.
+- Capture enough context to diagnose tmux/psmux, PATH, shell command, agent
+  startup, and session state failures.
+- Keep the logger usable from both VS Code extension code and CLI code.
+- Keep `src/core` independent of the `vscode` module.
+- Avoid logging full user prompts, task text, API keys, tokens, passwords, or
+  complete environment dumps.
+- Keep the performance cost negligible for create/start/attach flows.
+
+## Non-Goals
+
+- Do not replace `hydra worker logs` or `hydra copilot logs`; those remain pane
+  capture commands for running sessions.
+- Do not build a full telemetry or remote upload system.
+- Do not upload logs automatically.
+- Do not add a diagnostic bundle archive in V1. The file log and Output channel
+  are enough for the first implementation.
+- Do not log full terminal pane output or full agent transcripts.
+- Do not make debug logging the default.
+
+## User Experience
+
+### Log File
+
+Hydra writes a file log at:
+
+```text
+~/.hydra/logs/hydra.log
+```
+
+On Windows this resolves to:
+
+```text
+C:\Users\<user>\.hydra\logs\hydra.log
+```
+
+This path is stable across VS Code and CLI entry points because it is derived
+from the same Hydra home resolution used for `sessions.json`, `archive.json`,
+and `config.json`.
+
+### VS Code Output
+
+The extension creates an Output channel:
+
+```text
+Hydra
+```
+
+The channel shows user-actionable `info`, `warn`, and `error` messages. Debug
+entries should stay file-only unless debug logging is enabled.
+
+### Commands
+
+Add these VS Code commands:
+
+| Command | Purpose |
+| --- | --- |
+| `Hydra: Show Logs` | Reveal the `Hydra` Output channel. |
+| `Hydra: Open Logs Folder` | Open `~/.hydra/logs` in the OS file browser. |
+| `Hydra: Copy Diagnostic Info` | Copy a short diagnostic text block with Hydra version, platform, Hydra home, config path, log path, multiplexer command, and configured/default agent. |
+
+### Error Actions
+
+Startup errors should offer log-oriented actions. For example, copilot creation
+should show:
+
+```text
+Failed to create copilot.
+```
+
+Actions:
+
+```text
+Show Logs
+Open Logs Folder
+Copy Details
+```
+
+The visible toast should stay concise. The detailed command, cwd, stderr,
+stdout snippet, and stack belong in the log file.
+
+### CLI Doctor
+
+`hydra doctor` should include:
+
+- Hydra home path.
+- Hydra config path.
+- Hydra log path.
+- Whether the log directory exists and is writable.
+- Resolved tmux/psmux availability.
+- Resolved AI agent CLI availability.
+
+## Log Format
+
+Use JSON Lines. Each line is one event.
+
+```json
+{"ts":"2026-06-03T15:12:01.123Z","level":"error","scope":"tmux.createSession","message":"Failed to create multiplexer session","platform":"win32","pid":12345,"sessionName":"hydra-copilot-codex","agent":"codex","cwd":"C:\\Users\\Mr.Black","command":"psmux new-session -d -s ...","durationMs":318,"exitCode":1,"stderr":"...","stdout":"..."}
+```
+
+Required fields:
+
+| Field | Description |
+| --- | --- |
+| `ts` | ISO timestamp. |
+| `level` | `debug`, `info`, `warn`, or `error`. |
+| `scope` | Stable code area such as `exec`, `tmux.createSession`, or `session.createCopilot`. |
+| `message` | Human-readable summary. |
+| `platform` | `process.platform`. |
+| `pid` | Current process id. |
+
+Common optional fields:
+
+| Field | Description |
+| --- | --- |
+| `sessionName` | Hydra session name. |
+| `agent` | Agent type or command category. |
+| `cwd` | Working directory. |
+| `command` | Redacted shell command. |
+| `durationMs` | Operation duration. |
+| `exitCode` | Child process exit code. |
+| `stdout` | Redacted and truncated stdout snippet. |
+| `stderr` | Redacted and truncated stderr snippet. |
+| `error` | Redacted error message. |
+| `stack` | Redacted stack trace for internal errors. |
+| `promptLength` | Prompt/task length when relevant. |
+| `promptHash` | Hash of prompt/task text when correlation is useful. |
+
+## Retention and Rotation
+
+Use size-based rotation because it is deterministic and avoids time-zone and
+clock issues.
+
+Default layout:
+
+```text
+~/.hydra/logs/
+  hydra.log
+  hydra.1.log
+  hydra.2.log
+  hydra.3.log
+  hydra.4.log
+```
+
+Default limits:
+
+- `hydra.log` maximum size: 5 MB.
+- Retained rotated files: 4.
+- Total default footprint: about 25 MB.
+
+Rotation algorithm:
+
+1. Before flushing a batch, check `hydra.log` size plus the pending batch size.
+2. If the combined size is above the max, rotate.
+3. Delete `hydra.4.log`.
+4. Rename `hydra.3.log` to `hydra.4.log`.
+5. Rename `hydra.2.log` to `hydra.3.log`.
+6. Rename `hydra.1.log` to `hydra.2.log`.
+7. Rename `hydra.log` to `hydra.1.log`.
+8. Write the pending batch to a new `hydra.log`.
+
+If a rename fails because a file does not exist, continue. If rotation fails
+because of filesystem permissions, drop the pending file write and mirror a
+single warning to any registered in-memory sinks. Logging must not crash Hydra.
+
+## Configuration
+
+Add VS Code configuration keys:
+
+```json
+{
+  "hydra.logging.level": "info",
+  "hydra.logging.maxFileSizeMB": 5,
+  "hydra.logging.maxFiles": 5
+}
+```
+
+Rules:
+
+- `hydra.logging.level` applies to file logging.
+- Output channel defaults to `info` and above.
+- `debug` is opt-in.
+- Invalid size/count values fall back to defaults.
+- The CLI should use the same defaults. CLI-specific config can be added later
+  if needed.
+
+## Technical Architecture
+
+Add shared core modules:
+
+```text
+src/core/logger.ts
+src/core/logRedaction.ts
+src/core/logRotation.ts
+```
+
+### `src/core/logger.ts`
+
+Responsibilities:
+
+- Define `LogLevel`, `LogEntry`, `LogContext`, and `LogSink`.
+- Export a singleton-style `logger`.
+- Support `debug`, `info`, `warn`, and `error`.
+- Queue log entries in memory and flush asynchronously.
+- Write JSONL to the rotating file sink.
+- Allow additional sinks for VS Code Output.
+- Expose helpers for log paths:
+  - `getHydraLogsDir()`
+  - `getHydraLogFilePath()`
+- Expose `flush()` for tests and process shutdown.
+
+Core should not import `vscode`.
+
+Suggested API:
+
+```ts
+logger.info('session.createCopilot', 'Creating copilot session', {
+  sessionName,
+  agent,
+  cwd,
+});
+
+logger.error('tmux.createSession', 'Failed to create multiplexer session', {
+  sessionName,
+  cwd,
+  error,
+});
+```
+
+### `src/core/logRedaction.ts`
+
+Responsibilities:
+
+- Redact secret-like key/value material.
+- Truncate large strings.
+- Normalize unknown errors into safe structured fields.
+
+Default redaction patterns:
+
+- `*_TOKEN`
+- `*_SECRET`
+- `*_PASSWORD`
+- `*_API_KEY`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GITHUB_TOKEN`
+- `Authorization: Bearer ...`
+- `sk-...` style API keys when they appear in command text.
+
+Default truncation:
+
+- `stdout`: 8 KB.
+- `stderr`: 8 KB.
+- `stack`: 8 KB.
+- `command`: 16 KB.
+- Any generic string field: 16 KB.
+
+### `src/core/logRotation.ts`
+
+Responsibilities:
+
+- Ensure `~/.hydra/logs` exists.
+- Check file size.
+- Rotate `hydra.log` through numbered backups.
+- Keep rotation side effects isolated from logging API code.
+
+### VS Code Wiring
+
+In `src/extension.ts`:
+
+- Create `vscode.window.createOutputChannel('Hydra')`.
+- Register an Output sink with the core logger.
+- Register `Hydra: Show Logs`, `Hydra: Open Logs Folder`, and
+  `Hydra: Copy Diagnostic Info`.
+- On activation, log:
+  - extension version
+  - platform
+  - Hydra home
+  - config path
+  - log path
+  - workspace folder count
+
+Update error handling in command files to log the full failure before showing a
+short toast:
+
+- `src/commands/createCopilot.ts`
+- `src/commands/newTask.ts`
+- `src/commands/attachCreate.ts`
+- `src/commands/removeTask.ts`
+- `src/commands/ensureBackendInstalled.ts`
+
+### CLI Wiring
+
+In `src/cli/index.ts`:
+
+- Initialize the file logger before registering commands.
+- Log CLI startup at `debug`.
+- On `beforeExit`, flush logger after telemetry.
+- On `SIGINT`/`SIGTERM`, flush best-effort before exiting.
+
+In `src/cli/output.ts`:
+
+- Log structured CLI errors before printing stderr and exiting.
+
+In `src/cli/commands/doctor.ts`:
+
+- Add log path and log writability checks.
+- Include log path in JSON output.
+
+## Logging Points
+
+### Shell Execution
+
+`src/core/exec.ts` is the most important integration point because it is the
+shared shell command boundary.
+
+Log:
+
+- `debug` before command execution:
+  - scope: `exec.start`
+  - command
+  - cwd
+- `debug` after successful command execution:
+  - scope: `exec.success`
+  - command
+  - cwd
+  - duration
+  - stdout length
+- `error` after failed command execution:
+  - scope: `exec.failure`
+  - command
+  - cwd
+  - duration
+  - exit code
+  - stdout/stderr snippets
+  - error message
+
+This would have captured the Windows `env -u ... psmux new-session ...`
+failure that motivated issue #213.
+
+### Multiplexer
+
+In `src/core/tmux.ts`, log:
+
+- `isInstalled`
+- `listSessions`
+- `createSession`
+- `hasSession`
+- `sendKeys`
+- `capturePane`
+
+Use operation-specific scopes such as `tmux.createSession`. Avoid logging the
+contents of `sendKeys` when it may contain a prompt. Record only command type,
+length, and hash when needed.
+
+### Session Lifecycle
+
+In `src/core/sessionManager.ts`, log:
+
+- `createCopilot`
+- `createWorker`
+- `startWorker`
+- `restore`
+- `delete`
+- `waitForReadyAndCaptureSessionId`
+- `captureAgentSessionInfo`
+
+Do not log full initial task text or onboarding prompt text. Log prompt length
+and hash only.
+
+## Privacy and Safety
+
+Logging must be useful enough for support without becoming a transcript or
+secret leak.
+
+Rules:
+
+- Never log full prompts or worker tasks.
+- Never log full environment maps.
+- Never log API keys or token-like values.
+- Redact secrets inside commands, stdout, stderr, error messages, and stacks.
+- Truncate large text fields before writing.
+- Treat logger failures as non-fatal.
+
+## Performance
+
+The logger should not meaningfully affect session creation speed.
+
+Implementation rules:
+
+- Logging calls enqueue entries and return quickly.
+- Flush asynchronously with a short debounce, e.g. 100 ms.
+- Flush immediately only for process shutdown or tests.
+- Batch writes with `appendFile`.
+- Keep debug logging disabled by default.
+- Bound each entry size before enqueueing.
+- Rotation checks run only before file flush, not on every field mutation.
+
+Expected default cost is a small number of file appends during user-triggered
+operations. These paths are not high frequency.
+
+## Testing Plan
+
+Add focused smoke/unit-style tests:
+
+- Redaction redacts token/password/API-key values in commands and stderr.
+- Truncation caps stdout/stderr/stack fields.
+- Rotation creates `hydra.1.log` and keeps only the configured count.
+- `exec()` failure writes an `exec.failure` entry with command, cwd, exit code,
+  stderr, and redacted content.
+- Logger failures do not throw into callers.
+
+Add a real CLI/e2e check:
+
+- Run Hydra with isolated `HYDRA_HOME`.
+- Force a session creation failure by setting an isolated command environment
+  where the multiplexer command cannot run, or by using an invalid
+  `HYDRA_TMUX_SOCKET`/backend setup that makes the create path fail.
+- Assert `~/.hydra/logs/hydra.log` exists.
+- Assert the log includes the failed command scope and error context.
+
+## V1 Acceptance Criteria
+
+- Failed copilot or worker creation creates `~/.hydra/logs/hydra.log`.
+- Logs include Hydra version or entry-point version, platform, cwd,
+  sessionName, agent, command scope, stderr/stdout snippet, and error message
+  when available.
+- VS Code `Output -> Hydra` shows high-level `info`, `warn`, and `error`
+  entries.
+- `hydra doctor` prints the log path and checks log directory writability.
+- Full user prompts and secret-like values are absent from the log.
+- Compile, lint, focused logger tests, and a real CLI/e2e logging check pass.
+
+## Open Questions
+
+- Should `Copy Diagnostic Info` include the last N error entries in a future
+  release? V1 should not include log excerpts automatically.
+- Should debug logging be configurable from CLI config as well as VS Code
+  settings? V1 can keep CLI defaults fixed.
+- Should diagnostic bundles include `sessions.json` with redaction? This is
+  useful but should be a separate product decision.

--- a/package.json
+++ b/package.json
@@ -192,6 +192,18 @@
       {
         "command": "hydra.startCopilotSudoCode",
         "title": "Hydra: Start Copilot (Sudo Code)"
+      },
+      {
+        "command": "hydra.showLogs",
+        "title": "Hydra: Show Logs"
+      },
+      {
+        "command": "hydra.openLogsFolder",
+        "title": "Hydra: Open Logs Folder"
+      },
+      {
+        "command": "hydra.copyDiagnosticInfo",
+        "title": "Hydra: Copy Diagnostic Info"
       }
     ],
     "keybindings": [
@@ -250,6 +262,29 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Automatically notify the parent copilot when a worker finishes its task. The notification is sent as a message to the copilot's tmux session."
+        },
+        "hydra.logging.level": {
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "default": "info",
+          "markdownDescription": "Minimum level written to the Hydra diagnostic log file. Debug logging is more verbose and may include command start/success entries."
+        },
+        "hydra.logging.maxFileSizeMB": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "markdownDescription": "Maximum size in MB of the active Hydra diagnostic log before rotation."
+        },
+        "hydra.logging.maxFiles": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "markdownDescription": "Maximum number of Hydra diagnostic log files to retain, including the active hydra.log."
         }
       }
     },
@@ -317,7 +352,10 @@
     "onCommand:hydra.startCopilotClaude",
     "onCommand:hydra.startCopilotCodex",
     "onCommand:hydra.startCopilotGemini",
-    "onCommand:hydra.startCopilotSudoCode"
+    "onCommand:hydra.startCopilotSudoCode",
+    "onCommand:hydra.showLogs",
+    "onCommand:hydra.openLogsFolder",
+    "onCommand:hydra.copyDiagnosticInfo"
   ],
   "scripts": {
     "compile": "tsc -p ./ && node scripts/postcompile.js",
@@ -337,13 +375,15 @@
     "smoke:telemetry": "node out/smoke/telemetrySmoke.js",
     "smoke:telemetry-e2e": "node out/smoke/telemetryE2eSmoke.js",
     "smoke:telemetry-posthog-real": "node out/smoke/telemetryPostHogRealSmoke.js",
+    "smoke:logging": "node out/smoke/loggingSmoke.js",
+    "smoke:logging-cli-e2e": "node out/smoke/loggingCliE2eSmoke.js",
     "smoke:session-file-resolve": "node out/smoke/sessionFileResolveSmoke.js",
     "smoke:sudocode-agent": "node out/smoke/sudocodeAgentSmoke.js",
     "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
     "smoke:cli-config": "node out/smoke/cliConfigSmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:share && npm run smoke:repo-registry"
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:share && npm run smoke:repo-registry"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, constants, accessSync } from 'fs';
 import { join, delimiter } from 'path';
-import { getHydraBinDir, getHydraConfigPath, getHydraHome } from '../../core/path';
+import { getHydraBinDir, getHydraConfigPath, getHydraHome, getHydraLogFile, getHydraLogsDir } from '../../core/path';
 import { type OutputOpts } from '../output';
 
 interface CheckResult {
@@ -54,6 +54,8 @@ export function registerDoctorCommand(program: Command): void {
       const hydraDir = getHydraHome();
       const hydraConfigPath = getHydraConfigPath();
       const hydraBinDir = getHydraBinDir();
+      const hydraLogsDir = getHydraLogsDir();
+      const hydraLogFile = getHydraLogFile();
       const hydraBin = join(hydraBinDir, process.platform === 'win32' ? 'hydra.cmd' : 'hydra');
 
       // 1. git
@@ -61,8 +63,12 @@ export function registerDoctorCommand(program: Command): void {
         ? { name: 'git', status: 'pass', message: 'git is installed' }
         : { name: 'git', status: 'fail', message: 'git not found — install from https://git-scm.com' });
 
-      // 2. tmux (not available on Windows)
-      if (process.platform !== 'win32') {
+      // 2. Multiplexer backend
+      if (process.platform === 'win32') {
+        checks.push(checkOnPath('psmux')
+          ? { name: 'psmux', status: 'pass', message: 'psmux is installed' }
+          : { name: 'psmux', status: 'fail', message: 'psmux not found — install with: winget install psmux' });
+      } else {
         checks.push(checkOnPath('tmux')
           ? { name: 'tmux', status: 'pass', message: 'tmux is installed' }
           : { name: 'tmux', status: 'fail', message: 'tmux not found — install with: brew install tmux' });
@@ -88,7 +94,17 @@ export function registerDoctorCommand(program: Command): void {
         checks.push({ name: 'hydra-config', status: 'warn', message: `Hydra config not found yet: ${hydraConfigPath}` });
       }
 
-      // 6. Hydra CLI binary
+      // 6. Hydra log directory
+      try {
+        mkdirSync(hydraLogsDir, { recursive: true });
+        accessSync(hydraLogsDir, constants.W_OK);
+        checks.push({ name: 'hydra-logs', status: 'pass', message: `Hydra log path is writable: ${hydraLogFile}` });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        checks.push({ name: 'hydra-logs', status: 'fail', message: `Hydra log path is not writable: ${hydraLogFile} (${message})` });
+      }
+
+      // 7. Hydra CLI binary
       if (existsSync(hydraBin) && isExecutable(hydraBin)) {
         checks.push({ name: 'hydra-cli', status: 'pass', message: `Hydra CLI is installed at ${hydraBin}` });
       } else {
@@ -98,7 +114,7 @@ export function registerDoctorCommand(program: Command): void {
         checks.push({ name: 'hydra-cli', status: 'fail', message: `Hydra CLI not found at ${hydraBin} — open VS Code with the Hydra extension installed to auto-install` });
       }
 
-      // 7. Hydra bin in PATH
+      // 8. Hydra bin in PATH
       const pathDirs = (process.env.PATH || '').split(delimiter);
       const binInPath = pathDirs.some(d => d === hydraBinDir);
       if (binInPath) {
@@ -110,12 +126,12 @@ export function registerDoctorCommand(program: Command): void {
         checks.push({ name: 'hydra-path', status: 'warn', message: `${hydraBinDir} is not in PATH — add to your shell profile:\n    ${pathHint}` });
       }
 
-      // 8. GitHub CLI
+      // 9. GitHub CLI
       checks.push(checkOnPath('gh')
         ? { name: 'gh', status: 'pass', message: 'GitHub CLI is installed' }
         : { name: 'gh', status: 'fail', message: 'gh not found — install from https://cli.github.com' });
 
-      // 9. GitHub CLI authenticated
+      // 10. GitHub CLI authenticated
       if (checkOnPath('gh')) {
         checks.push(ghAuthenticated()
           ? { name: 'gh-auth', status: 'pass', message: 'GitHub CLI is authenticated' }
@@ -124,7 +140,7 @@ export function registerDoctorCommand(program: Command): void {
         checks.push({ name: 'gh-auth', status: 'fail', message: 'gh is not authenticated (gh not installed)' });
       }
 
-      // 10. AI agent CLIs
+      // 11. AI agent CLIs
       const agents = ['claude', 'codex', 'gemini', 'scode'];
       const foundAgents = agents.filter(a => checkOnPath(a));
       if (foundAgents.length > 0) {
@@ -141,7 +157,7 @@ export function registerDoctorCommand(program: Command): void {
 
       // Output
       if (globalOpts.json) {
-        console.log(JSON.stringify({ checks, passed, failed, warned }));
+        console.log(JSON.stringify({ checks, passed, failed, warned, hydraLogFile }));
       } else if (!globalOpts.quiet) {
         console.log('\nHydra Doctor\n');
         for (const check of checks) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,8 +13,19 @@ import { registerTestCommand } from './commands/test';
 import { registerShareCommands } from './commands/share';
 import { registerConfigCommands } from './commands/config';
 import { peekTelemetry } from '../core/telemetry';
+import { getHydraConfigPath, getHydraHome, getHydraLogFile } from '../core/path';
+import { getHostSummary, logger } from '../core/logger';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+logger.debug('cli.start', 'Hydra CLI started', {
+  version: pkg.version,
+  command: process.argv[2],
+  subcommand: process.argv[3],
+  hydraHome: getHydraHome(),
+  hydraConfigPath: getHydraConfigPath(),
+  hydraLogFile: getHydraLogFile(),
+  ...getHostSummary(),
+});
 
 const program = new Command();
 program
@@ -49,7 +60,20 @@ process.on('beforeExit', async () => {
   } catch {
     // never let telemetry crash the CLI
   }
+  await logger.flush();
 });
+
+process.on('exit', () => {
+  logger.flushSync();
+});
+
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, () => {
+    logger.warn('cli.signal', 'Hydra CLI received signal', { signal });
+    logger.flushSync();
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  });
+}
 
 registerListCommand(program);
 registerWorkerCommands(program);

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,3 +1,5 @@
+import { logger } from '../core/logger';
+
 // Exit codes following agent-friendly CLI conventions
 export const EXIT_OK = 0;
 export const EXIT_INTERNAL = 1;
@@ -40,6 +42,11 @@ export function outputError(error: unknown, opts: OutputOpts): never {
   const message = error instanceof Error ? error.message : String(error);
   const code = classifyError(message);
   const retryable = code === EXIT_INTERNAL;
+  logger.error('cli.error', 'Hydra CLI command failed', {
+    exitCode: code,
+    retryable,
+    error,
+  });
 
   if (opts.json) {
     const errorObj: Record<string, unknown> = { error: { code, message, retryable } };
@@ -52,6 +59,7 @@ export function outputError(error: unknown, opts: OutputOpts): never {
     console.error(`Error: ${message}`);
   }
 
+  logger.flushSync();
   process.exit(code);
 }
 

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -7,6 +7,7 @@ import { SessionManager } from '../core/sessionManager';
 import { TmuxBackendCore } from '../core/tmux';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { sendCopilotOnboarding } from './createCopilot';
+import { showHydraCommandError } from './logs';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
@@ -119,7 +120,6 @@ export async function attachCreate(item?: TmuxItem | string): Promise<void> {
         await handleCommandExecution();
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to attach/create: ${message}`);
+    void showHydraCommandError('Failed to attach/create', 'command.attachCreate', error);
   }
 }

--- a/src/commands/createCopilot.ts
+++ b/src/commands/createCopilot.ts
@@ -6,6 +6,7 @@ import { CopilotMode } from '../core/types';
 import { TmuxBackendCore } from '../core/tmux';
 import { SessionManager } from '../core/sessionManager';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
+import { showHydraCommandError } from './logs';
 
 const ONBOARDING_PROMPT = `You are a Hydra copilot — an AI orchestrator that manages parallel AI workers to complete complex tasks.
 
@@ -148,8 +149,11 @@ export async function createCopilotWithAgent(agentType: AgentType, copilotMode?:
     vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, resolvedMode));
     vscode.commands.executeCommand('tmux.refresh');
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to create copilot: ${message}`);
+    void showHydraCommandError('Failed to create copilot', 'command.createCopilotWithAgent', error, {
+      agent: agentType,
+      copilotMode: resolvedMode,
+      sessionName,
+    });
   }
 }
 
@@ -214,7 +218,11 @@ export async function createCopilot(): Promise<void> {
     vscode.window.showInformationMessage(getCreatedMessage(sessionName, agentType, copilotMode));
     vscode.commands.executeCommand('tmux.refresh');
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to create copilot: ${message}`);
+    void showHydraCommandError('Failed to create copilot', 'command.createCopilot', error, {
+      agent: agentType,
+      copilotMode,
+      sessionName,
+      requestedName: nameInput.trim(),
+    });
   }
 }

--- a/src/commands/ensureBackendInstalled.ts
+++ b/src/commands/ensureBackendInstalled.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { MultiplexerBackend } from '../utils/multiplexer';
+import { logger } from '../core/logger';
 
 const INSTALL_PSMUX_ACTION = 'Install psmux';
 const COPY_COMMAND_ACTION = 'Copy command';
@@ -25,12 +26,14 @@ async function promptForPsmuxInstall(): Promise<void> {
   );
 
   if (choice === INSTALL_PSMUX_ACTION) {
+    logger.info('command.ensureBackendInstalled', 'Starting psmux installation terminal');
     showPsmuxInstallTerminal();
     return;
   }
 
   if (choice === COPY_COMMAND_ACTION) {
     await vscode.env.clipboard.writeText(PSMUX_INSTALL_COMMAND);
+    logger.info('command.ensureBackendInstalled', 'Copied psmux install command');
     void vscode.window.showInformationMessage('Copied psmux install command to clipboard.');
   }
 }
@@ -43,15 +46,21 @@ async function promptForTmuxInstall(backend: MultiplexerBackend): Promise<void> 
 
   if (choice === COPY_COMMAND_ACTION) {
     await vscode.env.clipboard.writeText(TMUX_INSTALL_COMMAND);
+    logger.info('command.ensureBackendInstalled', 'Copied tmux install command', { backend: backend.displayName });
     void vscode.window.showInformationMessage('Copied tmux install command to clipboard.');
   }
 }
 
 export async function ensureBackendInstalled(backend: MultiplexerBackend): Promise<boolean> {
   if (await backend.isInstalled()) {
+    logger.debug('command.ensureBackendInstalled', 'Multiplexer backend is installed', { backend: backend.displayName });
     return true;
   }
 
+  logger.warn('command.ensureBackendInstalled', 'Multiplexer backend is missing', {
+    backend: backend.displayName,
+    platform: process.platform,
+  });
   if (process.platform === 'win32') {
     await promptForPsmuxInstall();
     return false;

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,135 @@
+import * as vscode from 'vscode';
+import {
+  formatLogEntryForOutput,
+  getHostSummary,
+  getHydraLogFilePath,
+  getHydraLogsDirectory,
+  isLogLevel,
+  logger,
+  type LogContext,
+  type LogLevel,
+} from '../core/logger';
+import { getHydraConfigPath, getHydraHome, getTmuxCommand } from '../core/path';
+import { getHydraGlobalDefaultAgent } from '../core/hydraGlobalConfig';
+
+export const HYDRA_SHOW_LOGS_COMMAND = 'hydra.showLogs';
+export const HYDRA_OPEN_LOGS_FOLDER_COMMAND = 'hydra.openLogsFolder';
+export const HYDRA_COPY_DIAGNOSTIC_INFO_COMMAND = 'hydra.copyDiagnosticInfo';
+
+const SHOW_LOGS_ACTION = 'Show Logs';
+const OPEN_LOGS_FOLDER_ACTION = 'Open Logs Folder';
+const COPY_DETAILS_ACTION = 'Copy Details';
+
+export function configureLoggerFromVSCode(): void {
+  const hydraConfig = vscode.workspace.getConfiguration('hydra');
+  const rawLevel = hydraConfig.get<string>('logging.level', 'info');
+  const level = rawLevel && isLogLevel(rawLevel) ? rawLevel : 'info';
+  const maxFileSizeMB = hydraConfig.get<number>('logging.maxFileSizeMB', 5);
+  const maxFiles = hydraConfig.get<number>('logging.maxFiles', 5);
+
+  logger.configure({
+    level,
+    maxFileSizeBytes: Math.max(1, maxFileSizeMB) * 1024 * 1024,
+    maxFiles: Math.max(1, maxFiles),
+  });
+}
+
+export function registerHydraLogCommands(
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel,
+): void {
+  context.subscriptions.push(
+    outputChannel,
+    {
+      dispose: logger.addSink((entry) => {
+        if (shouldShowInOutput(entry.level)) {
+          outputChannel.appendLine(formatLogEntryForOutput(entry));
+        }
+      }),
+    },
+    vscode.commands.registerCommand(HYDRA_SHOW_LOGS_COMMAND, () => {
+      outputChannel.show(true);
+    }),
+    vscode.commands.registerCommand(HYDRA_OPEN_LOGS_FOLDER_COMMAND, async () => {
+      logger.ensureLogsDir();
+      await vscode.env.openExternal(vscode.Uri.file(getHydraLogsDirectory()));
+    }),
+    vscode.commands.registerCommand(HYDRA_COPY_DIAGNOSTIC_INFO_COMMAND, async () => {
+      await vscode.env.clipboard.writeText(buildDiagnosticInfo(context));
+      void vscode.window.showInformationMessage('Hydra diagnostic info copied.');
+    }),
+  );
+}
+
+export async function showHydraCommandError(
+  title: string,
+  scope: string,
+  error: unknown,
+  context?: LogContext,
+): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+  logger.error(scope, title, { ...context, error });
+  const choice = await vscode.window.showErrorMessage(
+    `${title}: ${message}`,
+    SHOW_LOGS_ACTION,
+    OPEN_LOGS_FOLDER_ACTION,
+    COPY_DETAILS_ACTION,
+  );
+
+  if (choice === SHOW_LOGS_ACTION) {
+    await vscode.commands.executeCommand(HYDRA_SHOW_LOGS_COMMAND);
+  } else if (choice === OPEN_LOGS_FOLDER_ACTION) {
+    await vscode.commands.executeCommand(HYDRA_OPEN_LOGS_FOLDER_COMMAND);
+  } else if (choice === COPY_DETAILS_ACTION) {
+    await vscode.env.clipboard.writeText([
+      title,
+      `Message: ${message}`,
+      `Log file: ${getHydraLogFilePath()}`,
+      '',
+      buildDiagnosticInfo(),
+    ].join('\n'));
+    void vscode.window.showInformationMessage('Hydra error details copied.');
+  }
+}
+
+export function logExtensionActivated(context: vscode.ExtensionContext): void {
+  logger.info('extension.activate', 'Hydra extension activated', {
+    version: getExtensionVersion(context),
+    hydraHome: getHydraHome(),
+    hydraConfigPath: getHydraConfigPath(),
+    hydraLogFile: getHydraLogFilePath(),
+    workspaceFolderCount: vscode.workspace.workspaceFolders?.length ?? 0,
+    ...getHostSummary(),
+  });
+}
+
+function shouldShowInOutput(level: LogLevel): boolean {
+  return level === 'info' || level === 'warn' || level === 'error';
+}
+
+function buildDiagnosticInfo(context?: vscode.ExtensionContext): string {
+  let defaultAgent = 'unknown';
+  try {
+    defaultAgent = getHydraGlobalDefaultAgent().agent;
+  } catch {
+    // Config may not have been initialized yet.
+  }
+
+  return [
+    'Hydra diagnostics',
+    `Version: ${context ? getExtensionVersion(context) : 'unknown'}`,
+    `Platform: ${process.platform}`,
+    `Arch: ${process.arch}`,
+    `Node: ${process.version}`,
+    `Hydra home: ${getHydraHome()}`,
+    `Hydra config: ${getHydraConfigPath()}`,
+    `Hydra log: ${getHydraLogFilePath()}`,
+    `Multiplexer command: ${getTmuxCommand()}`,
+    `Default agent: ${defaultAgent}`,
+  ].join('\n');
+}
+
+function getExtensionVersion(context: vscode.ExtensionContext): string {
+  const packageJson = context.extension.packageJSON as { version?: unknown };
+  return typeof packageJson.version === 'string' ? packageJson.version : 'unknown';
+}

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -8,6 +8,7 @@ import { pickAgentType } from '../utils/agentConfig';
 import { getActiveBackend } from '../utils/multiplexer';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { detectIdentity, getWorkerCreationBlockedMessage } from '../core/sessionIdentity';
+import { showHydraCommandError } from './logs';
 
 function getBaseBranchOverride(): string | undefined {
   const hydraOverride = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch');
@@ -225,8 +226,8 @@ export async function newTask(): Promise<void> {
     return;
   }
 
-  let workspacePath: string;
-  let repoRoot: string | null;
+  let workspacePath = '';
+  let repoRoot: string | null = null;
   try {
     workspacePath = getRepoRoot();
     repoRoot = await tryGetWorkspaceGitRoot(workspacePath);
@@ -236,8 +237,7 @@ export async function newTask(): Promise<void> {
       return;
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+    void showHydraCommandError('Failed to create worker', 'command.createWorker.preflight', error);
     return;
   }
 
@@ -271,7 +271,9 @@ export async function newTask(): Promise<void> {
       await createTaskWorker(workspacePath, false);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    vscode.window.showErrorMessage(`Failed to create worker: ${message}`);
+    void showHydraCommandError('Failed to create worker', 'command.createWorker', error, {
+      workspacePath,
+      repoRoot,
+    });
   }
 }

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -3,12 +3,14 @@ import path from 'node:path';
 import os from 'node:os';
 import { promisify } from 'util';
 import { getIsolatedEnv } from './path';
+import { logger } from './logger';
 
 const execPromise = promisify(execCallback);
 const execFilePromise = promisify(execFileCallback);
 
 export interface ExecOptions {
   cwd?: string;
+  logFailure?: boolean;
 }
 
 // VS Code is a GUI app and doesn't inherit shell PATH.
@@ -63,11 +65,49 @@ function getExecEnv(): Record<string, string | undefined> {
 }
 
 export async function exec(command: string, options?: ExecOptions): Promise<string> {
-  const { stdout } = await execPromise(command, {
-    cwd: options?.cwd,
-    env: getExecEnv(),
-  });
-  return stdout.trim();
+  const startedAt = Date.now();
+  const cwd = options?.cwd;
+  logger.debug('exec.start', 'Running shell command', { command, cwd });
+  try {
+    const { stdout } = await execPromise(command, {
+      cwd,
+      env: getExecEnv(),
+    });
+    logger.debug('exec.success', 'Shell command completed', {
+      command,
+      cwd,
+      durationMs: Date.now() - startedAt,
+      stdoutLength: stdout.length,
+    });
+    return stdout.trim();
+  } catch (error) {
+    const failure = error as Error & {
+      code?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+    };
+    if (options?.logFailure === false) {
+      logger.debug('exec.probeFailure', 'Shell probe command failed', {
+        command,
+        cwd,
+        durationMs: Date.now() - startedAt,
+        exitCode: failure.code,
+        stdoutLength: typeof failure.stdout === 'string' ? failure.stdout.length : undefined,
+        stderrLength: typeof failure.stderr === 'string' ? failure.stderr.length : undefined,
+      });
+    } else {
+      logger.error('exec.failure', 'Shell command failed', {
+        command,
+        cwd,
+        durationMs: Date.now() - startedAt,
+        exitCode: failure.code,
+        stdout: failure.stdout,
+        stderr: failure.stderr,
+        error,
+      });
+    }
+    throw error;
+  }
 }
 
 function posixShellQuote(value: string): string {

--- a/src/core/logRedaction.ts
+++ b/src/core/logRedaction.ts
@@ -1,0 +1,150 @@
+import * as crypto from 'crypto';
+
+export const DEFAULT_STDIO_LIMIT = 8 * 1024;
+export const DEFAULT_COMMAND_LIMIT = 16 * 1024;
+export const DEFAULT_STRING_LIMIT = 16 * 1024;
+
+const REDACTED = '[REDACTED]';
+
+const SECRET_KEY_PATTERN = /(?:^|[_-])(TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|AUTH)(?:$|[_-])/i;
+const KEY_VALUE_SECRET_PATTERN = /(\b[A-Z0-9_.-]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY)[A-Z0-9_.-]*\b\s*[:=]\s*)(['"]?)([^\s'",;]+)/gi;
+const BEARER_PATTERN = /(Authorization\s*:\s*Bearer\s+)([A-Za-z0-9._~+/=-]+)/gi;
+const OPENAI_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{16,}\b/g;
+const GITHUB_TOKEN_PATTERN = /\bgh[opsu]_[A-Za-z0-9_]{20,}\b/g;
+
+export type SanitizedLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SanitizedLogValue[]
+  | { [key: string]: SanitizedLogValue };
+
+export function isSecretLikeKey(key: string): boolean {
+  if (SECRET_KEY_PATTERN.test(key)) {
+    return true;
+  }
+  const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+  return normalized.includes('token') ||
+    normalized.includes('secret') ||
+    normalized.includes('password') ||
+    normalized.includes('passwd') ||
+    normalized.includes('apikey') ||
+    normalized.includes('accesskey');
+}
+
+export function redactText(value: string, limit = DEFAULT_STRING_LIMIT): string {
+  const redacted = value
+    .replace(KEY_VALUE_SECRET_PATTERN, `$1$2${REDACTED}`)
+    .replace(BEARER_PATTERN, `$1${REDACTED}`)
+    .replace(OPENAI_KEY_PATTERN, REDACTED)
+    .replace(GITHUB_TOKEN_PATTERN, REDACTED);
+  return truncateText(redacted, limit);
+}
+
+export function truncateText(value: string, limit = DEFAULT_STRING_LIMIT): string {
+  if (value.length <= limit) {
+    return value;
+  }
+  return `${value.slice(0, limit)}...[truncated ${value.length - limit} chars]`;
+}
+
+export function hashText(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+export function sanitizeLogValue(key: string, value: unknown): SanitizedLogValue | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (isSecretLikeKey(key)) {
+    return REDACTED;
+  }
+
+  const limit = getLimitForKey(key);
+
+  if (value instanceof Error) {
+    const sanitized: { [key: string]: SanitizedLogValue } = {
+      name: value.name,
+      message: redactText(value.message, limit),
+    };
+    if (value.stack) {
+      sanitized.stack = redactText(value.stack, DEFAULT_STDIO_LIMIT);
+    }
+    const maybeError = value as Error & {
+      code?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+    };
+    if (maybeError.code !== undefined) {
+      const code = sanitizeLogValue('code', maybeError.code);
+      if (code !== undefined) sanitized.code = code;
+    }
+    if (maybeError.stdout !== undefined) {
+      const stdout = sanitizeLogValue('stdout', maybeError.stdout);
+      if (stdout !== undefined) sanitized.stdout = stdout;
+    }
+    if (maybeError.stderr !== undefined) {
+      const stderr = sanitizeLogValue('stderr', maybeError.stderr);
+      if (stderr !== undefined) sanitized.stderr = stderr;
+    }
+    return sanitized;
+  }
+
+  if (typeof value === 'string') {
+    return redactText(value, limit);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return Number.isFinite(value as number) || typeof value !== 'number' ? value as SanitizedLogValue : String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 50)
+      .map((entry, index) => sanitizeLogValue(`${key}.${index}`, entry))
+      .filter((entry): entry is SanitizedLogValue => entry !== undefined);
+  }
+
+  if (typeof value === 'object') {
+    const result: { [key: string]: SanitizedLogValue } = {};
+    for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+      const sanitized = sanitizeLogValue(childKey, childValue);
+      if (sanitized !== undefined) {
+        result[childKey] = sanitized;
+      }
+    }
+    return result;
+  }
+
+  return redactText(String(value), limit);
+}
+
+export function sanitizeLogContext(context?: Record<string, unknown>): Record<string, SanitizedLogValue> {
+  const sanitized: Record<string, SanitizedLogValue> = {};
+  if (!context) {
+    return sanitized;
+  }
+
+  for (const [key, value] of Object.entries(context)) {
+    const safeValue = sanitizeLogValue(key, value);
+    if (safeValue !== undefined) {
+      sanitized[key] = safeValue;
+    }
+  }
+  return sanitized;
+}
+
+function getLimitForKey(key: string): number {
+  switch (key) {
+    case 'stdout':
+    case 'stderr':
+    case 'stack':
+      return DEFAULT_STDIO_LIMIT;
+    case 'command':
+      return DEFAULT_COMMAND_LIMIT;
+    default:
+      return DEFAULT_STRING_LIMIT;
+  }
+}

--- a/src/core/logRotation.ts
+++ b/src/core/logRotation.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface LogRotationOptions {
+  maxFileSizeBytes: number;
+  maxFiles: number;
+}
+
+export const DEFAULT_LOG_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+export const DEFAULT_LOG_MAX_FILES = 5;
+
+export function normalizeRotationOptions(options?: Partial<LogRotationOptions>): LogRotationOptions {
+  const maxFileSizeBytes = Number.isFinite(options?.maxFileSizeBytes)
+    ? Math.max(1024, Math.floor(options!.maxFileSizeBytes!))
+    : DEFAULT_LOG_MAX_FILE_SIZE_BYTES;
+  const maxFiles = Number.isFinite(options?.maxFiles)
+    ? Math.max(1, Math.floor(options!.maxFiles!))
+    : DEFAULT_LOG_MAX_FILES;
+  return { maxFileSizeBytes, maxFiles };
+}
+
+export async function appendRotatingLog(
+  filePath: string,
+  content: string,
+  options?: Partial<LogRotationOptions>,
+): Promise<void> {
+  const normalized = normalizeRotationOptions(options);
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  if (await shouldRotate(filePath, Buffer.byteLength(content), normalized.maxFileSizeBytes)) {
+    await rotateLogFiles(filePath, normalized.maxFiles);
+  }
+  await fs.promises.appendFile(filePath, content, 'utf-8');
+}
+
+export function appendRotatingLogSync(
+  filePath: string,
+  content: string,
+  options?: Partial<LogRotationOptions>,
+): void {
+  const normalized = normalizeRotationOptions(options);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (shouldRotateSync(filePath, Buffer.byteLength(content), normalized.maxFileSizeBytes)) {
+    rotateLogFilesSync(filePath, normalized.maxFiles);
+  }
+  fs.appendFileSync(filePath, content, 'utf-8');
+}
+
+export async function ensureLogDirectory(dirPath: string): Promise<void> {
+  await fs.promises.mkdir(dirPath, { recursive: true });
+}
+
+export function ensureLogDirectorySync(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+async function shouldRotate(filePath: string, pendingBytes: number, maxFileSizeBytes: number): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(filePath);
+    return stat.size + pendingBytes > maxFileSizeBytes;
+  } catch {
+    return false;
+  }
+}
+
+function shouldRotateSync(filePath: string, pendingBytes: number, maxFileSizeBytes: number): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.size + pendingBytes > maxFileSizeBytes;
+  } catch {
+    return false;
+  }
+}
+
+async function rotateLogFiles(filePath: string, maxFiles: number): Promise<void> {
+  if (maxFiles <= 1) {
+    await removeIfExists(filePath);
+    return;
+  }
+
+  await removeIfExists(rotatedPath(filePath, maxFiles - 1));
+  for (let index = maxFiles - 2; index >= 1; index--) {
+    await renameIfExists(rotatedPath(filePath, index), rotatedPath(filePath, index + 1));
+  }
+  await renameIfExists(filePath, rotatedPath(filePath, 1));
+}
+
+function rotateLogFilesSync(filePath: string, maxFiles: number): void {
+  if (maxFiles <= 1) {
+    removeIfExistsSync(filePath);
+    return;
+  }
+
+  removeIfExistsSync(rotatedPath(filePath, maxFiles - 1));
+  for (let index = maxFiles - 2; index >= 1; index--) {
+    renameIfExistsSync(rotatedPath(filePath, index), rotatedPath(filePath, index + 1));
+  }
+  renameIfExistsSync(filePath, rotatedPath(filePath, 1));
+}
+
+function rotatedPath(filePath: string, index: number): string {
+  const ext = path.extname(filePath);
+  const base = filePath.slice(0, filePath.length - ext.length);
+  return `${base}.${index}${ext}`;
+}
+
+async function removeIfExists(filePath: string): Promise<void> {
+  try {
+    await fs.promises.rm(filePath, { force: true });
+  } catch {
+    // Best effort. Logging must not crash Hydra.
+  }
+}
+
+function removeIfExistsSync(filePath: string): void {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch {
+    // Best effort. Logging must not crash Hydra.
+  }
+}
+
+async function renameIfExists(from: string, to: string): Promise<void> {
+  try {
+    await fs.promises.rename(from, to);
+  } catch {
+    // Missing older rotations are normal.
+  }
+}
+
+function renameIfExistsSync(from: string, to: string): void {
+  try {
+    fs.renameSync(from, to);
+  } catch {
+    // Missing older rotations are normal.
+  }
+}

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,254 @@
+import * as os from 'os';
+import { appendRotatingLog, appendRotatingLogSync, DEFAULT_LOG_MAX_FILE_SIZE_BYTES, DEFAULT_LOG_MAX_FILES, ensureLogDirectorySync, type LogRotationOptions } from './logRotation';
+import { sanitizeLogContext, type SanitizedLogValue } from './logRedaction';
+import { getHydraLogFile, getHydraLogsDir } from './path';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  scope: string;
+  message: string;
+  platform: string;
+  pid: number;
+  [key: string]: SanitizedLogValue | string | number;
+}
+
+export type LogContext = Record<string, unknown>;
+export type LogSink = (entry: LogEntry, line: string) => void;
+
+export interface LoggerConfig extends Partial<LogRotationOptions> {
+  level?: LogLevel;
+  filePath?: string;
+  flushDelayMs?: number;
+}
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const DEFAULT_FLUSH_DELAY_MS = 100;
+
+class HydraLogger {
+  private queue: string[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | undefined;
+  private flushInProgress: Promise<void> | undefined;
+  private sinks = new Set<LogSink>();
+  private config: Required<Pick<LoggerConfig, 'level' | 'flushDelayMs'>> & {
+    filePath?: string;
+    maxFileSizeBytes: number;
+    maxFiles: number;
+  } = {
+    level: 'info',
+    flushDelayMs: DEFAULT_FLUSH_DELAY_MS,
+    maxFileSizeBytes: DEFAULT_LOG_MAX_FILE_SIZE_BYTES,
+    maxFiles: DEFAULT_LOG_MAX_FILES,
+  };
+
+  configure(config: LoggerConfig): void {
+    if (config.level && isLogLevel(config.level)) {
+      this.config.level = config.level;
+    }
+    if (config.filePath) {
+      this.config.filePath = config.filePath;
+    }
+    if (Number.isFinite(config.maxFileSizeBytes)) {
+      this.config.maxFileSizeBytes = Math.max(1024, Math.floor(config.maxFileSizeBytes!));
+    }
+    if (Number.isFinite(config.maxFiles)) {
+      this.config.maxFiles = Math.max(1, Math.floor(config.maxFiles!));
+    }
+    if (Number.isFinite(config.flushDelayMs)) {
+      this.config.flushDelayMs = Math.max(0, Math.floor(config.flushDelayMs!));
+    }
+  }
+
+  addSink(sink: LogSink): () => void {
+    this.sinks.add(sink);
+    return () => this.sinks.delete(sink);
+  }
+
+  debug(scope: string, message: string, context?: LogContext): void {
+    this.log('debug', scope, message, context);
+  }
+
+  info(scope: string, message: string, context?: LogContext): void {
+    this.log('info', scope, message, context);
+  }
+
+  warn(scope: string, message: string, context?: LogContext): void {
+    this.log('warn', scope, message, context);
+  }
+
+  error(scope: string, message: string, context?: LogContext): void {
+    this.log('error', scope, message, context);
+  }
+
+  log(level: LogLevel, scope: string, message: string, context?: LogContext): void {
+    if (!this.shouldLog(level)) {
+      return;
+    }
+
+    const entry: LogEntry = {
+      ts: new Date().toISOString(),
+      level,
+      scope,
+      message,
+      platform: process.platform,
+      pid: process.pid,
+      ...sanitizeLogContext(context),
+    };
+    const line = `${JSON.stringify(entry)}\n`;
+
+    for (const sink of this.sinks) {
+      try {
+        sink(entry, line);
+      } catch {
+        // Sink failures must not affect Hydra.
+      }
+    }
+
+    this.queue.push(line);
+    this.scheduleFlush();
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    if (this.flushInProgress) {
+      await this.flushInProgress.catch(() => {});
+    }
+    const lines = this.drainQueue();
+    if (!lines) {
+      return;
+    }
+    const filePath = this.getFilePath();
+    const rotation = this.getRotationOptions();
+    this.flushInProgress = appendRotatingLog(filePath, lines, rotation)
+      .catch(() => {})
+      .finally(() => {
+        this.flushInProgress = undefined;
+      });
+    await this.flushInProgress;
+  }
+
+  flushSync(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    const lines = this.drainQueue();
+    if (!lines) {
+      return;
+    }
+    try {
+      appendRotatingLogSync(this.getFilePath(), lines, this.getRotationOptions());
+    } catch {
+      // Logging must not crash Hydra.
+    }
+  }
+
+  getLogFilePath(): string {
+    return this.getFilePath();
+  }
+
+  getLogsDir(): string {
+    return getHydraLogsDir();
+  }
+
+  ensureLogsDir(): void {
+    ensureLogDirectorySync(this.getLogsDir());
+  }
+
+  resetForTests(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    this.queue = [];
+    this.flushInProgress = undefined;
+    this.sinks.clear();
+    this.config = {
+      level: 'info',
+      flushDelayMs: DEFAULT_FLUSH_DELAY_MS,
+      maxFileSizeBytes: DEFAULT_LOG_MAX_FILE_SIZE_BYTES,
+      maxFiles: DEFAULT_LOG_MAX_FILES,
+    };
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_ORDER[level] >= LEVEL_ORDER[this.config.level];
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) {
+      return;
+    }
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      void this.flush();
+    }, this.config.flushDelayMs);
+  }
+
+  private drainQueue(): string {
+    const lines = this.queue.join('');
+    this.queue = [];
+    return lines;
+  }
+
+  private getFilePath(): string {
+    return this.config.filePath || getHydraLogFile();
+  }
+
+  private getRotationOptions(): LogRotationOptions {
+    return {
+      maxFileSizeBytes: this.config.maxFileSizeBytes,
+      maxFiles: this.config.maxFiles,
+    };
+  }
+}
+
+export const logger = new HydraLogger();
+
+export function isLogLevel(value: string): value is LogLevel {
+  return value === 'debug' || value === 'info' || value === 'warn' || value === 'error';
+}
+
+export function formatLogEntryForOutput(entry: LogEntry): string {
+  const details = Object.entries(entry)
+    .filter(([key]) => !['ts', 'level', 'scope', 'message', 'platform', 'pid'].includes(key))
+    .map(([key, value]) => `${key}=${formatOutputValue(value)}`)
+    .join(' ');
+  return `[${entry.ts}] [${entry.level}] ${entry.scope}: ${entry.message}${details ? ` ${details}` : ''}`;
+}
+
+function formatOutputValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.includes(' ') ? JSON.stringify(value) : value;
+  }
+  return JSON.stringify(value);
+}
+
+export function getHydraLogsDirectory(): string {
+  return getHydraLogsDir();
+}
+
+export function getHydraLogFilePath(): string {
+  return getHydraLogFile();
+}
+
+export function getHostSummary(): Record<string, string | number> {
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    pid: process.pid,
+    home: os.homedir(),
+  };
+}

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -295,6 +295,8 @@ export interface HydraResolvedPaths {
   hydraBinDir: string;
   hydraSessionsFile: string;
   hydraArchiveFile: string;
+  hydraLogsDir: string;
+  hydraLogFile: string;
   hydraWorktreesRoot: string;
   hydraReposRoot: string;
   hydraTasksRoot: string;
@@ -369,6 +371,8 @@ export function getHydraPaths(): HydraResolvedPaths {
     hydraBinDir: path.join(hydraHome, 'bin'),
     hydraSessionsFile: path.join(hydraHome, 'sessions.json'),
     hydraArchiveFile: path.join(hydraHome, 'archive.json'),
+    hydraLogsDir: path.join(hydraHome, 'logs'),
+    hydraLogFile: path.join(hydraHome, 'logs', 'hydra.log'),
     hydraWorktreesRoot: path.join(hydraHome, 'worktrees'),
     hydraReposRoot: path.join(hydraHome, 'repos'),
     hydraTasksRoot: path.join(hydraHome, 'tasks'),
@@ -403,6 +407,14 @@ export function getHydraSessionsFile(): string {
 
 export function getHydraArchiveFile(): string {
   return getHydraPaths().hydraArchiveFile;
+}
+
+export function getHydraLogsDir(): string {
+  return getHydraPaths().hydraLogsDir;
+}
+
+export function getHydraLogFile(): string {
+  return getHydraPaths().hydraLogFile;
 }
 
 export function getHydraWorktreesRoot(): string {

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -9,6 +9,8 @@ import { HYDRA_COPILOT_SESSION_ENV } from './env';
 import { exec, resolveCommandPath } from './exec';
 import { expandAndResolvePath, getHydraArchiveFile, getHydraHome, getHydraSessionsFile, getHydraTasksRoot, resolveAgentSessionFile, toCanonicalPath } from './path';
 import { shellQuote } from './shell';
+import { logger } from './logger';
+import { hashText } from './logRedaction';
 
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 75000;
 const SESSION_STATE_LOCK_TIMEOUT_MS = 10000;
@@ -524,6 +526,15 @@ export class SessionManager {
     let { task, taskFile } = opts;
     const agentType = opts.agentType || getHydraGlobalDefaultAgent().agent;
     let agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
+    logger.info('session.createRepoWorker', 'Creating code worker', {
+      repoRoot,
+      branchName,
+      agent: agentType,
+      taskLength: task?.length ?? 0,
+      taskHash: task ? hashText(task) : undefined,
+      hasTaskFile: !!taskFile,
+      fetchMode: opts.fetchMode,
+    });
 
     const validationError = coreGit.validateBranchName(branchName);
     if (validationError) {
@@ -658,6 +669,16 @@ export class SessionManager {
     const agentType = opts.agentType || getHydraGlobalDefaultAgent().agent;
     const agentCommand = await this.resolveAgentCommand(opts.agentCommand || this.getDefaultAgentCommand(agentType));
     const sessionName = preservedWorker?.sessionName || this.backend.buildSessionName(TASK_WORKER_SESSION_NAMESPACE, slug);
+    logger.info('session.createDirectoryWorker', 'Creating task worker', {
+      sessionName,
+      workdir,
+      slug,
+      agent: agentType,
+      managedWorkdir,
+      taskLength: task?.length ?? 0,
+      taskHash: task ? hashText(task) : undefined,
+      hasTaskFile: !!opts.taskFile,
+    });
 
     return this.launchPreparedWorker({
       source: 'directory',
@@ -686,6 +707,18 @@ export class SessionManager {
       prepared.notifyCopilot &&
       !!prepared.copilotSessionName &&
       !!prepared.task;
+    logger.info('session.launchWorker', 'Launching worker session', {
+      source: prepared.source,
+      sessionName: prepared.sessionName,
+      workdir: prepared.workdir,
+      repoRoot: prepared.repoRoot,
+      branch: prepared.branch,
+      agent: prepared.agentType,
+      isResume: !!prepared.resumeSessionId,
+      taskLength: prepared.task?.length ?? 0,
+      taskHash: prepared.task ? hashText(prepared.task) : undefined,
+      notifyCopilot: shouldNotifyCopilot,
+    });
 
     if (shouldNotifyCopilot && prepared.copilotSessionName) {
       const peekState = this.readSessionState();
@@ -769,6 +802,15 @@ export class SessionManager {
       state.updatedAt = now;
       return nextWorker;
     });
+    logger.info('session.launchWorker', 'Worker session persisted', {
+      source: workerInfo.source,
+      sessionName: workerInfo.sessionName,
+      workdir: workerInfo.workdir,
+      branch: workerInfo.branch,
+      agent: workerInfo.agent,
+      workerId: workerInfo.workerId,
+      sessionId: workerInfo.sessionId,
+    });
 
     const postCreatePromise = this.withPostCreateTimeout((async () => {
       if (isResume) {
@@ -790,18 +832,78 @@ export class SessionManager {
 
   async deleteWorker(sessionName: string, opts: DeleteWorkerOpts = {}): Promise<void> {
     const worker = this.readSessionState().workers[sessionName];
-    if (worker && isDirectoryWorker(worker) && opts.deleteFiles && !worker.managedWorkdir) {
-      throw new Error(`Worker "${sessionName}" uses a user-provided directory. --delete-files is only supported for Hydra-managed task workers.`);
-    }
+    const context = {
+      type: 'worker',
+      sessionName,
+      found: !!worker,
+      source: worker?.source,
+      agent: worker?.agent,
+      workdir: worker?.workdir,
+      branch: worker?.branch,
+      managedWorkdir: worker?.managedWorkdir,
+      deleteFiles: opts.deleteFiles === true,
+    };
+    logger.info('session.delete', 'Deleting worker session', { ...context, phase: 'start' });
 
-    await this.killSessionOrConfirmAbsent(sessionName);
+    try {
+      if (worker && isDirectoryWorker(worker) && opts.deleteFiles && !worker.managedWorkdir) {
+        throw new Error(`Worker "${sessionName}" uses a user-provided directory. --delete-files is only supported for Hydra-managed task workers.`);
+      }
 
-    const archivedWorker = worker ? this.prepareArchivedSessionData(worker) as WorkerInfo : undefined;
+      await this.killSessionOrConfirmAbsent(sessionName);
+      logger.info('session.delete', 'Worker multiplexer session removed or absent', {
+        ...context,
+        phase: 'killSession',
+      });
 
-    if (worker && isDirectoryWorker(worker)) {
-      if (opts.deleteFiles && worker.managedWorkdir && worker.workdir && fs.existsSync(worker.workdir)) {
+      const archivedWorker = worker ? this.prepareArchivedSessionData(worker) as WorkerInfo : undefined;
+      let deletedFiles = false;
+      let removedWorktree = false;
+      let deletedBranch = false;
+
+      if (worker && isDirectoryWorker(worker)) {
+        if (opts.deleteFiles && worker.managedWorkdir && worker.workdir && fs.existsSync(worker.workdir)) {
+          logger.info('session.delete', 'Deleting managed task worker files', {
+            ...context,
+            phase: 'deleteFiles',
+          });
+          try {
+            fs.rmSync(worker.workdir, { recursive: true, force: true });
+            deletedFiles = true;
+            logger.info('session.delete', 'Deleted managed task worker files', {
+              ...context,
+              phase: 'deleteFiles',
+            });
+          } catch (error) {
+            await this.updateSessionState((state) => {
+              if (state.workers[sessionName]) {
+                state.workers[sessionName].status = 'stopped';
+                state.workers[sessionName].attached = false;
+                state.updatedAt = new Date().toISOString();
+              }
+            });
+            logger.error('session.delete', 'Failed to delete managed task worker files', {
+              ...context,
+              phase: 'deleteFiles',
+              error,
+            });
+            throw error;
+          }
+        }
+      } else if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
+        logger.info('session.delete', 'Removing worker worktree', {
+          ...context,
+          phase: 'removeWorktree',
+          repoRoot: worker.repoRoot,
+        });
         try {
-          fs.rmSync(worker.workdir, { recursive: true, force: true });
+          await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
+          removedWorktree = true;
+          logger.info('session.delete', 'Removed worker worktree', {
+            ...context,
+            phase: 'removeWorktree',
+            repoRoot: worker.repoRoot,
+          });
         } catch (error) {
           await this.updateSessionState((state) => {
             if (state.workers[sessionName]) {
@@ -810,41 +912,74 @@ export class SessionManager {
               state.updatedAt = new Date().toISOString();
             }
           });
+          logger.error('session.delete', 'Failed to remove worker worktree', {
+            ...context,
+            phase: 'removeWorktree',
+            repoRoot: worker.repoRoot,
+            error,
+          });
           throw error;
         }
-      }
-    } else if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
-      try {
-        await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
-      } catch (error) {
-        await this.updateSessionState((state) => {
-          if (state.workers[sessionName]) {
-            state.workers[sessionName].status = 'stopped';
-            state.workers[sessionName].attached = false;
-            state.updatedAt = new Date().toISOString();
+
+        if (worker.branch) {
+          logger.info('session.delete', 'Deleting worker branch', {
+            ...context,
+            phase: 'deleteBranch',
+            repoRoot: worker.repoRoot,
+          });
+          try {
+            await exec(`git branch -D ${shellQuote(worker.branch)}`, {
+              cwd: worker.repoRoot,
+              logFailure: false,
+            });
+            deletedBranch = true;
+            logger.info('session.delete', 'Deleted worker branch', {
+              ...context,
+              phase: 'deleteBranch',
+              repoRoot: worker.repoRoot,
+            });
+          } catch {
+            logger.debug('session.delete', 'Worker branch was not deleted', {
+              ...context,
+              phase: 'deleteBranch',
+              repoRoot: worker.repoRoot,
+            });
           }
+        }
+      }
+
+      // Archive only after destructive cleanup has succeeded, so failed deletes remain retryable.
+      if (archivedWorker) {
+        logger.info('session.delete', 'Archiving worker metadata', {
+          ...context,
+          phase: 'archive',
+          agentSessionId: archivedWorker.sessionId,
         });
-        throw error;
+        this.archiveEntry('worker', archivedWorker.sessionName, archivedWorker.sessionId, archivedWorker);
       }
 
-      if (worker.branch) {
-        try {
-          await exec(`git branch -D ${shellQuote(worker.branch)}`, { cwd: worker.repoRoot });
-        } catch { /* Branch may not exist */ }
-      }
+      await this.updateSessionState((state) => {
+        if (state.workers[sessionName]) {
+          delete state.workers[sessionName];
+          state.updatedAt = new Date().toISOString();
+        }
+      });
+      logger.info('session.delete', 'Deleted worker session', {
+        ...context,
+        phase: 'complete',
+        archived: !!archivedWorker,
+        deletedFiles,
+        removedWorktree,
+        deletedBranch,
+      });
+    } catch (error) {
+      logger.error('session.delete', 'Failed to delete worker session', {
+        ...context,
+        phase: 'failed',
+        error,
+      });
+      throw error;
     }
-
-    // Archive only after destructive cleanup has succeeded, so failed deletes remain retryable.
-    if (archivedWorker) {
-      this.archiveEntry('worker', archivedWorker.sessionName, archivedWorker.sessionId, archivedWorker);
-    }
-
-    await this.updateSessionState((state) => {
-      if (state.workers[sessionName]) {
-        delete state.workers[sessionName];
-        state.updatedAt = new Date().toISOString();
-      }
-    });
   }
 
   async stopWorker(sessionName: string): Promise<void> {
@@ -873,6 +1008,13 @@ export class SessionManager {
 
     const agent = agentType || existingWorker.agent || getHydraGlobalDefaultAgent().agent;
     const command = await this.resolveAgentCommand(agentCommand || this.getDefaultAgentCommand(agent));
+    logger.info('session.startWorker', 'Starting worker session', {
+      sessionName,
+      workdir: existingWorker.workdir,
+      agent,
+      source: getWorkerSource(existingWorker),
+      hasStoredSessionId: !!existingWorker.sessionId,
+    });
 
     await this.backend.createSession(sessionName, existingWorker.workdir);
     await this.backend.setSessionWorkdir(sessionName, existingWorker.workdir);
@@ -1055,6 +1197,14 @@ export class SessionManager {
     const displayName = opts.name || opts.sessionName || defaultSessionName;
     const sessionName = opts.sessionName || this.backend.sanitizeSessionName(defaultSessionName);
     const agentOptions: AgentCommandOptions = { copilotMode };
+    logger.info('session.createCopilot', 'Creating copilot session', {
+      sessionName,
+      displayName,
+      workdir: opts.workdir,
+      agent: agentType,
+      copilotMode,
+      isResume: !!opts.resumeSessionId,
+    });
 
     const exists = await this.backend.hasSession(sessionName);
     if (exists) {
@@ -1126,6 +1276,13 @@ export class SessionManager {
       state.copilots[sessionName] = nextCopilot;
       state.updatedAt = now;
       return nextCopilot;
+    });
+    logger.info('session.createCopilot', 'Copilot session persisted', {
+      sessionName: persistedCopilotInfo.sessionName,
+      workdir: persistedCopilotInfo.workdir,
+      agent: persistedCopilotInfo.agent,
+      copilotMode: persistedCopilotInfo.copilotMode,
+      sessionId: persistedCopilotInfo.sessionId,
     });
 
     // Match worker lifecycle semantics: wait for readiness and persist any deferred
@@ -1315,24 +1472,57 @@ export class SessionManager {
   }
 
   async deleteCopilot(sessionName: string): Promise<void> {
-    try {
-      await this.backend.killSession(sessionName);
-    } catch { /* Already dead */ }
-
     const copilot = this.readSessionState().copilots[sessionName];
-    const archivedCopilot = copilot ? this.prepareArchivedSessionData(copilot) as CopilotInfo : undefined;
+    const context = {
+      type: 'copilot',
+      sessionName,
+      found: !!copilot,
+      agent: copilot?.agent,
+      copilotMode: copilot?.copilotMode,
+      workdir: copilot?.workdir,
+    };
+    logger.info('session.delete', 'Deleting copilot session', { ...context, phase: 'start' });
 
-    // Archive before removing
-    if (archivedCopilot) {
-      this.archiveEntry('copilot', archivedCopilot.sessionName, archivedCopilot.sessionId, archivedCopilot);
-    }
+    try {
+      try {
+        await this.backend.killSession(sessionName);
+      } catch { /* Already dead */ }
+      logger.info('session.delete', 'Copilot multiplexer session removed or absent', {
+        ...context,
+        phase: 'killSession',
+      });
 
-    await this.updateSessionState((state) => {
-      if (state.copilots[sessionName]) {
-        delete state.copilots[sessionName];
-        state.updatedAt = new Date().toISOString();
+      const archivedCopilot = copilot ? this.prepareArchivedSessionData(copilot) as CopilotInfo : undefined;
+
+      // Archive before removing
+      if (archivedCopilot) {
+        logger.info('session.delete', 'Archiving copilot metadata', {
+          ...context,
+          phase: 'archive',
+          agentSessionId: archivedCopilot.sessionId,
+        });
+        this.archiveEntry('copilot', archivedCopilot.sessionName, archivedCopilot.sessionId, archivedCopilot);
       }
-    });
+
+      await this.updateSessionState((state) => {
+        if (state.copilots[sessionName]) {
+          delete state.copilots[sessionName];
+          state.updatedAt = new Date().toISOString();
+        }
+      });
+      logger.info('session.delete', 'Deleted copilot session', {
+        ...context,
+        phase: 'complete',
+        archived: !!archivedCopilot,
+      });
+    } catch (error) {
+      logger.error('session.delete', 'Failed to delete copilot session', {
+        ...context,
+        phase: 'failed',
+        error,
+      });
+      throw error;
+    }
   }
 
   // ── Public helpers for VS Code extension ──
@@ -1598,6 +1788,14 @@ export class SessionManager {
       data: { ...data },
     });
     this.writeArchiveState(archive);
+    logger.info('session.archive', 'Archived session metadata', {
+      type,
+      sessionName,
+      agent: data.agent,
+      workdir: data.workdir,
+      agentSessionId,
+      agentSessionFile: data.agentSessionFile ?? null,
+    });
   }
 
   private prepareArchivedSessionData(data: WorkerInfo | CopilotInfo): WorkerInfo | CopilotInfo {
@@ -1864,6 +2062,12 @@ export class SessionManager {
     workdir: string,
     launchStartedAt?: number,
   ): Promise<void> {
+    logger.info('session.waitForReady', 'Waiting for agent readiness', {
+      sessionName,
+      agent: agentType,
+      workdir,
+      hasPreAssignedSessionId: !!preAssignedSessionId,
+    });
     if (preAssignedSessionId) {
       // Claude (or resume): sessionId already known — just wait for TUI readiness
       await this.waitForAgentReady(sessionName, agentType);
@@ -1888,6 +2092,12 @@ export class SessionManager {
     notifyCopilot = false,
   ): Promise<void> {
     if (task) {
+      logger.info('session.sendInitialPrompt', 'Sending initial worker prompt', {
+        sessionName,
+        promptLength: task.length,
+        promptHash: hashText(task),
+        notifyCopilot,
+      });
       if (notifyCopilot) {
         this.armCompletionNotification(sessionName);
       }
@@ -2366,8 +2576,22 @@ export class SessionManager {
   ): Promise<{ sessionId: string | null; agentSessionFile: string | null }> {
     const config = AGENT_SESSION_CAPTURE[agentType];
     if (!config) return { sessionId: null, agentSessionFile: null };
+    const logCaptured = (result: { sessionId: string | null; agentSessionFile: string | null }, source: string) => {
+      logger.info('session.captureAgentSessionInfo', 'Captured agent session info', {
+        sessionName,
+        agent: agentType,
+        source,
+        hasSessionId: !!result.sessionId,
+        hasAgentSessionFile: !!result.agentSessionFile,
+      });
+    };
 
     try {
+      logger.info('session.captureAgentSessionInfo', 'Capturing agent session info', {
+        sessionName,
+        agent: agentType,
+        workdir,
+      });
       // For REPL TUIs, wait for the prompt before sending status. Starting
       // with Codex 0.129, the trust prompt and first paint can take long enough
       // that fixed sleeps race the input handler and lose the status command.
@@ -2380,11 +2604,13 @@ export class SessionManager {
       const existingOutput = await this.backend.capturePane(sessionName, 400);
       const existing = this.parseAgentSessionInfo(agentType, workdir, existingOutput);
       if (existing.sessionId) {
+        logCaptured(existing, 'existing-output');
         return existing;
       }
       if (agentType === 'sudocode') {
         const latest = this.findLatestSudoCodeSessionInfo(workdir, launchStartedAt);
         if (latest.sessionId) {
+          logCaptured(latest, 'sudocode-session-file');
           return latest;
         }
       }
@@ -2400,11 +2626,13 @@ export class SessionManager {
         const output = await this.backend.capturePane(sessionName, 400);
         const parsed = this.parseAgentSessionInfo(agentType, workdir, output);
         if (parsed.sessionId) {
+          logCaptured(parsed, 'status-command');
           return parsed;
         }
         if (agentType === 'sudocode') {
           const latest = this.findLatestSudoCodeSessionInfo(workdir, launchStartedAt);
           if (latest.sessionId) {
+            logCaptured(latest, 'sudocode-session-file');
             return latest;
           }
         }
@@ -2413,9 +2641,18 @@ export class SessionManager {
       console.warn(
         `[hydra] Could not parse session ID for ${agentType} in ${sessionName}`,
       );
+      logger.warn('session.captureAgentSessionInfo', 'Could not parse agent session ID', {
+        sessionName,
+        agent: agentType,
+      });
       return { sessionId: null, agentSessionFile: null };
     } catch (error) {
       console.warn(`[hydra] Session ID capture failed for ${sessionName}:`, error);
+      logger.warn('session.captureAgentSessionInfo', 'Agent session capture failed', {
+        sessionName,
+        agent: agentType,
+        error,
+      });
       return { sessionId: null, agentSessionFile: null };
     }
   }
@@ -2722,12 +2959,7 @@ export class SessionManager {
         }
       }
 
-      if (task) {
-        if (shouldNotifyCopilot) {
-          this.armCompletionNotification(sessionName);
-        }
-        await this.backend.sendKeys(sessionName, task);
-      }
+      await this.sendInitialPrompt(sessionName, task, shouldNotifyCopilot);
 
       const workdir = sessionWorkdir || savedWorker?.workdir || '';
       const agent = await this.backend.getSessionAgent(sessionName) || agentType;

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -6,6 +6,7 @@ import { HYDRA_COPILOT_SESSION_ENV } from './env';
 import { getHydraConfigPath, getHydraHome, getTmuxCommand, toCanonicalPath } from './path';
 import { shellQuote, pwshQuote } from './shell';
 import { MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo, HydraRole } from './types';
+import { logger } from './logger';
 
 interface ExecFailure extends Error {
   stderr?: string;
@@ -174,8 +175,14 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
     try {
       const cmd = process.platform === 'win32' ? 'where psmux' : 'which tmux';
       await exec(cmd);
+      logger.debug('tmux.isInstalled', 'Multiplexer command found', {
+        binary: process.platform === 'win32' ? 'psmux' : 'tmux',
+      });
       return true;
     } catch {
+      logger.warn('tmux.isInstalled', 'Multiplexer command not found', {
+        binary: process.platform === 'win32' ? 'psmux' : 'tmux',
+      });
       return false;
     }
   }
@@ -184,7 +191,7 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
     try {
       const tmuxCommand = getTmuxCommand();
       const output = await exec(`${tmuxCommand} list-sessions -F '#{session_name}|||#{session_windows}|||#{session_attached}'`);
-      return output.split('\n').filter(l => l.trim()).map(line => {
+      const sessions = output.split('\n').filter(l => l.trim()).map(line => {
         const [name, windows, attached] = line.split('|||');
         return {
           name,
@@ -192,22 +199,44 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
           attached: attached === '1'
         };
       });
+      logger.debug('tmux.listSessions', 'Listed multiplexer sessions', { count: sessions.length });
+      return sessions;
     } catch (error) {
       if (isTmuxNoServerError(error)) {
+        logger.debug('tmux.listSessions', 'No multiplexer server is running');
         return [];
       }
+      logger.error('tmux.listSessions', 'Unable to list multiplexer sessions', { error });
       throw new TmuxUnavailableError(`Unable to access tmux sessions: ${getExecFailureText(error)}`);
     }
   }
 
   async createSession(sessionName: string, cwd: string): Promise<void> {
-    await scrubStoredTmuxEnvironment(sessionName);
-    await exec(buildSanitizedTmuxCommand(`new-session -d -s ${shellQuote(sessionName)} -c ${shellQuote(cwd)}`));
+    logger.info('tmux.createSession', 'Creating multiplexer session', {
+      sessionName,
+      cwd,
+      tmuxCommand: getTmuxCommand(),
+    });
+    try {
+      await scrubStoredTmuxEnvironment(sessionName);
+      await exec(buildSanitizedTmuxCommand(`new-session -d -s ${shellQuote(sessionName)} -c ${shellQuote(cwd)}`));
+      logger.info('tmux.createSession', 'Created multiplexer session', { sessionName, cwd });
+    } catch (error) {
+      logger.error('tmux.createSession', 'Failed to create multiplexer session', { sessionName, cwd, error });
+      throw error;
+    }
   }
 
   async killSession(sessionName: string): Promise<void> {
     const tmuxCommand = getTmuxCommand();
-    await exec(`${tmuxCommand} kill-session -t ${shellQuote(sessionName)}`);
+    logger.info('tmux.killSession', 'Killing multiplexer session', { sessionName });
+    try {
+      await exec(`${tmuxCommand} kill-session -t ${shellQuote(sessionName)}`);
+      logger.info('tmux.killSession', 'Killed multiplexer session', { sessionName });
+    } catch (error) {
+      logger.error('tmux.killSession', 'Failed to kill multiplexer session', { sessionName, error });
+      throw error;
+    }
   }
 
   async renameSession(oldName: string, newName: string): Promise<void> {
@@ -218,7 +247,8 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
   async hasSession(sessionName: string): Promise<boolean> {
     try {
       const tmuxCommand = getTmuxCommand();
-      await exec(`${tmuxCommand} has-session -t ${shellQuote(sessionName)}`);
+      await exec(`${tmuxCommand} has-session -t ${shellQuote(sessionName)}`, { logFailure: false });
+      logger.debug('tmux.hasSession', 'Multiplexer session exists', { sessionName });
       return true;
     } catch (error) {
       if (
@@ -226,8 +256,10 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
         || isTmuxMissingSessionError(error)
         || isSilentExecFailure(error)
       ) {
+        logger.debug('tmux.hasSession', 'Multiplexer session does not exist', { sessionName });
         return false;
       }
+      logger.error('tmux.hasSession', 'Unable to inspect multiplexer session', { sessionName, error });
       throw new TmuxUnavailableError(`Unable to inspect tmux session "${sessionName}": ${getExecFailureText(error)}`);
     }
   }
@@ -294,13 +326,23 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
 
   async sendKeys(sessionName: string, keys: string): Promise<void> {
     const tmuxCommand = getTmuxCommand();
+    logger.debug('tmux.sendKeys', 'Sending keys to multiplexer session', {
+      sessionName,
+      keyLength: keys.length,
+    });
     await exec(`${tmuxCommand} send-keys -t ${shellQuote(sessionName)} ${shellQuote(keys)} Enter`);
   }
 
   async capturePane(sessionName: string, lines?: number): Promise<string> {
     const tmuxCommand = getTmuxCommand();
     const startArg = lines ? `-S -${lines}` : '';
-    return exec(`${tmuxCommand} capture-pane -t ${shellQuote(sessionName)} -p ${startArg}`.trim());
+    const output = await exec(`${tmuxCommand} capture-pane -t ${shellQuote(sessionName)} -p ${startArg}`.trim());
+    logger.debug('tmux.capturePane', 'Captured multiplexer pane', {
+      sessionName,
+      lines,
+      outputLength: output.length,
+    });
+    return output;
   }
 
   async sendMessage(sessionName: string, message: string): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } fro
 import { lookupWorkerId } from './core/sessionManager';
 import { getHydraSessionsFile } from './core/path';
 import { HydraSessionKind, hasHydraItemIdentity, listHydraSessionChoices } from './commands/treeItemResolver';
+import { configureLoggerFromVSCode, logExtensionActivated, registerHydraLogCommands } from './commands/logs';
 
 const SESSION_REFRESH_DEBOUNCE_MS = 200;
 const SESSION_REFRESH_POLL_INTERVAL_MS = 1000;
@@ -42,6 +43,11 @@ function delay(ms: number): Promise<void> {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  configureLoggerFromVSCode();
+  const hydraOutputChannel = vscode.window.createOutputChannel('Hydra');
+  registerHydraLogCommands(context, hydraOutputChannel);
+  logExtensionActivated(context);
+
   const copilotProvider = new CopilotProvider();
   copilotProvider.setExtensionUri(context.extensionUri);
   const workerProvider = new WorkerProvider();
@@ -169,6 +175,9 @@ export function activate(context: vscode.ExtensionContext) {
       }
       if (e.affectsConfiguration('hydra.defaultAgent')) {
         syncDefaultAgentToHydraConfig();
+      }
+      if (e.affectsConfiguration('hydra.logging')) {
+        configureLoggerFromVSCode();
       }
     })
   );

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -111,14 +111,14 @@ function parseGitPorcelainStatus(lines: string[]): Pick<
 
 async function getWorktreeBranchLabel(worktreePath: string, fallbackLabel: string): Promise<string> {
   try {
-    const branch = (await exec('git symbolic-ref --short HEAD', { cwd: worktreePath })).trim();
+    const branch = (await exec('git symbolic-ref --short HEAD', { cwd: worktreePath, logFailure: false })).trim();
     if (branch) return branch;
   } catch {
     void 0;
   }
 
   try {
-    const head = (await exec('git rev-parse --short HEAD', { cwd: worktreePath })).trim();
+    const head = (await exec('git rev-parse --short HEAD', { cwd: worktreePath, logFailure: false })).trim();
     if (head) return head;
   } catch {
     void 0;
@@ -134,12 +134,12 @@ async function getWorktreeGitStatus(worktreePath: string): Promise<Pick<
   let commitsAhead = 0;
   let parsed = { gitDirty: 0, gitModified: 0, gitAdded: 0, gitDeleted: 0, gitUntracked: 0 };
 
-  if (!fs.existsSync(worktreePath)) {
+  if (!fs.existsSync(worktreePath) || !(await isGitInitialized(worktreePath))) {
     return { ...parsed, commitsAhead };
   }
 
   try {
-    const gitStatusOutput = await exec('git status --porcelain', { cwd: worktreePath });
+    const gitStatusOutput = await exec('git status --porcelain', { cwd: worktreePath, logFailure: false });
     const lines = gitStatusOutput.split('\n');
     parsed = parseGitPorcelainStatus(lines);
   } catch {
@@ -147,7 +147,7 @@ async function getWorktreeGitStatus(worktreePath: string): Promise<Pick<
   }
 
   try {
-    const aheadOutput = await exec('git rev-list --count @{upstream}..HEAD', { cwd: worktreePath });
+    const aheadOutput = await exec('git rev-list --count @{upstream}..HEAD', { cwd: worktreePath, logFailure: false });
     commitsAhead = parseInt(aheadOutput.trim(), 10) || 0;
   } catch {
     void 0;
@@ -196,9 +196,12 @@ async function getSessionStatus(sessionName: string, worktreePath?: string): Pro
     void 0;
   }
 
-  if (worktreePath && fs.existsSync(worktreePath)) {
+  const canReadGitStatus = worktreePath
+    && fs.existsSync(worktreePath)
+    && await isGitInitialized(worktreePath);
+  if (canReadGitStatus) {
     try {
-      const gitStatusOutput = await exec('git status --porcelain', { cwd: worktreePath });
+      const gitStatusOutput = await exec('git status --porcelain', { cwd: worktreePath, logFailure: false });
       const parsed = parseGitPorcelainStatus(gitStatusOutput.split('\n'));
       gitDirty = parsed.gitDirty;
       gitModified = parsed.gitModified;
@@ -210,7 +213,7 @@ async function getSessionStatus(sessionName: string, worktreePath?: string): Pro
     }
 
     try {
-      const aheadOutput = await exec('git rev-list --count @{upstream}..HEAD', { cwd: worktreePath });
+      const aheadOutput = await exec('git rev-list --count @{upstream}..HEAD', { cwd: worktreePath, logFailure: false });
       commitsAhead = parseInt(aheadOutput.trim(), 10) || 0;
     } catch {
       void 0;
@@ -233,7 +236,7 @@ async function getSessionStatus(sessionName: string, worktreePath?: string): Pro
 
 async function isGitInitialized(dirPath: string): Promise<boolean> {
   try {
-    await exec('git rev-parse --git-dir', { cwd: dirPath });
+    await exec('git rev-parse --git-dir', { cwd: dirPath, logFailure: false });
     return true;
   } catch {
     return false;
@@ -260,7 +263,7 @@ async function fetchRepoPrStatuses(repoRoot: string): Promise<Map<string, PrInfo
     const json = await Promise.race([
       exec(
         'gh pr list --state all --json headRefName,number,state --limit 100',
-        { cwd: repoRoot }
+        { cwd: repoRoot, logFailure: false }
       ),
       new Promise<string>((_, reject) =>
         setTimeout(() => reject(new Error('gh pr list timeout')), PR_STATUS_FETCH_TIMEOUT_MS)

--- a/src/smoke/loggingCliE2eSmoke.ts
+++ b/src/smoke/loggingCliE2eSmoke.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E smoke: a real CLI copilot create failure writes Hydra diagnostics.
+ *
+ * The test uses an isolated HYDRA_HOME and a deliberately invalid tmux socket
+ * path so session creation fails before any agent process is launched. This
+ * mirrors user reports where no worker/copilot pane log exists yet.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+function which(cmd: string): string | null {
+  const r = spawnSync('sh', ['-c', `command -v ${cmd}`], { encoding: 'utf-8' });
+  return r.status === 0 && r.stdout.trim() ? r.stdout.trim() : null;
+}
+
+function skip(reason: string): never {
+  console.log(`loggingCliE2eSmoke: SKIP (${reason})`);
+  process.exit(0);
+}
+
+if (process.platform === 'win32') {
+  skip('Windows is not supported by this smoke (POSIX-only socket paths)');
+}
+if (!which('tmux')) {
+  skip('tmux is not on PATH');
+}
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-logging-cli-e2e-'));
+const homeDir = path.join(tempRoot, 'home');
+const hydraHome = path.join(homeDir, '.hydra');
+const workdir = path.join(tempRoot, 'workdir');
+const stubBinDir = path.join(tempRoot, 'bin');
+const missingSocket = path.join(os.tmpdir(), `hydra-log-missing-${process.pid}`, 'hydra.sock');
+const cliEntry = path.resolve(__dirname, '..', 'cli', 'index.js');
+
+try {
+  fs.mkdirSync(hydraHome, { recursive: true });
+  fs.mkdirSync(workdir, { recursive: true });
+  fs.mkdirSync(stubBinDir, { recursive: true });
+
+  const stubClaude = path.join(stubBinDir, 'claude');
+  fs.writeFileSync(stubClaude, '#!/bin/sh\nexec tail -f /dev/null\n', 'utf-8');
+  fs.chmodSync(stubClaude, 0o755);
+
+  const childEnv = {
+    ...process.env,
+    HOME: homeDir,
+    HYDRA_HOME: hydraHome,
+    HYDRA_CONFIG_PATH: path.join(hydraHome, 'config.json'),
+    HYDRA_TMUX_SOCKET: missingSocket,
+    PATH: `${stubBinDir}${path.delimiter}${process.env.PATH || ''}`,
+  };
+
+  const result = spawnSync(process.execPath, [
+    cliEntry,
+    'copilot',
+    'create',
+    '--workdir',
+    workdir,
+    '--agent',
+    'claude',
+    '--session',
+    'logging-e2e-fail',
+  ], {
+    cwd: workdir,
+    env: childEnv,
+    encoding: 'utf-8',
+  });
+
+  assert.notEqual(result.status, 0, 'copilot create should fail with an invalid tmux socket');
+
+  const logPath = path.join(hydraHome, 'logs', 'hydra.log');
+  assert.ok(fs.existsSync(logPath), `Hydra log should exist at ${logPath}`);
+  const raw = fs.readFileSync(logPath, 'utf-8');
+  assert.doesNotMatch(raw, /"scope":"cli.start"/, 'default info logs should not include debug CLI startup noise');
+  assert.match(raw, /"scope":"session.createCopilot"/, 'log should include copilot creation context');
+  assert.match(raw, /"scope":"tmux.createSession"/, 'log should include tmux create context');
+  assert.match(raw, /"scope":"exec.failure"/, 'log should include failed shell command');
+  assert.match(raw, /logging-e2e-fail/, 'log should include session name');
+  assert.match(raw, /hydra-log-missing-/, 'log should include failing socket path context');
+
+  console.log('loggingCliE2eSmoke: ok');
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/src/smoke/loggingSmoke.ts
+++ b/src/smoke/loggingSmoke.ts
@@ -1,0 +1,251 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { logger } from '../core/logger';
+import { isSecretLikeKey, redactText } from '../core/logRedaction';
+import { exec } from '../core/exec';
+import { SessionManager, type WorkerInfo } from '../core/sessionManager';
+import type { HydraRole, MultiplexerBackendCore, MultiplexerSession, SessionStatusInfo } from '../core/types';
+
+class FakeBackend implements MultiplexerBackendCore {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'fake';
+  readonly installHint = '';
+
+  async isInstalled(): Promise<boolean> { return true; }
+  async listSessions(): Promise<MultiplexerSession[]> { return []; }
+  async createSession(): Promise<void> {}
+  async killSession(): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async hasSession(): Promise<boolean> { return false; }
+  async getSessionWorkdir(): Promise<string | undefined> { return undefined; }
+  async setSessionWorkdir(): Promise<void> {}
+  async getSessionRole(): Promise<HydraRole | undefined> { return undefined; }
+  async setSessionRole(): Promise<void> {}
+  async getSessionAgent(): Promise<string | undefined> { return undefined; }
+  async setSessionAgent(): Promise<void> {}
+  async sendKeys(): Promise<void> {}
+  async capturePane(): Promise<string> { return ''; }
+  async sendMessage(): Promise<void> {}
+  async getSessionInfo(): Promise<SessionStatusInfo> { return { attached: false, lastActive: 0 }; }
+  async getSessionPaneCount(): Promise<number> { return 1; }
+  async getSessionPanePids(): Promise<string[]> { return []; }
+  async splitPane(): Promise<void> {}
+  async newWindow(): Promise<void> {}
+  buildSessionName(repoName: string, slug: string): string { return `${repoName}_${slug}`; }
+  sanitizeSessionName(name: string): string { return name.replace(/[^A-Za-z0-9_.-]/g, '-'); }
+}
+
+function makeTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-logging-smoke-'));
+}
+
+function resetLogger(filePath: string, maxFileSizeBytes = 5 * 1024 * 1024, maxFiles = 5): void {
+  logger.resetForTests();
+  logger.configure({
+    level: 'debug',
+    filePath,
+    flushDelayMs: 0,
+    maxFileSizeBytes,
+    maxFiles,
+  });
+}
+
+function readJsonLines(filePath: string): Array<Record<string, unknown>> {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function testRedaction(): Promise<void> {
+  const text = [
+    'OPENAI_API_KEY=sk-proj-secret1234567890',
+    'Authorization: Bearer secret-token-value',
+    'GITHUB_TOKEN=ghp_123456789012345678901234567890123456',
+    'safe text',
+  ].join('\n');
+  const redacted = redactText(text);
+  assert.ok(!redacted.includes('sk-proj-secret1234567890'), 'OpenAI key should be redacted');
+  assert.ok(!redacted.includes('secret-token-value'), 'Bearer token should be redacted');
+  assert.ok(!redacted.includes('ghp_123456789012345678901234567890123456'), 'GitHub token should be redacted');
+  assert.ok(redacted.includes('safe text'), 'non-secret text should remain');
+  assert.ok(isSecretLikeKey('apiKey'), 'camelCase apiKey fields should be treated as secret');
+  assert.ok(isSecretLikeKey('accessToken'), 'camelCase accessToken fields should be treated as secret');
+}
+
+async function testRotation(): Promise<void> {
+  const root = makeTempRoot();
+  const logPath = path.join(root, 'hydra.log');
+  try {
+    resetLogger(logPath, 1024, 3);
+    for (let i = 0; i < 5; i++) {
+      logger.info('smoke.rotation', 'rotation payload', {
+        index: i,
+        payload: 'x'.repeat(1500),
+      });
+      await logger.flush();
+    }
+
+    assert.ok(fs.existsSync(logPath), 'active log should exist');
+    assert.ok(fs.existsSync(path.join(root, 'hydra.1.log')), 'first rotated log should exist');
+    assert.ok(fs.existsSync(path.join(root, 'hydra.2.log')), 'second rotated log should exist');
+    assert.ok(!fs.existsSync(path.join(root, 'hydra.3.log')), 'rotation should respect maxFiles including active file');
+  } finally {
+    logger.resetForTests();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function testExecFailureLogging(): Promise<void> {
+  const root = makeTempRoot();
+  const logPath = path.join(root, 'hydra.log');
+  const previousHydraHome = process.env.HYDRA_HOME;
+  const previousHydraConfigPath = process.env.HYDRA_CONFIG_PATH;
+  process.env.HYDRA_HOME = root;
+  process.env.HYDRA_CONFIG_PATH = path.join(root, 'config.json');
+
+  try {
+    resetLogger(logPath);
+    await assert.rejects(
+      () => exec('node -e "console.error(\'OPENAI_API_KEY=sk-proj-secret1234567890\'); process.exit(7)"', { cwd: root }),
+      /Command failed/,
+    );
+    await logger.flush();
+
+    const entries = readJsonLines(logPath);
+    const failure = entries.find(entry => entry.scope === 'exec.failure');
+    assert.ok(failure, 'exec.failure entry should be written');
+    assert.equal(failure?.cwd, root);
+    assert.equal(failure?.exitCode, 7);
+    const serialized = JSON.stringify(failure);
+    assert.ok(serialized.includes('OPENAI_API_KEY='), 'failure should include stderr context');
+    assert.ok(!serialized.includes('sk-proj-secret1234567890'), 'stderr secret should be redacted');
+  } finally {
+    logger.resetForTests();
+    if (previousHydraHome === undefined) {
+      delete process.env.HYDRA_HOME;
+    } else {
+      process.env.HYDRA_HOME = previousHydraHome;
+    }
+    if (previousHydraConfigPath === undefined) {
+      delete process.env.HYDRA_CONFIG_PATH;
+    } else {
+      process.env.HYDRA_CONFIG_PATH = previousHydraConfigPath;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function testSuppressedProbeFailureLogging(): Promise<void> {
+  const root = makeTempRoot();
+  const logPath = path.join(root, 'hydra.log');
+  try {
+    resetLogger(logPath);
+    await assert.rejects(
+      () => exec('node -e "process.exit(3)"', { cwd: root, logFailure: false }),
+      /Command failed/,
+    );
+    await logger.flush();
+
+    const entries = readJsonLines(logPath);
+    assert.ok(!entries.some(entry => entry.scope === 'exec.failure'), 'probe failures should not write exec.failure');
+    assert.ok(entries.some(entry => entry.scope === 'exec.probeFailure'), 'debug probe failure should remain available');
+  } finally {
+    logger.resetForTests();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function testWorkerDeleteLifecycleLogging(): Promise<void> {
+  const root = makeTempRoot();
+  const hydraHome = path.join(root, '.hydra');
+  const logPath = path.join(hydraHome, 'logs', 'hydra.log');
+  const sessionsPath = path.join(hydraHome, 'sessions.json');
+  const previousHydraHome = process.env.HYDRA_HOME;
+  const previousHydraConfigPath = process.env.HYDRA_CONFIG_PATH;
+  const now = new Date().toISOString();
+  const worker: WorkerInfo = {
+    source: 'directory',
+    sessionName: 'task_log-test',
+    displayName: 'log-test',
+    workerId: 1,
+    repo: null,
+    repoRoot: null,
+    branch: null,
+    slug: 'log-test',
+    status: 'running',
+    attached: false,
+    agent: 'custom',
+    workdir: path.join(root, 'task-workdir'),
+    managedWorkdir: false,
+    tmuxSession: 'task_log-test',
+    createdAt: now,
+    lastSeenAt: now,
+    sessionId: 'agent-session-1',
+    agentSessionFile: null,
+    copilotSessionName: null,
+  };
+
+  process.env.HYDRA_HOME = hydraHome;
+  process.env.HYDRA_CONFIG_PATH = path.join(hydraHome, 'config.json');
+
+  try {
+    fs.mkdirSync(worker.workdir, { recursive: true });
+    fs.mkdirSync(hydraHome, { recursive: true });
+    fs.writeFileSync(sessionsPath, JSON.stringify({
+      copilots: {},
+      workers: { [worker.sessionName]: worker },
+      nextWorkerId: 2,
+      updatedAt: now,
+    }, null, 2), 'utf-8');
+
+    resetLogger(logPath);
+    const sm = new SessionManager(new FakeBackend());
+    await sm.deleteWorker(worker.sessionName);
+    await logger.flush();
+
+    const entries = readJsonLines(logPath);
+    const deleteEntries = entries.filter(entry => entry.scope === 'session.delete');
+    assert.ok(deleteEntries.some(entry => entry.phase === 'start'), 'delete should log start phase');
+    assert.ok(deleteEntries.some(entry => entry.phase === 'archive'), 'delete should log archive phase');
+    assert.ok(deleteEntries.some(entry => entry.phase === 'complete'), 'delete should log complete phase');
+    assert.ok(entries.some(entry => entry.scope === 'session.archive'), 'archive helper should log archived metadata');
+
+    const sessions = JSON.parse(fs.readFileSync(sessionsPath, 'utf-8')) as { workers: Record<string, unknown> };
+    assert.ok(!sessions.workers[worker.sessionName], 'worker should be removed from sessions.json');
+    const archive = JSON.parse(fs.readFileSync(path.join(hydraHome, 'archive.json'), 'utf-8')) as {
+      entries: Array<{ sessionName: string }>;
+    };
+    assert.ok(archive.entries.some(entry => entry.sessionName === worker.sessionName), 'worker should be archived');
+  } finally {
+    logger.resetForTests();
+    if (previousHydraHome === undefined) {
+      delete process.env.HYDRA_HOME;
+    } else {
+      process.env.HYDRA_HOME = previousHydraHome;
+    }
+    if (previousHydraConfigPath === undefined) {
+      delete process.env.HYDRA_CONFIG_PATH;
+    } else {
+      process.env.HYDRA_CONFIG_PATH = previousHydraConfigPath;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  await testRedaction();
+  await testRotation();
+  await testExecFailureLogging();
+  await testSuppressedProbeFailureLogging();
+  await testWorkerDeleteLifecycleLogging();
+  console.log('loggingSmoke: ok');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a product and technical design for Hydra diagnostic logging, then implements the V1 logging system across the VS Code extension and CLI. Logs are JSONL files under the Hydra home logs directory with rotation, redaction, VS Code commands, doctor output, and CLI failure flushing.

## What changed

- Added a core logger with JSONL output, async debounce flush, sync flush, sinks, rotation, and secret redaction.
- Added VS Code commands for showing logs, opening the logs folder, and copying diagnostic info.
- Wired command error toasts to log actions for copilot/worker creation and attach/create paths.
- Logged CLI, tmux, exec, session create/start/delete/archive, readiness, and agent-session capture lifecycle events.
- Suppressed expected probe failures from status polling so git/tmux checks do not flood `exec.failure`.
- Added `hydra doctor` log path/check output and logging configuration settings.
- Added smoke and CLI e2e coverage for redaction, rotation, failure logging, delete lifecycle logging, and real CLI diagnostics.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:logging`
- `npm run smoke:logging-cli-e2e`
- `npm test`
- `git diff --check`
- Manual VS Code Extension Development Host check for `Hydra: Show Logs` and `Hydra: Copy Diagnostic Info`
- Isolated real CLI create/delete check for `task_log-test` showing `session.delete` phases without status-line git error noise
