### PR TITLE
[codex] Add local event log stream

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -142,6 +142,73 @@ Returns:
 `defaultAgent` and `default_agent` are accepted aliases for the same key in
 commands that take a config key.
 
+### `hydra events --json`
+
+Reads the append-only local event stream in `HYDRA_HOME/events.jsonl`.
+Returns:
+
+| Field | Type | Contract |
+| --- | --- | --- |
+| `status` | string | `"ok"`. |
+| `events` | array | Event records with `seq` greater than `--after`, in ascending sequence order. |
+| `count` | number | `events.length`. |
+| `lastSeq` | number | Last printed event sequence, or the starting sequence when no events matched. |
+
+Event records include:
+
+| Field | Type |
+| --- | --- |
+| `version` | `1` |
+| `seq` | number |
+| `bootId` | string |
+| `ts` | string |
+| `type` | string |
+| `source` | `"cli"`, `"extension"`, `"session-manager"`, or `"hook"` |
+| `session` | string or undefined |
+| `role` | `"worker"`, `"copilot"`, or undefined |
+| `agent` | string or undefined |
+| `workdir` | string or undefined |
+| `payload` | object or undefined |
+
+Current event types:
+
+| Type | Source | Role | Payload contract |
+| --- | --- | --- | --- |
+| `notify.created` | `cli` or `hook` | undefined | `notificationId`, `kind`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
+| `notify.read` | `cli` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
+| `notify.cleared` | `cli` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`. Emitted only when at least one notification is removed. |
+| `worker.created` | `session-manager` | `worker` | `workerId`, `source`, optional `branch`, `repo`, `managedWorkdir`. Emitted for fresh code/task worker creation. |
+| `worker.started` | `session-manager` | `worker` | Worker identity fields plus `resumed`; existing-branch paths also include `alreadyRunning`. Emitted when an existing worker session is started or reused. |
+| `worker.stopped` | `session-manager` | `worker` | Worker identity fields. |
+| `worker.deleted` | `session-manager` | `worker` | Worker identity fields plus `archived`, `deletedFiles`, `removedWorktree`, `deletedBranch`. |
+| `worker.restored` | `session-manager` | `worker` | Worker identity fields plus `archivedAt`. |
+| `copilot.created` | `session-manager` | `copilot` | `copilotMode`. Emitted for fresh copilot creation. |
+| `copilot.started` | `session-manager` | `copilot` | `copilotMode`, `resumed`. Emitted when an existing copilot session is started. |
+| `copilot.deleted` | `session-manager` | `copilot` | `copilotMode`, `archived`. |
+| `copilot.restored` | `session-manager` | `copilot` | `copilotMode`, `archivedAt`. |
+| `session.id.captured` | `session-manager` | `worker` or `copilot` | `hasSessionId`, `hasAgentSessionFile`. |
+
+Payloads are sanitized before writing. Keys that may carry prompt, message,
+body, diff, content, token, credential, password, authorization, API key, or
+private key data are redacted.
+
+`--after <seq>` returns only events with a larger `seq`.
+
+`--cursor-file <path>` reads the starting sequence from a file when `--after`
+is omitted and updates the file after printing events. Cursor files contain the
+last printed sequence as plain text.
+
+### `hydra events --follow --json`
+
+Streams new event records as JSON lines until interrupted. Each stdout line is
+one event record, not a wrapper object. `--after` and `--cursor-file` have the
+same meaning as non-follow mode; the cursor file is updated after each printed
+event.
+
+The first event-log version does not rotate `events.jsonl`. Consumers should
+track by `seq`, not byte offset, so a future rotation implementation can remain
+compatible.
+
 ### `hydra notify create --json`
 
 Creates a structured local notification in `HYDRA_HOME/notifications.json`.
@@ -290,6 +357,12 @@ Notify commands:
 | `notify clear` | Clear all notifications, or a narrowed session/source/target subset. |
 | `notify open <id>` | Mark one notification read and return its suggested action. |
 
+Events command:
+
+| Command | Contract |
+| --- | --- |
+| `events` | Read `HYDRA_HOME/events.jsonl`. Supports `--after`, `--follow`, and `--cursor-file`. |
+
 Archive commands:
 
 | Command | Contract |
@@ -317,6 +390,7 @@ the expected text without tmux, git, VS Code, or a populated `~/.hydra`.
 - `hydra copilot logs --help` -> `Usage: hydra copilot logs [options] <session>`
 - `hydra copilot send --help` -> `Usage: hydra copilot send [options] <session> <message>`
 - `hydra config get --help` -> `Usage: hydra config get [options] <key>`
+- `hydra events --help` -> `Usage: hydra events [options]`
 - `hydra notify create --help` -> `Usage: hydra notify create [options]`
 - `hydra notify list --help` -> `Usage: hydra notify list [options]`
 - `hydra notify read --help` -> `Usage: hydra notify read [options] <id>`

--- a/docs/control-plane-roadmap.md
+++ b/docs/control-plane-roadmap.md
@@ -20,10 +20,12 @@ injecting messages.
 
 2. **Event log (#232)**
    - Add `HYDRA_HOME/events.jsonl`.
-   - Emit notification lifecycle events such as `notification.created`,
-     `notification.read`, and `notification.cleared`.
+   - Add `hydra events --json`, `--after`, `--follow`, and `--cursor-file`.
+   - Emit notification lifecycle events and the main worker/copilot lifecycle
+     events needed by future extension and dashboard consumers.
    - Redact text payloads in events; keep full notification text only in the
      local notification store.
+   - Defer event-log rotation until consumers are stable.
 
 3. **VS Code notification service**
    - Load notification snapshots in the extension host.

--- a/package.json
+++ b/package.json
@@ -382,6 +382,7 @@
     "smoke:cli-session-fields": "node out/smoke/cliSessionFieldsSmoke.js",
     "smoke:cli-config": "node out/smoke/cliConfigSmoke.js",
     "smoke:cli-contract": "node out/smoke/cliContractSmoke.js",
+    "smoke:events-cli": "node out/smoke/eventsCliSmoke.js",
     "smoke:notify-cli": "node out/smoke/notifyCliSmoke.js",
     "smoke:agent-registry": "node out/smoke/agentRegistrySmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
@@ -397,7 +398,7 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:notify-cli && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
     "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {

--- a/src/cli/commands/events.ts
+++ b/src/cli/commands/events.ts
@@ -1,0 +1,102 @@
+import { Command } from 'commander';
+import {
+  EventLog,
+  readCursorFile,
+  writeCursorFile,
+  type HydraEvent,
+} from '../../core/events';
+import { outputError, outputResult, type OutputOpts } from '../output';
+
+interface EventsOptions {
+  after?: string;
+  follow?: boolean;
+  cursorFile?: string;
+}
+
+const FOLLOW_POLL_INTERVAL_MS = 250;
+
+export function registerEventsCommand(program: Command): void {
+  program
+    .command('events')
+    .description('Read Hydra local event stream')
+    .option('--after <seq>', 'Only return events with seq greater than this value')
+    .option('--follow', 'Keep streaming new events as JSON lines')
+    .option('--cursor-file <path>', 'Read the starting seq from a cursor file and update it after printing events')
+    .action(async (opts: EventsOptions) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const log = new EventLog();
+        let after = opts.after != null
+          ? parseSeq(opts.after, '--after')
+          : opts.cursorFile
+            ? readCursorFile(opts.cursorFile)
+            : 0;
+
+        if (!opts.follow) {
+          const events = log.read({ after });
+          const lastSeq = events.length > 0 ? events[events.length - 1].seq : after;
+          if (opts.cursorFile && events.length > 0) {
+            writeCursorFile(opts.cursorFile, lastSeq);
+          }
+          outputResult(
+            {
+              status: 'ok',
+              events,
+              count: events.length,
+              lastSeq,
+            },
+            globalOpts,
+            () => {
+              if (events.length === 0) {
+                console.log('No events.');
+                return;
+              }
+              for (const event of events) {
+                printPrettyEvent(event);
+              }
+            },
+          );
+          return;
+        }
+
+        while (true) {
+          const events = log.read({ after, tolerateIncompleteTail: true });
+          for (const event of events) {
+            if (!globalOpts.quiet) {
+              if (globalOpts.json) {
+                process.stdout.write(`${JSON.stringify(event)}\n`);
+              } else {
+                printPrettyEvent(event);
+              }
+            }
+            after = event.seq;
+            if (opts.cursorFile) {
+              writeCursorFile(opts.cursorFile, after);
+            }
+          }
+          await sleep(FOLLOW_POLL_INTERVAL_MS);
+        }
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+}
+
+function parseSeq(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function printPrettyEvent(event: HydraEvent): void {
+  const session = event.session ? ` session=${event.session}` : '';
+  const role = event.role ? ` role=${event.role}` : '';
+  const agent = event.agent ? ` agent=${event.agent}` : '';
+  console.log(`#${event.seq} ${event.ts} ${event.type}${session}${role}${agent}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/cli/commands/notify.ts
+++ b/src/cli/commands/notify.ts
@@ -1,4 +1,5 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
+import { isHydraEventSource, type HydraEventSource } from '../../core/events';
 import {
   isNotificationKind,
   NotificationStore,
@@ -21,6 +22,7 @@ interface NotifyCreateOptions {
   branch?: string;
   workdir?: string;
   agent?: string;
+  eventSource?: string;
 }
 
 interface NotifyListOptions {
@@ -58,6 +60,7 @@ export function registerNotifyCommands(program: Command): void {
     .option('--branch <branch>', 'Branch name for notification context')
     .option('--workdir <path>', 'Workdir for notification context')
     .option('--agent <agent>', 'Agent for notification context')
+    .addOption(new Option('--event-source <source>').hideHelp())
     .action((opts: NotifyCreateOptions) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -83,6 +86,7 @@ export function registerNotifyCommands(program: Command): void {
             workdir: opts.workdir ?? null,
             agent: opts.agent ?? null,
           },
+          eventSource: parseEventSource(opts.eventSource),
         });
 
         outputResult(
@@ -228,6 +232,14 @@ export function registerNotifyCommands(program: Command): void {
         outputError(error, globalOpts);
       }
     });
+}
+
+function parseEventSource(value: string | undefined): HydraEventSource {
+  const normalized = (value || 'cli').trim();
+  if (isHydraEventSource(normalized)) {
+    return normalized;
+  }
+  throw new Error(`Invalid event source "${value}". Expected: cli, extension, session-manager, or hook.`);
 }
 
 function parseKind(value: string | undefined): NotificationKind {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { registerTestCommand } from './commands/test';
 import { registerShareCommands } from './commands/share';
 import { registerConfigCommands } from './commands/config';
 import { registerNotifyCommands } from './commands/notify';
+import { registerEventsCommand } from './commands/events';
 import { peekTelemetry } from '../core/telemetry';
 import { getHydraConfigPath, getHydraHome, getHydraLogFile } from '../core/path';
 import { getHostSummary, logger } from '../core/logger';
@@ -87,5 +88,6 @@ registerTestCommand(program);
 registerShareCommands(program);
 registerConfigCommands(program);
 registerNotifyCommands(program);
+registerEventsCommand(program);
 
 program.parse();

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,0 +1,387 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { randomUUID } from 'crypto';
+import { getHydraHome } from './path';
+
+export type HydraEventSource = 'cli' | 'extension' | 'session-manager' | 'hook';
+export type HydraEventRole = 'worker' | 'copilot';
+
+export interface HydraEvent {
+  version: 1;
+  seq: number;
+  bootId: string;
+  ts: string;
+  type: string;
+  source: HydraEventSource;
+  session?: string;
+  role?: HydraEventRole;
+  agent?: string;
+  workdir?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface AppendHydraEventInput {
+  type: string;
+  source: HydraEventSource;
+  session?: string | null;
+  role?: HydraEventRole | null;
+  agent?: string | null;
+  workdir?: string | null;
+  payload?: Record<string, unknown> | null;
+}
+
+export interface EventReadOptions {
+  after?: number;
+  tolerateIncompleteTail?: boolean;
+}
+
+interface EventStateFile {
+  version: 1;
+  lastSeq: number;
+}
+
+const EVENT_VERSION = 1;
+const BOOT_ID = randomUUID();
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_RETRY_MS = 25;
+const LOCK_STALE_MS = 30000;
+const MAX_TYPE_LENGTH = 120;
+const MAX_STRING_LENGTH = 500;
+const MAX_WORKDIR_LENGTH = 2000;
+const MAX_PAYLOAD_DEPTH = 4;
+const SENSITIVE_KEY_PATTERN = /(body|prompt|message|diff|content|text|token|secret|credential|password|authorization|api[_-]?key|private[_-]?key)/i;
+
+export function getHydraEventsFile(): string {
+  return path.join(getHydraHome(), 'events.jsonl');
+}
+
+export function getHydraEventsStateFile(): string {
+  return path.join(getHydraHome(), 'events.state.json');
+}
+
+export class EventLog {
+  constructor(
+    private readonly filePath: string = getHydraEventsFile(),
+    private readonly statePath: string = getHydraEventsStateFile(),
+  ) {}
+
+  append(input: AppendHydraEventInput): HydraEvent {
+    return this.withLock(() => {
+      const lastSeq = Math.max(this.readState().lastSeq, this.readLastSeqFromLog());
+      const event: HydraEvent = {
+        version: EVENT_VERSION,
+        seq: lastSeq + 1,
+        bootId: BOOT_ID,
+        ts: new Date().toISOString(),
+        type: truncate(input.type.trim(), MAX_TYPE_LENGTH),
+        source: input.source,
+      };
+
+      const session = normalizeOptionalString(input.session, MAX_STRING_LENGTH);
+      if (session) {
+        event.session = session;
+      }
+      if (input.role) {
+        event.role = input.role;
+      }
+      const agent = normalizeOptionalString(input.agent, MAX_STRING_LENGTH);
+      if (agent) {
+        event.agent = agent;
+      }
+      const workdir = normalizeOptionalString(input.workdir, MAX_WORKDIR_LENGTH);
+      if (workdir) {
+        event.workdir = workdir;
+      }
+      const payload = sanitizePayload(input.payload);
+      if (payload && Object.keys(payload).length > 0) {
+        event.payload = payload;
+      }
+
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.appendFileSync(this.filePath, `${JSON.stringify(event)}\n`, 'utf-8');
+      this.writeState({ version: EVENT_VERSION, lastSeq: event.seq });
+      return event;
+    });
+  }
+
+  read(options: EventReadOptions = {}): HydraEvent[] {
+    const after = options.after ?? 0;
+    if (!fs.existsSync(this.filePath)) {
+      return [];
+    }
+    const raw = fs.readFileSync(this.filePath, 'utf-8');
+    const events: HydraEvent[] = [];
+    const lines = raw.split(/\r?\n/);
+    const lastNonEmptyIndex = findLastNonEmptyLineIndex(lines);
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index].trim();
+      if (!line) {
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        if (options.tolerateIncompleteTail && index === lastNonEmptyIndex) {
+          break;
+        }
+        throw new Error(`Event log at ${this.filePath} has invalid JSON on line ${index + 1}`);
+      }
+      if (!isHydraEvent(parsed)) {
+        throw new Error(`Event log at ${this.filePath} has invalid event shape on line ${index + 1}`);
+      }
+      if (parsed.seq > after) {
+        events.push(parsed);
+      }
+    }
+    return events;
+  }
+
+  readLastSeq(): number {
+    return Math.max(this.readState().lastSeq, this.readLastSeqFromLog());
+  }
+
+  private readState(): EventStateFile {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.statePath, 'utf-8');
+    } catch (error) {
+      if (errorCode(error) === 'ENOENT') {
+        return { version: EVENT_VERSION, lastSeq: 0 };
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { version: EVENT_VERSION, lastSeq: this.readLastSeqFromLog() };
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      return { version: EVENT_VERSION, lastSeq: this.readLastSeqFromLog() };
+    }
+    const state = parsed as Partial<EventStateFile>;
+    if (state.version !== EVENT_VERSION || typeof state.lastSeq !== 'number' || !Number.isFinite(state.lastSeq)) {
+      return { version: EVENT_VERSION, lastSeq: this.readLastSeqFromLog() };
+    }
+    return { version: EVENT_VERSION, lastSeq: Math.max(0, Math.trunc(state.lastSeq)) };
+  }
+
+  private writeState(state: EventStateFile): void {
+    fs.mkdirSync(path.dirname(this.statePath), { recursive: true });
+    const tmpPath = path.join(
+      path.dirname(this.statePath),
+      `${path.basename(this.statePath)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+    );
+    fs.writeFileSync(tmpPath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+    fs.renameSync(tmpPath, this.statePath);
+  }
+
+  private readLastSeqFromLog(): number {
+    if (!fs.existsSync(this.filePath)) {
+      return 0;
+    }
+    const raw = fs.readFileSync(this.filePath, 'utf-8').trim();
+    if (!raw) {
+      return 0;
+    }
+    let lastSeq = 0;
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as Partial<HydraEvent>;
+        if (typeof parsed.seq === 'number' && Number.isFinite(parsed.seq)) {
+          lastSeq = Math.max(lastSeq, Math.trunc(parsed.seq));
+        }
+      } catch {
+        // read() is strict for consumers. Seq recovery is best effort so a
+        // malformed tail does not cause the next append to reuse a sequence.
+      }
+    }
+    return lastSeq;
+  }
+
+  private withLock<T>(fn: () => T): T {
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const lockDir = path.join(dir, 'events.lock');
+    const started = Date.now();
+    while (true) {
+      try {
+        fs.mkdirSync(lockDir);
+        break;
+      } catch (error) {
+        if (errorCode(error) !== 'EEXIST') {
+          throw error;
+        }
+        tryRemoveStaleLock(lockDir);
+        if (Date.now() - started > LOCK_TIMEOUT_MS) {
+          throw new Error(`Timed out waiting for event log lock at ${lockDir}`);
+        }
+        sleepSync(LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return fn();
+    } finally {
+      fs.rmSync(lockDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export function readCursorFile(cursorFile: string): number {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(cursorFile, 'utf-8').trim();
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') {
+      return 0;
+    }
+    throw error;
+  }
+  if (!raw) {
+    return 0;
+  }
+
+  let value: unknown = raw;
+  if (raw.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(raw) as { seq?: unknown; lastSeq?: unknown };
+      value = parsed.seq ?? parsed.lastSeq;
+    } catch {
+      value = raw;
+    }
+  }
+  const seq = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(seq) || seq < 0) {
+    throw new Error(`Invalid event cursor file at ${cursorFile}`);
+  }
+  return Math.trunc(seq);
+}
+
+export function writeCursorFile(cursorFile: string, seq: number): void {
+  fs.mkdirSync(path.dirname(cursorFile), { recursive: true });
+  const tmpPath = path.join(
+    path.dirname(cursorFile),
+    `${path.basename(cursorFile)}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`,
+  );
+  fs.writeFileSync(tmpPath, `${Math.max(0, Math.trunc(seq))}\n`, 'utf-8');
+  fs.renameSync(tmpPath, cursorFile);
+}
+
+function isHydraEvent(value: unknown): value is HydraEvent {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const event = value as Partial<HydraEvent>;
+  return event.version === EVENT_VERSION
+    && typeof event.seq === 'number'
+    && Number.isFinite(event.seq)
+    && typeof event.bootId === 'string'
+    && typeof event.ts === 'string'
+    && typeof event.type === 'string'
+    && isHydraEventSource(event.source)
+    && (event.session === undefined || typeof event.session === 'string')
+    && (event.role === undefined || event.role === 'worker' || event.role === 'copilot')
+    && (event.agent === undefined || typeof event.agent === 'string')
+    && (event.workdir === undefined || typeof event.workdir === 'string')
+    && (event.payload === undefined || (typeof event.payload === 'object' && event.payload !== null && !Array.isArray(event.payload)));
+}
+
+export function isHydraEventSource(value: unknown): value is HydraEventSource {
+  return value === 'cli' || value === 'extension' || value === 'session-manager' || value === 'hook';
+}
+
+function sanitizePayload(value: Record<string, unknown> | null | undefined): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  const sanitized = sanitizeObject(value, 0);
+  return sanitized && !Array.isArray(sanitized) && typeof sanitized === 'object'
+    ? sanitized as Record<string, unknown>
+    : undefined;
+}
+
+function sanitizeObject(value: unknown, depth: number): unknown {
+  if (depth > MAX_PAYLOAD_DEPTH) {
+    return '[redacted]';
+  }
+  if (value == null || typeof value === 'boolean' || typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return truncate(value, MAX_STRING_LENGTH);
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map(item => sanitizeObject(item, depth + 1));
+  }
+  if (typeof value !== 'object') {
+    return undefined;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      result[key] = '[redacted]';
+      continue;
+    }
+    const sanitized = sanitizeObject(child, depth + 1);
+    if (sanitized !== undefined) {
+      result[key] = sanitized;
+    }
+  }
+  return result;
+}
+
+function normalizeOptionalString(value: string | null | undefined, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? truncate(trimmed, maxLength) : undefined;
+}
+
+function findLastNonEmptyLineIndex(lines: string[]): number {
+  for (let index = lines.length - 1; index >= 0; index--) {
+    if (lines[index].trim()) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength);
+}
+
+function tryRemoveStaleLock(lockDir: string): void {
+  try {
+    const stat = fs.statSync(lockDir);
+    if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+      fs.rmSync(lockDir, { recursive: true, force: true });
+    }
+  } catch {
+    // Best effort.
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // Busy wait is acceptable here because locks are local and short-lived.
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { getHydraHome } from './path';
+import { EventLog, type HydraEventSource } from './events';
+import { logger } from './logger';
 
 export type NotificationKind = 'complete' | 'needs-input' | 'error' | 'blocked' | 'info';
 
@@ -42,6 +44,7 @@ export interface CreateNotificationInput {
   dedupeKey?: string;
   action?: NotificationAction;
   context?: HydraNotification['context'];
+  eventSource?: HydraEventSource;
 }
 
 export interface CreateNotificationResult {
@@ -99,6 +102,7 @@ export class NotificationStore {
   constructor(
     private readonly filePath: string = getHydraNotificationsFile(),
     private readonly retentionLimit: number = DEFAULT_RETENTION_LIMIT,
+    private readonly eventLog: EventLog = new EventLog(),
   ) {}
 
   create(input: CreateNotificationInput): CreateNotificationResult {
@@ -136,6 +140,7 @@ export class NotificationStore {
 
       store.notifications = [notification, ...store.notifications].slice(0, this.retentionLimit);
       this.writeStore(store);
+      this.emitNotificationEvent('notify.created', notification, input.eventSource || 'cli');
       return { notification, created: true };
     });
   }
@@ -168,6 +173,7 @@ export class NotificationStore {
       const updated = { ...existing, readAt: new Date().toISOString() };
       store.notifications[index] = updated;
       this.writeStore(store);
+      this.emitNotificationEvent('notify.read', updated, 'cli');
       return { notification: updated, markedRead: 1 };
     });
   }
@@ -180,6 +186,7 @@ export class NotificationStore {
       const cleared = before - store.notifications.length;
       if (cleared > 0) {
         this.writeStore(store);
+        this.emitClearEvent(cleared, filters);
       }
       return { cleared };
     });
@@ -263,6 +270,54 @@ export class NotificationStore {
       return fn();
     } finally {
       fs.rmSync(lockDir, { recursive: true, force: true });
+    }
+  }
+
+  private emitNotificationEvent(type: 'notify.created' | 'notify.read', notification: HydraNotification, source: HydraEventSource): void {
+    try {
+      this.eventLog.append({
+        type,
+        source,
+        session: notification.targetSession || notification.sourceSession,
+        payload: {
+          notificationId: notification.id,
+          kind: notification.kind,
+          targetSession: notification.targetSession,
+          sourceSession: notification.sourceSession,
+          actionType: notification.action?.type,
+          actionSession: notification.action?.session,
+          workerId: notification.context?.workerId,
+          branch: notification.context?.branch,
+          agent: notification.context?.agent,
+        },
+      });
+    } catch (error) {
+      logger.warn('notifications.event', 'Failed to append notification event', {
+        type,
+        notificationId: notification.id,
+        error,
+      });
+    }
+  }
+
+  private emitClearEvent(cleared: number, filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>): void {
+    try {
+      this.eventLog.append({
+        type: 'notify.cleared',
+        source: 'cli',
+        session: filters.session || filters.targetSession || filters.sourceSession,
+        payload: {
+          cleared,
+          session: filters.session,
+          targetSession: filters.targetSession,
+          sourceSession: filters.sourceSession,
+        },
+      });
+    } catch (error) {
+      logger.warn('notifications.event', 'Failed to append notification clear event', {
+        cleared,
+        error,
+      });
     }
   }
 }

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -12,6 +12,7 @@ import { shellQuote } from './shell';
 import { buildWindowsCopilotSessionEnvPrefix, probePaneShellWithRetry, type WindowsPaneShell } from './copilotSessionEnv';
 import { logger } from './logger';
 import { hashText } from './logRedaction';
+import { EventLog, type HydraEventRole } from './events';
 
 const POST_CREATE_TIMEOUT_MS = AGENT_READY_TIMEOUT_MS + 75000;
 const SESSION_STATE_LOCK_TIMEOUT_MS = 10000;
@@ -332,7 +333,10 @@ function normalizeCopilotMode(mode: CopilotMode | undefined): CopilotMode {
 // ── SessionManager Class ──
 
 export class SessionManager {
-  constructor(private backend: MultiplexerBackendCore) {}
+  constructor(
+    private backend: MultiplexerBackendCore,
+    private readonly eventLog: EventLog = new EventLog(),
+  ) {}
 
   // ── Sync: reconcile sessions.json <-> live multiplexer ──
 
@@ -821,6 +825,9 @@ export class SessionManager {
       workerId: workerInfo.workerId,
       sessionId: workerInfo.sessionId,
     });
+    if (!prepared.preservedWorkerInfo) {
+      this.emitWorkerEvent('worker.created', workerInfo);
+    }
 
     const postCreatePromise = this.withPostCreateTimeout((async () => {
       if (isResume) {
@@ -982,6 +989,14 @@ export class SessionManager {
         removedWorktree,
         deletedBranch,
       });
+      if (archivedWorker) {
+        this.emitWorkerEvent('worker.deleted', archivedWorker, {
+          archived: true,
+          deletedFiles,
+          removedWorktree,
+          deletedBranch,
+        });
+      }
     } catch (error) {
       logger.error('session.delete', 'Failed to delete worker session', {
         ...context,
@@ -1004,6 +1019,10 @@ export class SessionManager {
         state.updatedAt = new Date().toISOString();
       }
     });
+    const stoppedWorker = this.readSessionState().workers[sessionName];
+    if (stoppedWorker) {
+      this.emitWorkerEvent('worker.stopped', stoppedWorker);
+    }
   }
 
   async startWorker(sessionName: string, agentType?: string, agentCommand?: string): Promise<CreateWorkerResult> {
@@ -1116,6 +1135,8 @@ export class SessionManager {
       );
     }
 
+    this.emitWorkerEvent('worker.started', workerInfo, { resumed: canResume });
+
     return {
       workerInfo,
       postCreatePromise: this.withPostCreateTimeout(postCreatePromise, sessionName, 'worker startup'),
@@ -1197,6 +1218,8 @@ export class SessionManager {
         sessionName, agent, preAssignedSessionId, existingCopilot.workdir, launchStartedAt,
       );
     }
+
+    this.emitCopilotEvent('copilot.started', copilotInfo, { resumed: canResume });
 
     return {
       copilotInfo,
@@ -1313,6 +1336,9 @@ export class SessionManager {
       copilotMode: persistedCopilotInfo.copilotMode,
       sessionId: persistedCopilotInfo.sessionId,
     });
+    if (!opts.resumeSessionId) {
+      this.emitCopilotEvent('copilot.created', persistedCopilotInfo);
+    }
 
     // Match worker lifecycle semantics: wait for readiness and persist any deferred
     // session ID capture before the CLI treats creation as complete.
@@ -1544,6 +1570,9 @@ export class SessionManager {
         phase: 'complete',
         archived: !!archivedCopilot,
       });
+      if (archivedCopilot) {
+        this.emitCopilotEvent('copilot.deleted', archivedCopilot, { archived: true });
+      }
     } catch (error) {
       logger.error('session.delete', 'Failed to delete copilot session', {
         ...context,
@@ -1643,7 +1672,7 @@ export class SessionManager {
       if (!fs.existsSync(workdir) && !worker.managedWorkdir) {
         throw new Error(`Task worker workdir "${workdir}" does not exist`);
       }
-      return this.createDirectoryWorker({
+      const result = await this.createDirectoryWorker({
         workdir,
         name: worker.displayName || worker.slug,
         managedWorkdir: worker.managedWorkdir === true,
@@ -1652,12 +1681,14 @@ export class SessionManager {
         resumeSessionFile: entry.agentSessionFile || worker.agentSessionFile || undefined,
         preservedWorkerInfo: worker,
       });
+      this.emitWorkerEvent('worker.restored', result.workerInfo, { archivedAt: entry.archivedAt });
+      return result;
     }
 
     if (!worker.repoRoot || !worker.branch) {
       throw new Error(`Archived worker "${sessionName}" is missing repository metadata`);
     }
-    return this.createWorker({
+    const result = await this.createWorker({
       repoRoot: worker.repoRoot,
       branchName: worker.branch,
       agentType: worker.agent,
@@ -1665,6 +1696,8 @@ export class SessionManager {
       resumeSessionFile: entry.agentSessionFile || worker.agentSessionFile || undefined,
       preservedWorkerInfo: worker,
     });
+    this.emitWorkerEvent('worker.restored', result.workerInfo, { archivedAt: entry.archivedAt });
+    return result;
   }
 
   async restoreCopilot(sessionName: string): Promise<CreateCopilotResult> {
@@ -1677,7 +1710,7 @@ export class SessionManager {
     }
 
     const copilot = entry.data as CopilotInfo;
-    return this.createCopilot({
+    const result = await this.createCopilot({
       workdir: copilot.workdir,
       agentType: copilot.agent,
       copilotMode: copilot.copilotMode,
@@ -1686,9 +1719,69 @@ export class SessionManager {
       resumeSessionId: entry.agentSessionId || undefined,
       resumeSessionFile: entry.agentSessionFile || copilot.agentSessionFile || undefined,
     });
+    this.emitCopilotEvent('copilot.restored', result.copilotInfo, { archivedAt: entry.archivedAt });
+    return result;
   }
 
   // ── Private helpers ──
+
+  private emitLifecycleEvent(
+    type: string,
+    role: HydraEventRole,
+    info: {
+      sessionName: string;
+      agent?: string | null;
+      workdir?: string | null;
+      payload?: Record<string, unknown>;
+    },
+  ): void {
+    try {
+      this.eventLog.append({
+        type,
+        source: 'session-manager',
+        session: info.sessionName,
+        role,
+        agent: info.agent || undefined,
+        workdir: info.workdir || undefined,
+        payload: info.payload,
+      });
+    } catch (error) {
+      logger.warn('session.event', 'Failed to append session lifecycle event', {
+        type,
+        sessionName: info.sessionName,
+        role,
+        error,
+      });
+    }
+  }
+
+  private emitWorkerEvent(type: string, worker: WorkerInfo, payload: Record<string, unknown> = {}): void {
+    this.emitLifecycleEvent(type, 'worker', {
+      sessionName: worker.sessionName,
+      agent: worker.agent,
+      workdir: worker.workdir,
+      payload: {
+        workerId: worker.workerId,
+        source: getWorkerSource(worker),
+        branch: isRepoWorker(worker) ? worker.branch : null,
+        repo: isRepoWorker(worker) ? worker.repo : null,
+        managedWorkdir: isDirectoryWorker(worker) ? worker.managedWorkdir === true : false,
+        ...payload,
+      },
+    });
+  }
+
+  private emitCopilotEvent(type: string, copilot: CopilotInfo, payload: Record<string, unknown> = {}): void {
+    this.emitLifecycleEvent(type, 'copilot', {
+      sessionName: copilot.sessionName,
+      agent: copilot.agent,
+      workdir: copilot.workdir,
+      payload: {
+        copilotMode: copilot.copilotMode,
+        ...payload,
+      },
+    });
+  }
 
   private async finalizeCopilotResult(result: CreateCopilotResult): Promise<CopilotInfo> {
     await result.postCreatePromise;
@@ -2400,6 +2493,7 @@ export class SessionManager {
       '    --worker-id "$WORKER_ID" \\',
       '    --branch "$BRANCH" \\',
       '    --workdir "$WORKDIR" \\',
+      '    --event-source hook \\',
       '    --json >/dev/null 2>&1 || true',
       'fi',
       '',
@@ -2489,7 +2583,7 @@ export class SessionManager {
       '    }',
       '  }',
       '  if ($hydraPath) {',
-      '    & $hydraPath notify create --session $COPILOT --from $SESSION --kind complete --title $TITLE --body $BODY --dedupe-key $DEDUPE --action open-session --action-session $SESSION --worker-id $WORKER_ID --branch $BRANCH --workdir $WORKDIR --json *> $null',
+      '    & $hydraPath notify create --session $COPILOT --from $SESSION --kind complete --title $TITLE --body $BODY --dedupe-key $DEDUPE --action open-session --action-session $SESSION --worker-id $WORKER_ID --branch $BRANCH --workdir $WORKDIR --event-source hook --json *> $null',
       '  }',
       '',
       '  # Resolve psmux command (honors HYDRA_TMUX_SOCKET if set).',
@@ -3002,17 +3096,39 @@ export class SessionManager {
     sessionId: string | null,
     agentSessionFile: string | null,
   ): Promise<void> {
-    await this.updateSessionState((state) => {
+    const eventInfo = await this.updateSessionState((state) => {
       if (state.workers[sessionName]) {
         state.workers[sessionName].sessionId = sessionId;
         state.workers[sessionName].agentSessionFile = agentSessionFile;
         state.updatedAt = new Date().toISOString();
+        return {
+          role: 'worker' as const,
+          agent: state.workers[sessionName].agent,
+          workdir: state.workers[sessionName].workdir,
+        };
       } else if (state.copilots[sessionName]) {
         state.copilots[sessionName].sessionId = sessionId;
         state.copilots[sessionName].agentSessionFile = agentSessionFile;
         state.updatedAt = new Date().toISOString();
+        return {
+          role: 'copilot' as const,
+          agent: state.copilots[sessionName].agent,
+          workdir: state.copilots[sessionName].workdir,
+        };
       }
+      return null;
     });
+    if (sessionId && eventInfo) {
+      this.emitLifecycleEvent('session.id.captured', eventInfo.role, {
+        sessionName,
+        agent: eventInfo.agent,
+        workdir: eventInfo.workdir,
+        payload: {
+          hasSessionId: true,
+          hasAgentSessionFile: !!agentSessionFile,
+        },
+      });
+    }
   }
 
   private sleep(ms: number): Promise<void> {
@@ -3237,6 +3353,11 @@ export class SessionManager {
         return nextWorker;
       });
 
+      this.emitWorkerEvent('worker.started', workerInfo, {
+        resumed: true,
+        alreadyRunning: true,
+      });
+
       return {
         workerInfo,
         postCreatePromise: this.withPostCreateTimeout(Promise.resolve(), sessionName, 'worker startup'),
@@ -3353,6 +3474,11 @@ export class SessionManager {
         state.workers[sessionName] = nextWorker;
         state.updatedAt = now;
         return nextWorker;
+      });
+
+      this.emitWorkerEvent('worker.started', workerInfo, {
+        resumed: canResume,
+        alreadyRunning: false,
       });
 
       return {

--- a/src/smoke/cliContractSmoke.ts
+++ b/src/smoke/cliContractSmoke.ts
@@ -122,6 +122,7 @@ function assertHelpProbes(baseEnv: Record<string, string | undefined>): void {
     { args: ['copilot', 'logs', '--help'], expected: 'Usage: hydra copilot logs [options] <session>' },
     { args: ['copilot', 'send', '--help'], expected: 'Usage: hydra copilot send [options] <session> <message>' },
     { args: ['config', 'get', '--help'], expected: 'Usage: hydra config get [options] <key>' },
+    { args: ['events', '--help'], expected: 'Usage: hydra events [options]' },
     { args: ['notify', 'create', '--help'], expected: 'Usage: hydra notify create [options]' },
     { args: ['notify', 'list', '--help'], expected: 'Usage: hydra notify list [options]' },
     { args: ['notify', 'read', '--help'], expected: 'Usage: hydra notify read [options] <id>' },

--- a/src/smoke/codexBypassSmoke.ts
+++ b/src/smoke/codexBypassSmoke.ts
@@ -145,6 +145,18 @@ function readJson<T>(filePath: string, fallback: T): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
 }
 
+function readEvents(hydraDir: string): Array<{ type: string; session?: string; payload?: Record<string, unknown> }> {
+  const eventsPath = path.join(hydraDir, 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+  return fs.readFileSync(eventsPath, 'utf-8')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as { type: string; session?: string; payload?: Record<string, unknown> });
+}
+
 function countOccurrences(text: string, value: string): number {
   return text.split(value).length - 1;
 }
@@ -360,6 +372,55 @@ async function main(): Promise<void> {
   }
 
   {
+    const copilotStartWorkdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-copilot-start-'));
+    const state = readJson<Record<string, unknown>>(sessionsFile, {
+      copilots: {},
+      workers: {},
+      nextWorkerId: 1,
+      updatedAt: new Date().toISOString(),
+    });
+    const copilots = (state.copilots as Record<string, unknown>) || {};
+    copilots['copilot-start'] = {
+      sessionName: 'copilot-start',
+      displayName: 'copilot-start',
+      status: 'stopped',
+      attached: false,
+      agent: 'codex',
+      copilotMode: 'normal',
+      workdir: copilotStartWorkdir,
+      tmuxSession: 'copilot-start',
+      createdAt: new Date().toISOString(),
+      lastSeenAt: new Date().toISOString(),
+      sessionId: '55555555-5555-4555-8555-555555555555',
+      agentSessionFile: null,
+    };
+    state.copilots = copilots;
+    writeJson(sessionsFile, state);
+
+    const backend = new FakeBackend();
+    backend.paneOutputs.set('copilot-start', '⏵');
+    const sm = new SessionManager(backend);
+    forceFastSleeps(sm);
+
+    const result = await sm.startCopilot('copilot-start');
+    await result.postCreatePromise;
+
+    const command = lastSendKeysFor(backend, 'copilot-start');
+    assert.equal(
+      command,
+      withCopilotSessionEnv(
+        'copilot-start',
+        `${smokeCodexCommand} ${BYPASS_FLAGS} resume -C '${copilotStartWorkdir}' '55555555-5555-4555-8555-555555555555'`,
+      ),
+    );
+    assert.equal(result.resumed, true);
+    const startedEvent = readEvents(hydraDir)
+      .find(event => event.type === 'copilot.started' && event.session === 'copilot-start');
+    assert.ok(startedEvent, 'startCopilot should emit copilot.started');
+    assert.equal(startedEvent?.payload?.resumed, true);
+  }
+
+  {
     const workerWorkdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-start-'));
     const state = readJson<Record<string, unknown>>(sessionsFile, {
       copilots: {},
@@ -565,12 +626,86 @@ async function main(): Promise<void> {
           call.sessionName === 'repo-ns_foo-bar-2' && call.message === 'resume foo slash bar'
         ),
       );
+      const startedEvent = readEvents(hydraDir)
+        .find(event => event.type === 'worker.started' && event.session === 'repo-ns_foo-bar-2');
+      assert.ok(startedEvent, 'Existing-branch resume should emit worker.started');
+      assert.equal(startedEvent?.payload?.resumed, true);
+      assert.equal(startedEvent?.payload?.alreadyRunning, false);
       assert.equal(
         backend.sendKeysCalls.some(call =>
           call.sessionName === 'repo-ns_foo-bar' && call.keys === 'resume foo slash bar'
         ),
         false,
       );
+    } finally {
+      restoreCoreGit();
+    }
+  }
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-live-resume-repo-'));
+    const liveWorktree = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-live-resume-worktree-'));
+    const now = new Date().toISOString();
+    writeJson(sessionsFile, {
+      copilots: {},
+      workers: {
+        'repo-ns_live-branch': {
+          sessionName: 'repo-ns_live-branch',
+          displayName: 'live-branch',
+          workerId: 21,
+          repo: 'repo',
+          repoRoot,
+          branch: 'live/branch',
+          slug: 'live-branch',
+          status: 'running',
+          attached: false,
+          agent: 'codex',
+          workdir: liveWorktree,
+          tmuxSession: 'repo-ns_live-branch',
+          createdAt: now,
+          lastSeenAt: now,
+          sessionId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+          copilotSessionName: null,
+        },
+      },
+      nextWorkerId: 22,
+      updatedAt: now,
+    });
+
+    const restoreCoreGit = patchModule(coreGit, {
+      validateBranchName: () => undefined,
+      getRepoSessionNamespace: () => 'repo-ns',
+      localBranchExists: async (_repoRoot: string, branchName: string) => branchName === 'live/branch',
+      branchNameToSlug: () => 'live-branch',
+      getRepoName: () => 'repo',
+    });
+
+    try {
+      const backend = new FakeBackend();
+      await backend.createSession('repo-ns_live-branch', liveWorktree);
+      await backend.setSessionAgent('repo-ns_live-branch', 'codex');
+      const sm = new SessionManager(backend);
+      forceFastSleeps(sm);
+
+      const result = await sm.createWorker({
+        repoRoot,
+        branchName: 'live/branch',
+        agentType: 'codex',
+        task: 'reuse live branch',
+      });
+      await result.postCreatePromise;
+
+      assert.equal(result.workerInfo.sessionName, 'repo-ns_live-branch');
+      assert.ok(
+        backend.sendMessageCalls.some(call =>
+          call.sessionName === 'repo-ns_live-branch' && call.message === 'reuse live branch'
+        ),
+      );
+      const startedEvent = readEvents(hydraDir)
+        .find(event => event.type === 'worker.started' && event.session === 'repo-ns_live-branch');
+      assert.ok(startedEvent, 'Live existing branch should emit worker.started');
+      assert.equal(startedEvent?.payload?.resumed, true);
+      assert.equal(startedEvent?.payload?.alreadyRunning, true);
     } finally {
       restoreCoreGit();
     }
@@ -661,6 +796,11 @@ async function main(): Promise<void> {
         backend.sendKeysCalls.some(call => call.sessionName === 'repo-ns_foo-bar-2'),
         false,
       );
+      const startedEvent = readEvents(hydraDir)
+        .find(event => event.type === 'worker.started' && event.session === 'repo-ns_foo-bar');
+      assert.ok(startedEvent, 'Existing branch fresh start should emit worker.started');
+      assert.equal(startedEvent?.payload?.resumed, false);
+      assert.equal(startedEvent?.payload?.alreadyRunning, false);
     } finally {
       restoreCoreGit();
     }

--- a/src/smoke/completionHookSmoke.ts
+++ b/src/smoke/completionHookSmoke.ts
@@ -28,6 +28,17 @@ interface StoredNotificationSmoke {
   context?: { workerId?: number; branch?: string | null; workdir?: string | null };
 }
 
+interface StoredEventSmoke {
+  type: string;
+  source: string;
+  session?: string;
+  payload?: {
+    sourceSession?: string | null;
+    targetSession?: string | null;
+    notificationId?: string;
+  };
+}
+
 function sq(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
@@ -73,6 +84,18 @@ function readStoredNotifications(hydraHome: string): StoredNotificationSmoke[] {
   }
   const parsed = JSON.parse(fs.readFileSync(storePath, 'utf-8')) as { notifications?: unknown[] };
   return (parsed.notifications || []) as StoredNotificationSmoke[];
+}
+
+function readStoredEvents(hydraHome: string): StoredEventSmoke[] {
+  const eventsPath = path.join(hydraHome, 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+  return fs.readFileSync(eventsPath, 'utf-8')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as StoredEventSmoke);
 }
 
 class PromptBackend {
@@ -515,6 +538,8 @@ async function main(): Promise<void> {
       hookCommands.length,
       `Structured store should contain one completion notification per agent, got:\n${JSON.stringify(firstNotifications, null, 2)}`,
     );
+    const firstEvents = readStoredEvents(hydraDir).filter(event => event.type === 'notify.created' && event.source === 'hook');
+    assert.equal(firstEvents.length, hookCommands.length, 'Hook notifications should emit notify.created events');
     for (const { agent, info } of hookCommands) {
       const stored = firstNotifications.filter(notification => notification.sourceSession === info.sessionName);
       assert.equal(stored.length, 1, `${agent} should create exactly one structured notification`);
@@ -526,6 +551,9 @@ async function main(): Promise<void> {
       assert.equal(stored[0].context?.branch, info.branch);
       assert.equal(stored[0].context?.workdir, info.workdir);
       assert.ok(stored[0].dedupeKey?.startsWith(`completion:${info.sessionName}:`));
+      const event = firstEvents.find(candidate => candidate.payload?.sourceSession === info.sessionName);
+      assert.ok(event, `${agent} should create a hook-sourced notify.created event`);
+      assert.equal(event?.payload?.targetSession, COPILOT_SESSION);
     }
 
     // Re-arm to simulate a later copilot-originated worker message. The hook
@@ -656,6 +684,9 @@ async function main(): Promise<void> {
     assert.equal(twoStepNotifications[0].kind, 'complete');
     assert.equal(twoStepNotifications[0].targetSession, COPILOT_SESSION);
     assert.equal(twoStepNotifications[0].context?.workerId, twoStepWorkerId);
+    const twoStepEvents = readStoredEvents(hydraDir)
+      .filter(event => event.type === 'notify.created' && event.source === 'hook' && event.payload?.sourceSession === twoStepSession);
+    assert.equal(twoStepEvents.length, 1, 'Two-step E2E: notify.created event should be created');
 
     console.log('  Part 2b (two-step worker end-to-end notification): ok');
   } finally {

--- a/src/smoke/eventsCliSmoke.ts
+++ b/src/smoke/eventsCliSmoke.ts
@@ -1,0 +1,321 @@
+/**
+ * Smoke test: Hydra local JSONL event stream and CLI reader.
+ *
+ * Run: node out/smoke/eventsCliSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import { spawn, spawnSync, type ChildProcessByStdio, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Readable } from 'node:stream';
+import { EXIT_OK } from '../cli/output';
+
+const cliPath = path.resolve(__dirname, '..', 'cli', 'index.js');
+
+interface TestContext {
+  tmp: string;
+  home: string;
+  hydraHome: string;
+  configPath: string;
+  env: Record<string, string | undefined>;
+}
+
+interface EventRecord {
+  version: number;
+  seq: number;
+  bootId: string;
+  ts: string;
+  type: string;
+  source: string;
+  session?: string;
+  payload?: Record<string, unknown>;
+}
+
+function setupContext(): TestContext {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-events-cli-'));
+  const home = path.join(tmp, 'home');
+  const hydraHome = path.join(tmp, 'hydra');
+  const configPath = path.join(hydraHome, 'config.json');
+  fs.mkdirSync(home, { recursive: true });
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    HYDRA_HOME: hydraHome,
+    HYDRA_CONFIG_PATH: configPath,
+    HYDRA_TELEMETRY: '0',
+  };
+  return { tmp, home, hydraHome, configPath, env };
+}
+
+function runCli(args: string[], env: Record<string, string | undefined>): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function parseStdoutJson<T>(proc: SpawnSyncReturns<string>, label: string): T {
+  assert.equal(proc.status, EXIT_OK, `${label} should exit 0\nstdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`);
+  assert.equal(proc.stderr.trim(), '', `${label} should not write stderr`);
+  return JSON.parse(proc.stdout) as T;
+}
+
+async function main(): Promise<void> {
+  if (!fs.existsSync(cliPath)) {
+    console.log(`eventsCliSmoke: skipped (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const ctx = setupContext();
+  try {
+    const secretBody = 'secret body should not leak into events';
+    const created = parseStdoutJson<{ notification: { id: string } }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'repo_copilot',
+        '--from',
+        'repo_worker',
+        '--kind',
+        'complete',
+        '--title',
+        'Worker #9 completed',
+        '--body',
+        secretBody,
+        '--dedupe-key',
+        'completion:repo_worker:events-a',
+        '--json',
+      ], ctx.env),
+      'hydra notify create --json',
+    );
+
+    const duplicate = parseStdoutJson<{ status: string; created: boolean }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'repo_copilot',
+        '--from',
+        'repo_worker',
+        '--kind',
+        'complete',
+        '--title',
+        'Duplicate should not emit',
+        '--dedupe-key',
+        'completion:repo_worker:events-a',
+        '--json',
+      ], ctx.env),
+      'hydra notify create duplicate --json',
+    );
+    assert.equal(duplicate.status, 'exists');
+    assert.equal(duplicate.created, false);
+
+    const allAfterCreate = parseStdoutJson<{ status: string; events: EventRecord[]; count: number; lastSeq: number }>(
+      runCli(['events', '--json'], ctx.env),
+      'hydra events --json',
+    );
+    assert.equal(allAfterCreate.status, 'ok');
+    assert.equal(allAfterCreate.count, 1);
+    assert.equal(allAfterCreate.events[0].type, 'notify.created');
+    assert.equal(allAfterCreate.events[0].source, 'cli');
+    assert.equal(allAfterCreate.events[0].seq, 1);
+    assert.equal(allAfterCreate.lastSeq, 1);
+
+    parseStdoutJson<{ markedRead: number }>(
+      runCli(['notify', 'read', created.notification.id, '--json'], ctx.env),
+      'hydra notify read --json',
+    );
+
+    const afterOne = parseStdoutJson<{ events: EventRecord[]; count: number; lastSeq: number }>(
+      runCli(['events', '--after', '1', '--json'], ctx.env),
+      'hydra events --after 1 --json',
+    );
+    assert.equal(afterOne.count, 1);
+    assert.equal(afterOne.events[0].seq, 2);
+    assert.equal(afterOne.events[0].type, 'notify.read');
+    assert.equal(afterOne.lastSeq, 2);
+
+    const cursorFile = path.join(ctx.tmp, 'events.seq');
+    const cursorRead = parseStdoutJson<{ events: EventRecord[]; count: number; lastSeq: number }>(
+      runCli(['events', '--cursor-file', cursorFile, '--json'], ctx.env),
+      'hydra events --cursor-file --json',
+    );
+    assert.equal(cursorRead.count, 2);
+    assert.equal(cursorRead.lastSeq, 2);
+    assert.equal(fs.readFileSync(cursorFile, 'utf-8').trim(), '2');
+
+    const otherBody = 'another body should also stay out of events';
+    parseStdoutJson<{ notification: { id: string } }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'repo_copilot',
+        '--from',
+        'repo_worker',
+        '--kind',
+        'info',
+        '--title',
+        'Second event',
+        '--body',
+        otherBody,
+        '--json',
+      ], ctx.env),
+      'hydra notify create second --json',
+    );
+
+    const cursorNext = parseStdoutJson<{ events: EventRecord[]; count: number; lastSeq: number }>(
+      runCli(['events', '--cursor-file', cursorFile, '--json'], ctx.env),
+      'hydra events --cursor-file next --json',
+    );
+    assert.equal(cursorNext.count, 1);
+    assert.equal(cursorNext.events[0].seq, 3);
+    assert.equal(cursorNext.events[0].type, 'notify.created');
+    assert.equal(cursorNext.lastSeq, 3);
+    assert.equal(fs.readFileSync(cursorFile, 'utf-8').trim(), '3');
+
+    const eventLogPath = path.join(ctx.hydraHome, 'events.jsonl');
+    const followCursor = path.join(ctx.tmp, 'follow.seq');
+    const follow = spawn(process.execPath, [
+      cliPath,
+      'events',
+      '--after',
+      '3',
+      '--follow',
+      '--cursor-file',
+      followCursor,
+      '--json',
+    ], {
+      env: ctx.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    try {
+      const nextEvent = waitForJsonLine(follow);
+      await sleep(300);
+      parseStdoutJson<{ cleared: number }>(
+        runCli(['notify', 'clear', '--session', 'repo_worker', '--json'], ctx.env),
+        'hydra notify clear --json',
+      );
+      const followed = await nextEvent;
+      assert.equal(followed.seq, 4);
+      assert.equal(followed.type, 'notify.cleared');
+      await waitForFileContent(followCursor, '4');
+    } finally {
+      await stopProcess(follow);
+    }
+
+    const partialFollow = spawn(process.execPath, [
+      cliPath,
+      'events',
+      '--after',
+      '4',
+      '--follow',
+      '--json',
+    ], {
+      env: ctx.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    try {
+      const nextEvent = waitForJsonLine(partialFollow);
+      await sleep(300);
+      fs.appendFileSync(
+        eventLogPath,
+        `{"version":1,"seq":5,"bootId":"manual","ts":"${new Date().toISOString()}","type":"manual.partial","source":"cli"`,
+        'utf-8',
+      );
+      await sleep(400);
+      fs.appendFileSync(eventLogPath, '}\n', 'utf-8');
+      const completed = await nextEvent;
+      assert.equal(completed.seq, 5);
+      assert.equal(completed.type, 'manual.partial');
+    } finally {
+      await stopProcess(partialFollow);
+    }
+
+    const eventLogRaw = fs.readFileSync(eventLogPath, 'utf-8');
+    assert.equal(eventLogRaw.includes(secretBody), false, 'events.jsonl must not include notification body');
+    assert.equal(eventLogRaw.includes(otherBody), false, 'events.jsonl must not include notification body');
+    assert.match(eventLogRaw, /"type":"notify\.created"/);
+
+    console.log('eventsCliSmoke: ok');
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+function waitForJsonLine(proc: ChildProcessByStdio<null, Readable, Readable>): Promise<EventRecord> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for hydra events --follow\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 8000);
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8');
+      const line = stdout.split(/\r?\n/).find(candidate => candidate.trim().length > 0);
+      if (!line) {
+        return;
+      }
+      clearTimeout(timeout);
+      try {
+        resolve(JSON.parse(line) as EventRecord);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf-8');
+    });
+    proc.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    proc.on('exit', (code, signal) => {
+      if (!stdout.trim()) {
+        clearTimeout(timeout);
+        reject(new Error(`hydra events --follow exited before output code=${code} signal=${signal}\nstderr:\n${stderr}`));
+      }
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForFileContent(filePath: string, expected: string): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 5000) {
+    if (fs.existsSync(filePath) && fs.readFileSync(filePath, 'utf-8').trim() === expected) {
+      return;
+    }
+    await sleep(50);
+  }
+  const actual = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8').trim() : '<missing>';
+  assert.equal(actual, expected);
+}
+
+async function stopProcess(proc: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 2000);
+    proc.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    proc.kill('SIGTERM');
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/smoke/notifyCliSmoke.ts
+++ b/src/smoke/notifyCliSmoke.ts
@@ -204,6 +204,12 @@ function main(): void {
     assert.equal(emptyList.unreadCount, 0);
     assert.equal(emptyList.totalCount, 0);
 
+    const eventsPath = path.join(ctx.hydraHome, 'events.jsonl');
+    const events = fs.readFileSync(eventsPath, 'utf-8').trim().split(/\r?\n/).map(line => JSON.parse(line) as { type: string; seq: number });
+    assert.deepEqual(events.map(event => event.type), ['notify.created', 'notify.read', 'notify.cleared']);
+    assert.deepEqual(events.map(event => event.seq), [1, 2, 3]);
+    assert.equal(fs.readFileSync(eventsPath, 'utf-8').includes('Branch: feat/auth'), false);
+
     console.log('notifyCliSmoke: ok');
   } finally {
     fs.rmSync(ctx.tmp, { recursive: true, force: true });

--- a/src/smoke/taskWorkerSmoke.ts
+++ b/src/smoke/taskWorkerSmoke.ts
@@ -126,6 +126,18 @@ function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
 }
 
+function readEvents(hydraHome: string): Array<{ type: string; session?: string; payload?: Record<string, unknown> }> {
+  const eventsPath = path.join(hydraHome, 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+  return fs.readFileSync(eventsPath, 'utf-8')
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as { type: string; session?: string; payload?: Record<string, unknown> });
+}
+
 async function main(): Promise<void> {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-task-worker-'));
   process.env.HOME = tempHome;
@@ -154,6 +166,10 @@ async function main(): Promise<void> {
   assert.equal(unmanaged.workerInfo.managedWorkdir, false);
   assert.equal(unmanaged.workerInfo.workdir, userDir);
   assert.equal(backend.messages.at(-1)?.message, 'summarize the notes');
+  const unmanagedCreatedEvent = readEvents(process.env.HYDRA_HOME!)
+    .find(event => event.type === 'worker.created' && event.session === unmanaged.workerInfo.sessionName);
+  assert.ok(unmanagedCreatedEvent, 'task worker creation should emit worker.created');
+  assert.equal(unmanagedCreatedEvent?.payload?.source, 'directory');
 
   await assert.rejects(
     () => sm.deleteWorker(unmanaged.workerInfo.sessionName, { deleteFiles: true }),
@@ -164,6 +180,9 @@ async function main(): Promise<void> {
 
   await sm.deleteWorker(unmanaged.workerInfo.sessionName);
   assert.ok(fs.existsSync(userDir), 'unmanaged directory should survive normal delete');
+  const unmanagedDeletedEvent = readEvents(process.env.HYDRA_HOME!)
+    .find(event => event.type === 'worker.deleted' && event.session === unmanaged.workerInfo.sessionName);
+  assert.ok(unmanagedDeletedEvent, 'task worker deletion should emit worker.deleted');
   const stateAfterDelete = readJson<{ workers: Record<string, unknown> }>(getHydraSessionsFile());
   assert.equal(stateAfterDelete.workers[unmanaged.workerInfo.sessionName], undefined);
 
@@ -194,6 +213,9 @@ async function main(): Promise<void> {
   const managedDeletePath = managedDeleteFiles.workerInfo.workdir;
   await sm.deleteWorker(managedDeleteFiles.workerInfo.sessionName, { deleteFiles: true });
   assert.equal(fs.existsSync(managedDeletePath), false, 'managed task directory should be deleted with deleteFiles');
+  const managedDeletedEvent = readEvents(process.env.HYDRA_HOME!)
+    .find(event => event.type === 'worker.deleted' && event.session === managedDeleteFiles.workerInfo.sessionName);
+  assert.equal(managedDeletedEvent?.payload?.deletedFiles, true, 'deleteFiles should be recorded as event metadata');
 
   fs.rmSync(tempHome, { recursive: true, force: true });
   console.log('taskWorkerSmoke: ok');


### PR DESCRIPTION
## Summary

- add a versioned local JSONL event log with sequence state, cursor helpers, redaction, and tolerant follow reads
- add `hydra events` with `--json`, `--after`, `--follow`, and `--cursor-file`
- emit notification, worker, copilot, and session-id lifecycle events from the structured notification store and session manager
- preserve completion-hook behavior while dual-writing hook-sourced notification events
- document the event CLI contract and current event type vocabulary

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:events-cli`
- `npm run smoke:notify-cli`
- `npm run smoke:completion-hook`
- `npm run smoke:codex-bypass`
- `npm run smoke:task-worker`
- `npm run smoke:cli-contract`
- `npm test`
