### PR TITLE
Fix Windows copilot creation: env -u wrapper and log encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
+        "iconv-lite": "^0.7.2",
         "posthog-node": "^5.33.3"
       },
       "bin": {
@@ -1097,6 +1098,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -1420,6 +1437,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.3",

--- a/package.json
+++ b/package.json
@@ -396,6 +396,7 @@
   },
   "dependencies": {
     "commander": "^14.0.3",
+    "iconv-lite": "^0.7.2",
     "posthog-node": "^5.33.3"
   }
 }

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -11,6 +11,10 @@ const execFilePromise = promisify(execFileCallback);
 export interface ExecOptions {
   cwd?: string;
   logFailure?: boolean;
+  // Keys to remove from the child process environment. Used in place of a
+  // platform-specific `env -u` wrapper so the same call works on Windows,
+  // which has no `env` binary in cmd.exe/PowerShell.
+  unsetEnv?: string[];
 }
 
 // VS Code is a GUI app and doesn't inherit shell PATH.
@@ -51,7 +55,7 @@ function getEnhancedPath(): string {
     : currentPath;
 }
 
-function getExecEnv(): Record<string, string | undefined> {
+function getExecEnv(unsetKeys?: readonly string[]): Record<string, string | undefined> {
   const env: Record<string, string | undefined> = {
     ...getIsolatedEnv(),
     PATH: getEnhancedPath(),
@@ -59,6 +63,12 @@ function getExecEnv(): Record<string, string | undefined> {
 
   if (process.platform === 'win32') {
     delete env.Path;
+  }
+
+  if (unsetKeys) {
+    for (const key of unsetKeys) {
+      delete env[key];
+    }
   }
 
   return env;
@@ -71,7 +81,7 @@ export async function exec(command: string, options?: ExecOptions): Promise<stri
   try {
     const { stdout } = await execPromise(command, {
       cwd,
-      env: getExecEnv(),
+      env: getExecEnv(options?.unsetEnv),
     });
     logger.debug('exec.success', 'Shell command completed', {
       command,

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -1,12 +1,68 @@
-import { exec as execCallback, execFile as execFileCallback } from 'child_process';
+import {
+  exec as execCallback,
+  execFile as execFileCallback,
+  execSync,
+} from 'child_process';
 import path from 'node:path';
 import os from 'node:os';
 import { promisify } from 'util';
+import iconv from 'iconv-lite';
 import { getIsolatedEnv } from './path';
 import { logger } from './logger';
 
 const execPromise = promisify(execCallback);
 const execFilePromise = promisify(execFileCallback);
+
+const IS_WINDOWS = process.platform === 'win32';
+
+// Cached iconv-lite codec name (e.g. "cp936", "cp932", "cp437") for the
+// active Windows console code page. Set on first use and reused thereafter.
+let windowsConsoleCodecCache: string | null = null;
+
+function detectWindowsConsoleCodec(): string {
+  // (a) Respect OEMCP if Windows or the user provided one explicitly.
+  const oemcp = process.env.OEMCP?.trim();
+  if (oemcp && /^\d+$/.test(oemcp)) {
+    const codec = `cp${oemcp}`;
+    if (iconv.encodingExists(codec)) return codec;
+  }
+
+  // (b) Probe `chcp` once and parse "Active code page: NNN" (any locale —
+  //     fall back to the first run of digits anywhere in the output).
+  try {
+    const out = execSync('chcp', {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 5000,
+    }).toString();
+    const match = out.match(/(\d{3,5})/);
+    if (match) {
+      const codec = `cp${match[1]}`;
+      if (iconv.encodingExists(codec)) return codec;
+    }
+  } catch {
+    // chcp unavailable — fall through to the default.
+  }
+
+  // (c) Sensible fallback for OEM-locale Windows.
+  return iconv.encodingExists('cp437') ? 'cp437' : 'utf8';
+}
+
+function getWindowsConsoleCodec(): string {
+  if (windowsConsoleCodecCache !== null) return windowsConsoleCodecCache;
+  windowsConsoleCodecCache = detectWindowsConsoleCodec();
+  logger.debug('exec.codec', 'Detected Windows console codec', {
+    codec: windowsConsoleCodecCache,
+  });
+  return windowsConsoleCodecCache;
+}
+
+function decodeChildOutput(value: unknown, codec: string): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value)) return iconv.decode(value, codec);
+  return String(value);
+}
 
 export interface ExecOptions {
   cwd?: string;
@@ -78,24 +134,48 @@ export async function exec(command: string, options?: ExecOptions): Promise<stri
   const startedAt = Date.now();
   const cwd = options?.cwd;
   logger.debug('exec.start', 'Running shell command', { command, cwd });
+  // On Windows the console writes in the active OEM code page (CP936 for
+  // zh-CN, CP932 for ja-JP, CP437 for en-US, etc.), not UTF-8. The default
+  // string decoder in child_process therefore garbles non-ASCII output and
+  // error messages. Capture raw bytes and decode them through iconv-lite.
+  const codec = IS_WINDOWS ? getWindowsConsoleCodec() : 'utf8';
   try {
-    const { stdout } = await execPromise(command, {
-      cwd,
-      env: getExecEnv(options?.unsetEnv),
-    });
+    const { stdout } = IS_WINDOWS
+      ? await execPromise(command, {
+          cwd,
+          env: getExecEnv(options?.unsetEnv),
+          encoding: 'buffer',
+        })
+      : await execPromise(command, {
+          cwd,
+          env: getExecEnv(options?.unsetEnv),
+        });
+    const decodedStdout = IS_WINDOWS ? decodeChildOutput(stdout, codec) : (stdout as string);
     logger.debug('exec.success', 'Shell command completed', {
       command,
       cwd,
       durationMs: Date.now() - startedAt,
-      stdoutLength: stdout.length,
+      stdoutLength: decodedStdout.length,
     });
-    return stdout.trim();
+    return decodedStdout.trim();
   } catch (error) {
     const failure = error as Error & {
       code?: unknown;
       stdout?: unknown;
       stderr?: unknown;
     };
+    if (IS_WINDOWS) {
+      // Node attaches the captured Buffers to the rejected error when
+      // `encoding: 'buffer'` is set. Decode them in place so downstream
+      // log lines, error messages, and any caller that reads .stdout /
+      // .stderr off the error see readable text rather than mojibake.
+      if (failure.stdout !== undefined) {
+        failure.stdout = decodeChildOutput(failure.stdout, codec);
+      }
+      if (failure.stderr !== undefined) {
+        failure.stderr = decodeChildOutput(failure.stderr, codec);
+      }
+    }
     if (options?.logFailure === false) {
       logger.debug('exec.probeFailure', 'Shell probe command failed', {
         command,

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -169,11 +169,28 @@ export async function exec(command: string, options?: ExecOptions): Promise<stri
       // `encoding: 'buffer'` is set. Decode them in place so downstream
       // log lines, error messages, and any caller that reads .stdout /
       // .stderr off the error see readable text rather than mojibake.
-      if (failure.stdout !== undefined) {
-        failure.stdout = decodeChildOutput(failure.stdout, codec);
-      }
-      if (failure.stderr !== undefined) {
-        failure.stderr = decodeChildOutput(failure.stderr, codec);
+      const decodedStdout = failure.stdout !== undefined
+        ? decodeChildOutput(failure.stdout, codec)
+        : undefined;
+      const decodedStderr = failure.stderr !== undefined
+        ? decodeChildOutput(failure.stderr, codec)
+        : undefined;
+      if (decodedStdout !== undefined) failure.stdout = decodedStdout;
+      if (decodedStderr !== undefined) failure.stderr = decodedStderr;
+      // Node builds .message from the raw stderr Buffer via Buffer.toString()
+      // (UTF-8), so on a non-UTF-8 Windows console the message itself is
+      // still mojibake even after we fix .stdout / .stderr. Most callers log
+      // error.message (including the JSON log line in the user report that
+      // started this fix). Rebuild it from the iconv-decoded stderr, but
+      // only when the message has Node's "Command failed:" prefix, so we
+      // don't clobber errors thrown from elsewhere.
+      if (
+        typeof failure.message === 'string'
+        && failure.message.startsWith('Command failed:')
+      ) {
+        failure.message = decodedStderr
+          ? `Command failed: ${command}\n${decodedStderr}`
+          : `Command failed: ${command}`;
       }
     }
     if (options?.logFailure === false) {

--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -27,7 +27,11 @@ function isTmuxIntegrationEnvKey(key: string): boolean {
   return key.startsWith('VSCODE_') || TMUX_ENV_KEYS_TO_STRIP.includes(key);
 }
 
-function getTmuxSanitizedEnvKeys(): string[] {
+// The list of env vars that must NOT leak into the tmux/psmux process. Strip
+// these from the child process environment in exec(), not via an `env -u`
+// wrapper — Windows cmd.exe/PowerShell have no `env` binary, so the wrapper
+// approach fails before psmux even runs.
+export function getTmuxSanitizedEnvKeys(): string[] {
   return Array.from(new Set([
     ...TMUX_ENV_KEYS_TO_STRIP,
     ...Object.keys(process.env).filter(isTmuxIntegrationEnvKey),
@@ -35,13 +39,8 @@ function getTmuxSanitizedEnvKeys(): string[] {
 }
 
 export function buildSanitizedTmuxCommand(command: string): string {
-  const envKeys = getTmuxSanitizedEnvKeys();
   const tmuxCommand = getTmuxCommand();
-  if (envKeys.length === 0) {
-    return `${tmuxCommand} ${command}`;
-  }
-  const unsetArgs = envKeys.map((key) => `-u ${shellQuote(key)}`).join(' ');
-  return `env ${unsetArgs} ${tmuxCommand} ${command}`;
+  return `${tmuxCommand} ${command}`;
 }
 
 function buildStoredTmuxEnvScrubCommandPowerShell(sessionName?: string): string {
@@ -219,7 +218,10 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
     });
     try {
       await scrubStoredTmuxEnvironment(sessionName);
-      await exec(buildSanitizedTmuxCommand(`new-session -d -s ${shellQuote(sessionName)} -c ${shellQuote(cwd)}`));
+      await exec(
+        buildSanitizedTmuxCommand(`new-session -d -s ${shellQuote(sessionName)} -c ${shellQuote(cwd)}`),
+        { unsetEnv: getTmuxSanitizedEnvKeys() },
+      );
       logger.info('tmux.createSession', 'Created multiplexer session', { sessionName, cwd });
     } catch (error) {
       logger.error('tmux.createSession', 'Failed to create multiplexer session', { sessionName, cwd, error });

--- a/src/smoke/tmuxAttachSmoke.ts
+++ b/src/smoke/tmuxAttachSmoke.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { HYDRA_COPILOT_SESSION_ENV } from '../core/env';
-import { buildSanitizedTmuxCommand, buildStoredTmuxEnvScrubCommand } from '../core/tmux';
+import {
+  buildSanitizedTmuxCommand,
+  buildStoredTmuxEnvScrubCommand,
+  getTmuxSanitizedEnvKeys,
+} from '../core/tmux';
 import { buildTmuxMouseScrollbackCommand } from '../core/tmuxAttach';
 
 function main(): void {
@@ -29,10 +33,18 @@ function main(): void {
       );
     }
 
+    // Sanitization is no longer baked into the command string (env -u doesn't
+    // exist on Windows). Callers pass the keys to exec via unsetEnv instead.
+    delete process.env.HYDRA_TMUX_SOCKET;
     process.env[HYDRA_COPILOT_SESSION_ENV] = 'hydra-copilot-codex';
-    assert.match(
+    const expectedBinary = process.platform === 'win32' ? 'psmux' : 'tmux';
+    assert.equal(
       buildSanitizedTmuxCommand('new-session -d -s worker'),
-      new RegExp(HYDRA_COPILOT_SESSION_ENV),
+      `${expectedBinary} new-session -d -s worker`,
+    );
+    assert.ok(
+      getTmuxSanitizedEnvKeys().includes(HYDRA_COPILOT_SESSION_ENV),
+      `getTmuxSanitizedEnvKeys() should include ${HYDRA_COPILOT_SESSION_ENV}`,
     );
     assert.match(
       buildStoredTmuxEnvScrubCommand('worker'),


### PR DESCRIPTION
## Summary

A Windows zh-CN user reported copilot creation failing with a log full of mojibake:

```
Command failed: env -u "ELECTRON_RUN_AS_NODE" ... psmux new-session -d -s ...
'env' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
```

The garbled bytes decode from CP936 (GBK) to:
> `'env' 不是内部或外部命令，也不是可运行的程序`
> (`'env' is not recognized as an internal or external command…`)

That single log entry exposed **two independent root causes**. Both are Windows-only; macOS/Linux behavior is unchanged.

## Why two bugs, not one

| Layer | Bug | Symptom |
|-------|-----|---------|
| Command construction | `buildSanitizedTmuxCommand` prepended `env -u …` to every tmux/psmux invocation | The shell never finds an `env` binary on Windows — psmux is never even reached. |
| Output decoding | `exec()` ran with the default UTF-8 decoder | Even *if* psmux had run, any non-ASCII bytes (errors, paths) in the rejected error would be garbled in logs and bubbled-up UI strings. |

Fixing only the wrapper would have left every other non-ASCII Windows error path mojibake'd; fixing only the decoder would have left psmux unable to launch in the first place. Two separate commits, in order.

## Commits

### 1. `Avoid env -u wrapper on Windows when launching tmux/psmux`

- `ExecOptions` gains `unsetEnv?: string[]`. `exec()` removes those keys from the env it hands to `child_process` — the option-based path `promisify(child_process.exec)` already uses to set env.
- `buildSanitizedTmuxCommand` now returns just `<tmuxBinary> <command>`; the key list is exposed via a new `getTmuxSanitizedEnvKeys()` export.
- `TmuxBackendCore.createSession` passes the keys via `unsetEnv` instead of an `env -u` prefix.
- macOS/Linux strip the same set of keys — the only change is that they no longer go through a literal `env -u` shell prefix.

### 2. `Decode child process output with Windows console code page`

- Adds `iconv-lite` as a **runtime** dependency (in `dependencies`, not `devDependencies`).
- On Windows only, capture stdout/stderr as `Buffer`s (`encoding: 'buffer'`) and decode them through iconv-lite using the active OEM code page.
- Code-page detection is run once and cached:
  1. `process.env.OEMCP` if numeric
  2. else spawn `chcp` synchronously and parse the digit run (locale-agnostic — works on zh-CN's `活动代码页:` as well as the English `Active code page:`)
  3. fall back to `cp437` (or `utf8` if even that codec is unavailable)
- Decoding is applied in **both the success and failure paths** — when child_process rejects with `encoding: 'buffer'` set, Node attaches the captured Buffers to the rejected error; those are decoded in place so `getExecFailureText` and other downstream consumers see readable text.
- macOS/Linux still use the default UTF-8 string decoder — no behavior change.

## Cross-platform notes

- **macOS / Linux**: unchanged. The exact same env keys are stripped before psmux/tmux runs (Bug A); stdout/stderr is decoded as UTF-8 as before (Bug B).
- **Windows**: psmux now actually launches; non-ASCII bytes in its output and in any error message bubbled up to the UI are correctly decoded.

## Test plan

- [x] `npm run compile` — clean on each commit
- [x] `npm run lint` — clean on each commit
- [x] `npm run smoke:tmux-attach` — still passes (smoke test updated to assert the new `getTmuxSanitizedEnvKeys()` contract)
- [ ] Manual verification on Windows zh-CN — copilot creation succeeds and any non-ASCII error text in logs is readable (no Windows available to the author; verified by diff inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)