### PR TITLE
chore: release v0.3.2026060400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.2026060400] - 2026-06-04
+
+### Added
+- Add Hydra diagnostic logging across CLI and VS Code, including JSONL log files with rotation/redaction, log discovery commands, doctor output, and session lifecycle diagnostics
+
+### Changed
+- Clarify that a Hydra copilot is a cross-repo orchestrator rather than a per-repo worker
+
 ## [0.3.2026060300] - 2026-06-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026060300",
+  "version": "0.3.2026060400",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026060300",
+      "version": "0.3.2026060400",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026060300",
+  "version": "0.3.2026060400",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026060400

## Changes
- Add Hydra diagnostic logging across CLI and VS Code with JSONL files, rotation/redaction, log discovery commands, doctor output, and session lifecycle diagnostics.
- Clarify that a Hydra copilot is a cross-repo orchestrator rather than a per-repo worker.

## Validation
- npm install
- npm run compile
- git diff --check

After this PR is merged, the auto-tag workflow should create `v0.3.2026060400` and trigger publish.