### PR TITLE
chore: release v0.3.2026060502

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026060502] - 2026-06-11
+
+### Fixed
+- Fix Windows psmux format argument quoting so session listing does not fail under cmd.exe when tmux format strings contain pipe separators
+
 ## [0.3.2026060501] - 2026-06-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026060501",
+  "version": "0.3.2026060502",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026060501",
+      "version": "0.3.2026060502",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026060501",
+  "version": "0.3.2026060502",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary
- Bump Hydra Code to 0.3.2026060502
- Add release notes for the Windows psmux format quoting fix

## Verification
- npm run compile
- npm run smoke:windows-format-quoting

Merging this PR into main should trigger the auto-tag workflow for v0.3.2026060502, which then triggers the publish workflow.