### PR TITLE
chore: release v0.3.2026060401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.2026060401] - 2026-06-04
+
+### Added
+- Add Hydra diagnostic logging across CLI and VS Code, including JSONL log files with rotation/redaction, log discovery commands, doctor output, and session lifecycle diagnostics
+
+### Fixed
+- Avoid a VSIX package secret-scan false positive in the logging smoke test so the extension publish workflow can complete
+
 ## [0.3.2026060400] - 2026-06-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026060400",
+  "version": "0.3.2026060401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026060400",
+      "version": "0.3.2026060401",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026060400",
+  "version": "0.3.2026060401",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026060401

## Changes
- Add Hydra diagnostic logging across CLI and VS Code with JSONL files, rotation/redaction, log discovery commands, doctor output, and session lifecycle diagnostics.
- Avoid the VSIX package secret-scan false positive that blocked `v0.3.2026060400` from publishing.

## Validation
- npm install
- npm run compile
- npm run smoke:logging
- git diff --check
- npx @vscode/vsce package --out /tmp/hydra-0.3.2026060401-test.vsix

After this PR is merged, the auto-tag workflow should create `v0.3.2026060401` and trigger publish.