### PR TITLE
fix: avoid secret scan false positive in logging smoke

### DIFF
--- a/src/smoke/loggingSmoke.ts
+++ b/src/smoke/loggingSmoke.ts
@@ -61,16 +61,17 @@ function readJsonLines(filePath: string): Array<Record<string, unknown>> {
 }
 
 async function testRedaction(): Promise<void> {
+  const githubToken = ['ghp', '123456789012345678901234567890123456'].join('_');
   const text = [
     'OPENAI_API_KEY=sk-proj-secret1234567890',
     'Authorization: Bearer secret-token-value',
-    'GITHUB_TOKEN=ghp_123456789012345678901234567890123456',
+    `GITHUB_TOKEN=${githubToken}`,
     'safe text',
   ].join('\n');
   const redacted = redactText(text);
   assert.ok(!redacted.includes('sk-proj-secret1234567890'), 'OpenAI key should be redacted');
   assert.ok(!redacted.includes('secret-token-value'), 'Bearer token should be redacted');
-  assert.ok(!redacted.includes('ghp_123456789012345678901234567890123456'), 'GitHub token should be redacted');
+  assert.ok(!redacted.includes(githubToken), 'GitHub token should be redacted');
   assert.ok(redacted.includes('safe text'), 'non-secret text should remain');
   assert.ok(isSecretLikeKey('apiKey'), 'camelCase apiKey fields should be treated as secret');
   assert.ok(isSecretLikeKey('accessToken'), 'camelCase accessToken fields should be treated as secret');


### PR DESCRIPTION
## Summary

Fixes the failed `v0.3.2026060400` publish workflow by avoiding a literal GitHub-token-shaped fixture in the compiled logging smoke test. The test still constructs the same token shape at runtime and verifies redaction, but `vsce package` no longer flags the compiled output as containing a secret.

## Validation

- `npm install`
- `npm run compile`
- `npm run smoke:logging`
- `git diff --check`
- `npx @vscode/vsce package --out /tmp/hydra-0.3.2026060400-test.vsix`
