### PR TITLE
Use add icon for Create Copilot action

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
       {
         "command": "hydra.createCopilot",
         "title": "Hydra: Create Copilot",
-        "icon": "$(hubot)"
+        "icon": "$(add)"
       },
       {
         "command": "hydra.startPlanCopilot",


### PR DESCRIPTION
Switch the Create Copilot button icon from `$(hubot)` to `$(add)` so it visually communicates 'add a new copilot' instead of a generic chatbot.