### PR TITLE
fix(windows): launch quoted Sudo Code commands in PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.2026060503] - 2026-06-11
+
+### Fixed
+- Fix the Windows `hydra.cmd` wrapper so subcommands and `--version` are forwarded to Hydra instead of being consumed by Node
+- Fix Sudo Code launch on Windows PowerShell when the resolved `scode.exe` path must be quoted
+
 ## [0.3.2026060502] - 2026-06-11
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026060502",
+  "version": "0.3.2026060503",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026060502",
+      "version": "0.3.2026060503",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026060502",
+  "version": "0.3.2026060503",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -395,7 +395,8 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows"
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/core/agentConfig.ts
+++ b/src/core/agentConfig.ts
@@ -190,6 +190,26 @@ function ensureStandaloneCommandFlags(command: string, flags: string): string {
     .reduce((current, flag) => ensureCommandFlag(current, flag), command.trim());
 }
 
+function prepareCommandForShell(command: string, target?: ShellTarget): string {
+  if (target !== 'pwsh') {
+    return command;
+  }
+
+  const trimmed = command.trim();
+  if (/^&\s+/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // PowerShell treats a leading quoted executable path as a string expression.
+  // Use the call operator so commands like `"C:\Program Files\tool.exe" --flag`
+  // actually execute instead of failing with UnexpectedToken.
+  if (/^"[A-Za-z]:\\[^"]+\.(?:exe|cmd|bat|ps1)"(?:\s|$)/i.test(trimmed)) {
+    return `& ${trimmed}`;
+  }
+
+  return trimmed;
+}
+
 // Which shell will execute the launch/resume command string we build below.
 // `posix` is POSIX `sh`-family (default on macOS/Linux). On Windows the value
 // depends on the psmux pane's default-shell — `cmd` (cmd.exe) or `pwsh`
@@ -232,18 +252,24 @@ function buildAgentBaseCommand(
 ): string {
   if (!isPlanCopilot(options)) {
     const yolo = AGENT_YOLO_FLAGS[agentType] || '';
-    return ensureStandaloneCommandFlags(agentBinary, yolo);
+    return prepareCommandForShell(
+      ensureStandaloneCommandFlags(agentBinary, yolo),
+      options?.shellTarget,
+    );
   }
 
   assertPlanCommandIsSafe(agentBinary);
 
   switch (agentType) {
     case 'claude':
-      return ensureCommandFlag(agentBinary, '--permission-mode plan');
+      return prepareCommandForShell(
+        ensureCommandFlag(agentBinary, '--permission-mode plan'),
+        options?.shellTarget,
+      );
     case 'codex': {
       let command = ensureCommandFlag(agentBinary, '--sandbox read-only');
       command = ensureCommandFlag(command, '--ask-for-approval never');
-      return command;
+      return prepareCommandForShell(command, options?.shellTarget);
     }
     default:
       throw new Error(getUnsupportedCopilotModeMessage(agentType, 'plan'));

--- a/src/core/cliInstaller.ts
+++ b/src/core/cliInstaller.ts
@@ -10,9 +10,9 @@ function getWrapperPath(): string {
   return path.join(getHydraBinDir(), 'hydra');
 }
 
-function buildWrapperScriptWindows(): string {
+export function buildWrapperScriptWindows(): string {
   return `@echo off
-setlocal EnableDelayedExpansion
+setlocal DisableDelayedExpansion
 
 set "HYDRA_DEFAULT_HOME=%USERPROFILE%\\.hydra"
 if defined HYDRA_HOME (
@@ -27,7 +27,7 @@ if defined HYDRA_CONFIG_PATH (
   set "CONFIG_PATH=%HYDRA_HOME_DIR%\\config.json"
 )
 
-node -e "const fs=require('fs'),path=require('path'),os=require('os');function expandHomeDir(p){if(p==='~')return os.homedir();if(p.startsWith('~/')||p.startsWith('~\\\\'))return path.join(os.homedir(),p.slice(2));return p}function resolveConfigPathValue(v,c){if(typeof v!=='string'||!v.trim())return undefined;const e=expandHomeDir(v.trim());const a=path.isAbsolute(e)?e:path.resolve(path.dirname(c),e);return path.normalize(a)}const configPath=process.env.HYDRA_CONFIG_PATH||path.join(process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),'config.json');let cfg={};try{if(fs.existsSync(configPath))cfg=JSON.parse(fs.readFileSync(configPath,'utf8'))||{}}catch{}const extPath=typeof(cfg.cli||{}).extensionPath==='string'?cfg.cli.extensionPath:'';if(!extPath||!fs.existsSync(path.join(extPath,'out','cli','index.js'))){console.error('Error: Hydra VS Code extension not found. Open VS Code with Hydra installed.');process.exit(1)}const {spawnSync}=require('child_process');const r=spawnSync(process.execPath,[path.join(extPath,'out','cli','index.js'),...process.argv.slice(2)],{stdio:'inherit',env:{...process.env,HYDRA_HOME:process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),HYDRA_CONFIG_PATH:configPath}});if(r.error){console.error(r.error.message);process.exit(1)}process.exit(typeof r.status==='number'?r.status:1)" %*
+node -e "const fs=require('fs'),path=require('path'),os=require('os');function expandHomeDir(p){if(p==='~')return os.homedir();if(p.startsWith('~/')||p.startsWith('~\\\\'))return path.join(os.homedir(),p.slice(2));return p}function resolveConfigPathValue(v,c){if(typeof v!=='string'||!v.trim())return undefined;const e=expandHomeDir(v.trim());const a=path.isAbsolute(e)?e:path.resolve(path.dirname(c),e);return path.normalize(a)}const configPath=process.env.HYDRA_CONFIG_PATH||path.join(process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),'config.json');let cfg={};try{if(fs.existsSync(configPath))cfg=JSON.parse(fs.readFileSync(configPath,'utf8'))||{}}catch{}const extPath=typeof(cfg.cli||{}).extensionPath==='string'?cfg.cli.extensionPath:'';if(!extPath||!fs.existsSync(path.join(extPath,'out','cli','index.js'))){console.error('Error: Hydra VS Code extension not found. Open VS Code with Hydra installed.');process.exit(1)}const {spawnSync}=require('child_process');const r=spawnSync(process.execPath,[path.join(extPath,'out','cli','index.js'),...process.argv.slice(1)],{stdio:'inherit',env:{...process.env,HYDRA_HOME:process.env.HYDRA_HOME||path.join(os.homedir(),'.hydra'),HYDRA_CONFIG_PATH:configPath}});if(r.error){console.error(r.error.message);process.exit(1)}process.exit(typeof r.status==='number'?r.status:1)" -- %*
 `;
 }
 

--- a/src/smoke/sudocodeAgentSmoke.ts
+++ b/src/smoke/sudocodeAgentSmoke.ts
@@ -117,6 +117,26 @@ function testAgentConfig(): void {
     'scode --dangerously-skip-permissions',
   );
   assert.equal(
+    buildAgentLaunchCommand(
+      'sudocode',
+      '"C:\\Users\\admin\\AppData\\Local\\Programs\\SudoCode\\scode.exe"',
+      undefined,
+      undefined,
+      { shellTarget: 'pwsh' },
+    ),
+    '& "C:\\Users\\admin\\AppData\\Local\\Programs\\SudoCode\\scode.exe" --dangerously-skip-permissions',
+  );
+  assert.equal(
+    buildAgentLaunchCommand(
+      'sudocode',
+      '"C:\\Users\\admin\\AppData\\Local\\Programs\\SudoCode\\scode.exe"',
+      undefined,
+      undefined,
+      { shellTarget: 'cmd' },
+    ),
+    '"C:\\Users\\admin\\AppData\\Local\\Programs\\SudoCode\\scode.exe" --dangerously-skip-permissions',
+  );
+  assert.equal(
     buildAgentLaunchCommand('claude', 'claude', undefined, '11111111-1111-4111-8111-111111111111', { copilotMode: 'plan' }),
     "claude --permission-mode plan --session-id '11111111-1111-4111-8111-111111111111'",
   );

--- a/src/smoke/windowsCliWrapperSmoke.ts
+++ b/src/smoke/windowsCliWrapperSmoke.ts
@@ -1,0 +1,42 @@
+/**
+ * Smoke test for the generated Windows hydra.cmd wrapper.
+ *
+ * Run: node out/smoke/windowsCliWrapperSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import { buildWrapperScriptWindows } from '../core/cliInstaller';
+
+function main(): void {
+  const script = buildWrapperScriptWindows();
+
+  assert.match(
+    script,
+    /setlocal DisableDelayedExpansion/,
+    'Windows wrapper must not enable delayed expansion because the inline Node script contains JS ! operators',
+  );
+  assert.doesNotMatch(
+    script,
+    /setlocal EnableDelayedExpansion/,
+    'EnableDelayedExpansion corrupts inline JS such as !extPath before node sees it',
+  );
+  assert.match(
+    script,
+    /node -e ".*" -- %\*/s,
+    'Windows wrapper must use -- so --version and other CLI flags pass through to Hydra, not node',
+  );
+  assert.match(
+    script,
+    /process\.argv\.slice\(1\)/,
+    'node -e receives forwarded arguments from process.argv[1]',
+  );
+  assert.doesNotMatch(
+    script,
+    /process\.argv\.slice\(2\)/,
+    'slice(2) drops the first Hydra subcommand when invoked through node -e',
+  );
+
+  console.log('windowsCliWrapperSmoke: ok');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Fix the generated Windows hydra.cmd wrapper so delayed expansion does not corrupt inline JS and CLI args are forwarded correctly
- Prefix quoted Windows executable paths with PowerShell's call operator when launching agents, fixing resolved scode.exe paths
- Bump release version to 0.3.2026060503 and add release notes

## Verification
- npm run compile
- npm run smoke:sudocode-agent
- npm run smoke:windows-cli-wrapper
- npm run smoke:shell-quote-display
- npm run smoke:shell-target-e2e

Merging this PR into main should trigger the auto-tag workflow for v0.3.2026060503, which then triggers the publish workflow.