### PR TITLE
fix(tmux): reuse existing duplicate sessions

### DIFF
--- a/src/core/tmux.ts
+++ b/src/core/tmux.ts
@@ -164,6 +164,10 @@ function isTmuxMissingSessionError(error: unknown): boolean {
     || text.includes('session not found');
 }
 
+export function isTmuxDuplicateSessionError(error: unknown): boolean {
+  return getExecFailureText(error).toLowerCase().includes('duplicate session');
+}
+
 // psmux (the Windows tmux port) exits non-zero with empty stderr when
 // `has-session` finds no match, so the keyword-based detectors above can't
 // recognize the "missing session" signal there. Silent non-zero exits with no
@@ -246,6 +250,24 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
       );
       logger.info('tmux.createSession', 'Created multiplexer session', { sessionName, cwd });
     } catch (error) {
+      if (isTmuxDuplicateSessionError(error)) {
+        try {
+          if (await this.hasSession(sessionName)) {
+            logger.warn(
+              'tmux.createSession',
+              'Multiplexer session already exists; reusing existing session',
+              { sessionName, cwd },
+            );
+            return;
+          }
+        } catch (inspectError) {
+          logger.warn(
+            'tmux.createSession',
+            'Duplicate session reported, but existing session could not be verified',
+            { sessionName, cwd, inspectError },
+          );
+        }
+      }
       logger.error('tmux.createSession', 'Failed to create multiplexer session', { sessionName, cwd, error });
       throw error;
     }

--- a/src/smoke/tmuxAttachSmoke.ts
+++ b/src/smoke/tmuxAttachSmoke.ts
@@ -4,6 +4,7 @@ import {
   buildSanitizedTmuxCommand,
   buildStoredTmuxEnvScrubCommand,
   getTmuxSanitizedEnvKeys,
+  isTmuxDuplicateSessionError,
 } from '../core/tmux';
 import { buildTmuxMouseScrollbackCommand } from '../core/tmuxAttach';
 
@@ -49,6 +50,18 @@ function main(): void {
     assert.match(
       buildStoredTmuxEnvScrubCommand('worker'),
       new RegExp(HYDRA_COPILOT_SESSION_ENV),
+    );
+
+    const duplicateError = new Error('Command failed: tmux new-session\nduplicate session: hydra-copilot-sudocode');
+    assert.equal(
+      isTmuxDuplicateSessionError(duplicateError),
+      true,
+      'tmux/psmux duplicate-session failures should be classified for createSession reuse',
+    );
+    assert.equal(
+      isTmuxDuplicateSessionError(new Error('no server running')),
+      false,
+      'unrelated tmux failures must not be treated as duplicates',
     );
   } finally {
     if (previousSocket === undefined) {


### PR DESCRIPTION
## Summary
- Treat tmux/psmux duplicate-session failures during createSession as reusable existing sessions when hasSession confirms the session is live
- Keep unrelated createSession failures bubbling up normally
- Add smoke coverage for duplicate-session error classification

## Verification
- npm run compile
- npm run smoke:tmux-attach

This is a cross-platform tmux core fix for cases where Hydra metadata and live tmux/psmux state get out of sync.