### PR TITLE
[codex] Add notification state service

### DIFF
--- a/docs/control-plane-roadmap.md
+++ b/docs/control-plane-roadmap.md
@@ -28,9 +28,12 @@ injecting messages.
    - Defer event-log rotation until consumers are stable.
 
 3. **VS Code notification service**
-   - Load notification snapshots in the extension host.
-   - Watch or poll the store/event log.
-   - Expose unread counts and latest notifications to existing providers.
+   - Load notification snapshots in the extension host via
+     `NotificationStateService`.
+   - Treat `notifications.json` as the authoritative state source and
+     `events.jsonl` as a wake-up signal.
+   - Expose unread counts, latest notifications, and session/id lookups for
+     future providers and inbox UI.
 
 4. **Attention Inbox**
    - Add a user-facing notification surface in VS Code.

--- a/package.json
+++ b/package.json
@@ -384,6 +384,7 @@
     "smoke:cli-contract": "node out/smoke/cliContractSmoke.js",
     "smoke:events-cli": "node out/smoke/eventsCliSmoke.js",
     "smoke:notify-cli": "node out/smoke/notifyCliSmoke.js",
+    "smoke:notification-state": "node out/smoke/notificationStateServiceSmoke.js",
     "smoke:agent-registry": "node out/smoke/agentRegistrySmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
@@ -398,7 +399,7 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:notification-state && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
     "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {

--- a/src/core/notificationState.ts
+++ b/src/core/notificationState.ts
@@ -1,0 +1,130 @@
+import type { HydraNotification } from './notifications';
+
+export interface NotificationSnapshot {
+  readonly loadedAt: string;
+  readonly lastEventSeq: number;
+  readonly notifications: readonly HydraNotification[];
+  readonly totalCount: number;
+  readonly unreadCount: number;
+}
+
+export interface NotificationStateIndexes {
+  readonly byId: ReadonlyMap<string, HydraNotification>;
+  readonly bySession: ReadonlyMap<string, readonly HydraNotification[]>;
+}
+
+export interface NotificationState {
+  readonly snapshot: NotificationSnapshot;
+  readonly indexes: NotificationStateIndexes;
+  readonly contentRevision: string;
+}
+
+export function buildNotificationState(
+  notifications: readonly HydraNotification[],
+  lastEventSeq: number,
+  loadedAt: string = new Date().toISOString(),
+): NotificationState {
+  const clonedNotifications = notifications.map(cloneNotification);
+  return {
+    snapshot: {
+      loadedAt,
+      lastEventSeq,
+      notifications: clonedNotifications,
+      totalCount: clonedNotifications.length,
+      unreadCount: clonedNotifications.filter(notification => notification.readAt === null).length,
+    },
+    indexes: buildIndexes(clonedNotifications),
+    contentRevision: buildContentRevision(clonedNotifications),
+  };
+}
+
+export function cloneNotification(notification: HydraNotification): HydraNotification {
+  const cloned: HydraNotification = {
+    id: notification.id,
+    createdAt: notification.createdAt,
+    readAt: notification.readAt,
+    kind: notification.kind,
+    title: notification.title,
+    body: notification.body,
+    targetSession: notification.targetSession,
+    sourceSession: notification.sourceSession,
+  };
+  if (notification.dedupeKey !== undefined) {
+    cloned.dedupeKey = notification.dedupeKey;
+  }
+  if (notification.action) {
+    cloned.action = { ...notification.action };
+  }
+  if (notification.context) {
+    cloned.context = { ...notification.context };
+  }
+  return cloned;
+}
+
+export function cloneSnapshot(snapshot: NotificationSnapshot): NotificationSnapshot {
+  return {
+    loadedAt: snapshot.loadedAt,
+    lastEventSeq: snapshot.lastEventSeq,
+    notifications: snapshot.notifications.map(cloneNotification),
+    totalCount: snapshot.totalCount,
+    unreadCount: snapshot.unreadCount,
+  };
+}
+
+export function getLatestNotifications(snapshot: NotificationSnapshot, limit?: number): HydraNotification[] {
+  const notifications = snapshot.notifications.map(cloneNotification);
+  if (limit == null) {
+    return notifications;
+  }
+  return notifications.slice(0, Math.max(0, Math.trunc(limit)));
+}
+
+function buildIndexes(notifications: readonly HydraNotification[]): NotificationStateIndexes {
+  const byId = new Map<string, HydraNotification>();
+  const bySession = new Map<string, HydraNotification[]>();
+
+  for (const notification of notifications) {
+    byId.set(notification.id, notification);
+    const sessions = new Set<string>();
+    if (notification.targetSession) {
+      sessions.add(notification.targetSession);
+    }
+    if (notification.sourceSession) {
+      sessions.add(notification.sourceSession);
+    }
+    for (const session of sessions) {
+      const existing = bySession.get(session);
+      if (existing) {
+        existing.push(notification);
+      } else {
+        bySession.set(session, [notification]);
+      }
+    }
+  }
+
+  return { byId, bySession };
+}
+
+function buildContentRevision(notifications: readonly HydraNotification[]): string {
+  return JSON.stringify(notifications.map(notification => ({
+    id: notification.id,
+    createdAt: notification.createdAt,
+    readAt: notification.readAt,
+    kind: notification.kind,
+    title: notification.title,
+    body: notification.body,
+    targetSession: notification.targetSession,
+    sourceSession: notification.sourceSession,
+    dedupeKey: notification.dedupeKey,
+    action: notification.action ? {
+      type: notification.action.type,
+      session: notification.action.session,
+    } : null,
+    context: notification.context ? {
+      workerId: notification.context.workerId,
+      branch: notification.context.branch,
+      workdir: notification.context.workdir,
+      agent: notification.context.agent,
+    } : null,
+  })));
+}

--- a/src/core/notificationStateService.ts
+++ b/src/core/notificationStateService.ts
@@ -1,0 +1,308 @@
+import * as fs from 'fs';
+import {
+  EventLog,
+  getHydraEventsFile,
+  type HydraEvent,
+} from './events';
+import { logger } from './logger';
+import {
+  getHydraNotificationsFile,
+  NotificationStore,
+  type HydraNotification,
+  type NotificationClearResult,
+  type NotificationListFilters,
+  type NotificationOpenResult,
+  type NotificationReadResult,
+} from './notifications';
+import {
+  buildNotificationState,
+  cloneNotification,
+  cloneSnapshot,
+  getLatestNotifications,
+  type NotificationSnapshot,
+  type NotificationState,
+} from './notificationState';
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export interface NotificationStateServiceOptions {
+  readonly debounceMs?: number;
+  readonly pollIntervalMs?: number;
+  readonly notificationsFile?: string;
+  readonly eventsFile?: string;
+  readonly store?: NotificationStore;
+  readonly eventLog?: EventLog;
+}
+
+type NotificationSnapshotListener = (snapshot: NotificationSnapshot) => void;
+
+const DEFAULT_RELOAD_DEBOUNCE_MS = 150;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+export class NotificationStateService implements Disposable {
+  private readonly store: NotificationStore;
+  private readonly eventLog: EventLog;
+  private readonly notificationsFile: string;
+  private readonly eventsFile: string;
+  private readonly debounceMs: number;
+  private readonly pollIntervalMs: number;
+  private readonly listeners = new Set<NotificationSnapshotListener>();
+  private state: NotificationState = buildNotificationState([], 0);
+  private initialized = false;
+  private disposed = false;
+  private reloadTimer: ReturnType<typeof setTimeout> | undefined;
+  private lastEventSeq = 0;
+  private lastNotificationSignature = 'missing';
+  private lastEventSignature = 'missing';
+  private lastMalformedEventSignature: string | undefined;
+  private readonly notificationFileListener = (current: fs.Stats, previous: fs.Stats) => {
+    if (!this.didStatChange(current, previous)) {
+      return;
+    }
+    this.handleNotificationFileChange();
+  };
+  private readonly eventFileListener = (current: fs.Stats, previous: fs.Stats) => {
+    if (!this.didStatChange(current, previous)) {
+      return;
+    }
+    this.handleEventFileChange();
+  };
+
+  constructor(options: NotificationStateServiceOptions = {}) {
+    this.notificationsFile = options.notificationsFile ?? getHydraNotificationsFile();
+    this.eventsFile = options.eventsFile ?? getHydraEventsFile();
+    this.eventLog = options.eventLog ?? new EventLog(this.eventsFile);
+    this.store = options.store ?? new NotificationStore(this.notificationsFile, undefined, this.eventLog);
+    this.debounceMs = Math.max(0, Math.trunc(options.debounceMs ?? DEFAULT_RELOAD_DEBOUNCE_MS));
+    this.pollIntervalMs = Math.max(50, Math.trunc(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS));
+  }
+
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.disposed = false;
+    this.initialized = true;
+    const initialNotificationSignature = getFileSignature(this.notificationsFile);
+    this.lastNotificationSignature = initialNotificationSignature;
+    this.lastEventSignature = getFileSignature(this.eventsFile);
+    this.startWatching();
+
+    const baselineSeq = this.safeReadLastSeq();
+    this.lastEventSeq = baselineSeq;
+    this.reloadNow({ emit: false, reason: 'initialize' });
+    if (getFileSignature(this.notificationsFile) !== initialNotificationSignature) {
+      this.reloadNow({ emit: false, reason: 'initialize-signature-changed' });
+    }
+    this.processEventChangesAfter(baselineSeq, { reload: 'immediate', emit: false });
+  }
+
+  dispose(): void {
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+      this.reloadTimer = undefined;
+    }
+    fs.unwatchFile(this.notificationsFile, this.notificationFileListener);
+    fs.unwatchFile(this.eventsFile, this.eventFileListener);
+    this.listeners.clear();
+    this.disposed = true;
+    this.initialized = false;
+  }
+
+  onDidChange(listener: NotificationSnapshotListener): Disposable {
+    this.listeners.add(listener);
+    return {
+      dispose: () => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  getSnapshot(): NotificationSnapshot {
+    return cloneSnapshot(this.state.snapshot);
+  }
+
+  getUnreadCount(): number {
+    return this.state.snapshot.unreadCount;
+  }
+
+  getLatest(limit?: number): readonly HydraNotification[] {
+    return getLatestNotifications(this.state.snapshot, limit);
+  }
+
+  getBySession(sessionName: string): readonly HydraNotification[] {
+    const notifications = this.state.indexes.bySession.get(sessionName) || [];
+    return notifications.map(cloneNotification);
+  }
+
+  getById(id: string): HydraNotification | undefined {
+    const notification = this.state.indexes.byId.get(id);
+    return notification ? cloneNotification(notification) : undefined;
+  }
+
+  markRead(id: string): NotificationReadResult {
+    const result = this.store.markRead(id);
+    this.reloadNow({ emit: true, reason: 'mark-read' });
+    return result;
+  }
+
+  clear(filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {}): NotificationClearResult {
+    const result = this.store.clear(filters);
+    this.reloadNow({ emit: true, reason: 'clear' });
+    return result;
+  }
+
+  open(id: string): NotificationOpenResult {
+    const result = this.store.open(id);
+    this.reloadNow({ emit: true, reason: 'open' });
+    return result;
+  }
+
+  private startWatching(): void {
+    fs.watchFile(this.notificationsFile, { interval: this.pollIntervalMs }, this.notificationFileListener);
+    fs.watchFile(this.eventsFile, { interval: this.pollIntervalMs }, this.eventFileListener);
+  }
+
+  private handleNotificationFileChange(): void {
+    const signature = getFileSignature(this.notificationsFile);
+    if (signature === this.lastNotificationSignature) {
+      return;
+    }
+    this.lastNotificationSignature = signature;
+    this.scheduleReload('notification-file');
+  }
+
+  private handleEventFileChange(): void {
+    const signature = getFileSignature(this.eventsFile);
+    if (signature === this.lastEventSignature) {
+      return;
+    }
+    if (signature === this.lastMalformedEventSignature) {
+      this.lastEventSignature = signature;
+      return;
+    }
+    this.lastEventSignature = signature;
+    this.processEventChangesAfter(this.lastEventSeq, { reload: 'debounced', emit: true });
+  }
+
+  private processEventChangesAfter(after: number, options: { reload: 'debounced' | 'immediate'; emit: boolean }): void {
+    let events: HydraEvent[];
+    try {
+      events = this.eventLog.read({ after, tolerateIncompleteTail: true });
+      this.lastMalformedEventSignature = undefined;
+    } catch (error) {
+      this.warnMalformedEventsOnce(error);
+      this.lastEventSeq = this.safeReadLastSeq();
+      this.reloadNow({ emit: options.emit, reason: 'event-read-fallback' });
+      return;
+    }
+
+    if (events.length === 0) {
+      return;
+    }
+
+    this.lastEventSeq = Math.max(after, ...events.map(event => event.seq));
+    if (events.some(event => event.type.startsWith('notify.'))) {
+      if (options.reload === 'immediate') {
+        this.reloadNow({ emit: options.emit, reason: 'notification-event' });
+      } else {
+        this.scheduleReload('notification-event');
+      }
+      return;
+    }
+
+    this.state = buildNotificationState(this.state.snapshot.notifications, this.lastEventSeq);
+  }
+
+  private scheduleReload(reason: string): void {
+    if (this.disposed) {
+      return;
+    }
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+    }
+    this.reloadTimer = setTimeout(() => {
+      this.reloadTimer = undefined;
+      this.reloadNow({ emit: true, reason });
+    }, this.debounceMs);
+  }
+
+  private reloadNow(options: { emit: boolean; reason: string }): void {
+    if (this.disposed) {
+      return;
+    }
+
+    const previousRevision = this.state.contentRevision;
+    let notifications: HydraNotification[];
+    try {
+      notifications = this.store.list().notifications;
+    } catch (error) {
+      logger.warn('notification-state.reload', 'Failed to reload notification state', {
+        reason: options.reason,
+        error,
+      });
+      return;
+    }
+
+    this.lastNotificationSignature = getFileSignature(this.notificationsFile);
+    this.lastEventSeq = Math.max(this.lastEventSeq, this.safeReadLastSeq());
+    this.state = buildNotificationState(notifications, this.lastEventSeq);
+
+    if (options.emit && this.state.contentRevision !== previousRevision) {
+      this.emitChange();
+    }
+  }
+
+  private emitChange(): void {
+    const snapshot = this.getSnapshot();
+    for (const listener of this.listeners) {
+      try {
+        listener(cloneSnapshot(snapshot));
+      } catch (error) {
+        logger.warn('notification-state.listener', 'Notification state listener failed', { error });
+      }
+    }
+  }
+
+  private safeReadLastSeq(): number {
+    try {
+      return this.eventLog.readLastSeq();
+    } catch (error) {
+      logger.warn('notification-state.events', 'Failed to read last notification event sequence', { error });
+      return this.lastEventSeq;
+    }
+  }
+
+  private warnMalformedEventsOnce(error: unknown): void {
+    const signature = getFileSignature(this.eventsFile);
+    if (signature === this.lastMalformedEventSignature) {
+      return;
+    }
+    this.lastMalformedEventSignature = signature;
+    logger.warn('notification-state.events', 'Failed to read notification events; reloading notification store', {
+      error,
+    });
+  }
+
+  private didStatChange(current: fs.Stats, previous: fs.Stats): boolean {
+    return getFileStatSignature(current) !== getFileStatSignature(previous);
+  }
+}
+
+function getFileSignature(filePath: string): string {
+  try {
+    return getFileStatSignature(fs.statSync(filePath));
+  } catch {
+    return 'missing';
+  }
+}
+
+function getFileStatSignature(stat: fs.Stats): string {
+  if (stat.mtimeMs === 0 && stat.size === 0) {
+    return 'missing';
+  }
+  return `${stat.mtimeMs}:${stat.size}`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import {
 import { HYDRA_PREFIX_COPILOT, HYDRA_PREFIX_WORKER, buildHydraTerminalName } from './utils/hydraEditorGroup';
 import { lookupWorkerId } from './core/sessionManager';
 import { getHydraSessionsFile } from './core/path';
+import { NotificationStateService } from './core/notificationStateService';
 import { HydraSessionKind, hasHydraItemIdentity, listHydraSessionChoices } from './commands/treeItemResolver';
 import { configureLoggerFromVSCode, logExtensionActivated, registerHydraLogCommands } from './commands/logs';
 import { exec } from './utils/exec';
@@ -167,6 +168,12 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   ensureHydraGlobalConfig();
+  const notificationState = new NotificationStateService();
+  notificationState.initialize();
+  context.subscriptions.push(
+    notificationState,
+    notificationState.onDidChange(refreshTreeViews),
+  );
   silentInstallCli(context);
   seedDefaultAgentToHydraConfig();
   syncAgentCommandsToHydraConfig();

--- a/src/smoke/notificationStateServiceSmoke.ts
+++ b/src/smoke/notificationStateServiceSmoke.ts
@@ -1,0 +1,447 @@
+/**
+ * Smoke test: extension-host notification state service.
+ *
+ * Run: node out/smoke/notificationStateServiceSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { EXIT_OK } from '../cli/output';
+import { EventLog } from '../core/events';
+import { NotificationStateService } from '../core/notificationStateService';
+import {
+  NotificationStore,
+  type NotificationListFilters,
+  type NotificationListResult,
+} from '../core/notifications';
+
+const cliPath = path.resolve(__dirname, '..', 'cli', 'index.js');
+
+interface TestContext {
+  tmp: string;
+  home: string;
+  hydraHome: string;
+  configPath: string;
+  env: Record<string, string | undefined>;
+}
+
+class InitRaceStore extends NotificationStore {
+  private injected = false;
+
+  override list(filters: NotificationListFilters = {}): NotificationListResult {
+    const result = super.list(filters);
+    if (!this.injected) {
+      this.injected = true;
+      this.create({
+        kind: 'info',
+        title: 'Created during initialize',
+        targetSession: 'race_copilot',
+        sourceSession: 'race_worker',
+      });
+    }
+    return result;
+  }
+}
+
+function setupContext(prefix: string): TestContext {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const home = path.join(tmp, 'home');
+  const hydraHome = path.join(tmp, 'hydra');
+  const configPath = path.join(hydraHome, 'config.json');
+  fs.mkdirSync(home, { recursive: true });
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    HYDRA_HOME: hydraHome,
+    HYDRA_CONFIG_PATH: configPath,
+    HYDRA_TELEMETRY: '0',
+  };
+  return { tmp, home, hydraHome, configPath, env };
+}
+
+async function withProcessEnv<T>(ctx: TestContext, fn: () => Promise<T> | T): Promise<T> {
+  const previous = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    HYDRA_HOME: process.env.HYDRA_HOME,
+    HYDRA_CONFIG_PATH: process.env.HYDRA_CONFIG_PATH,
+    HYDRA_TELEMETRY: process.env.HYDRA_TELEMETRY,
+  };
+  process.env.HOME = ctx.home;
+  process.env.USERPROFILE = ctx.home;
+  process.env.HYDRA_HOME = ctx.hydraHome;
+  process.env.HYDRA_CONFIG_PATH = ctx.configPath;
+  process.env.HYDRA_TELEMETRY = '0';
+  try {
+    return await fn();
+  } finally {
+    restoreEnv(previous);
+  }
+}
+
+function restoreEnv(previous: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(previous)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function createService(): NotificationStateService {
+  return new NotificationStateService({ debounceMs: 5, pollIntervalMs: 50 });
+}
+
+function runCli(args: string[], env: Record<string, string | undefined>): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    env,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function parseStdoutJson<T>(proc: SpawnSyncReturns<string>, label: string): T {
+  assert.equal(proc.status, EXIT_OK, `${label} should exit 0\nstdout:\n${proc.stdout}\nstderr:\n${proc.stderr}`);
+  assert.equal(proc.stderr.trim(), '', `${label} should not write stderr`);
+  return JSON.parse(proc.stdout) as T;
+}
+
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(25);
+  }
+  assert.fail(`Timed out waiting for ${label}`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function testMissingFiles(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-missing-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(service.getUnreadCount(), 0);
+        assert.equal(service.getSnapshot().totalCount, 0);
+        assert.deepEqual(service.getLatest(), []);
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testInitialLoadAndIndexes(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-initial-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const first = store.create({
+        kind: 'complete',
+        title: 'Worker completed',
+        body: 'Review branch',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'review-diff', session: 'repo_worker' },
+        context: { workerId: 7, branch: 'feat/state', workdir: ctx.tmp, agent: 'codex' },
+      }).notification;
+      const second = store.create({
+        kind: 'needs-input',
+        title: 'Worker needs input',
+        targetSession: 'repo_copilot',
+        sourceSession: 'other_worker',
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(service.getUnreadCount(), 2);
+        assert.equal(service.getSnapshot().totalCount, 2);
+        assert.equal(service.getLatest(1)[0].id, second.id);
+        assert.equal(service.getById(first.id)?.title, 'Worker completed');
+        assert.deepEqual(service.getBySession('repo_worker').map(notification => notification.id), [first.id]);
+        assert.deepEqual(
+          service.getBySession('repo_copilot').map(notification => notification.id),
+          [second.id, first.id],
+        );
+
+        const snapshot = service.getSnapshot();
+        (snapshot.notifications as unknown as { pop(): unknown }).pop();
+        assert.equal(service.getSnapshot().totalCount, 2, 'snapshot callers must not mutate service state');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testServiceOperationsReloadSynchronously(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-ops-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const created = new NotificationStore().create({
+        kind: 'info',
+        title: 'Open me',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+      const service = createService();
+      const changes: number[] = [];
+      const listener = service.onDidChange(snapshot => changes.push(snapshot.unreadCount));
+      try {
+        service.initialize();
+        assert.equal(service.getUnreadCount(), 1);
+
+        const read = service.markRead(created.id);
+        assert.equal(read.markedRead, 1);
+        assert.equal(service.getUnreadCount(), 0, 'markRead should update snapshot synchronously');
+        assert.deepEqual(changes, [0]);
+
+        await sleep(250);
+        assert.deepEqual(changes, [0], 'watchers should not emit a duplicate markRead change');
+
+        const opened = service.open(created.id);
+        assert.equal(opened.opened, false);
+        assert.equal(opened.action?.type, 'open-session');
+        assert.equal(opened.markedRead, 0);
+        assert.deepEqual(changes, [0], 'open on an already read notification should not emit content changes');
+
+        const cleared = service.clear({ session: 'repo_worker' });
+        assert.equal(cleared.cleared, 1);
+        assert.equal(service.getSnapshot().totalCount, 0);
+        assert.deepEqual(changes, [0, 0]);
+      } finally {
+        listener.dispose();
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testWatcherUpdatesFromNotificationFileOnly(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-file-only-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      try {
+        service.initialize();
+        const eventsAsDirectory = path.join(ctx.hydraHome, 'events-as-directory');
+        fs.mkdirSync(eventsAsDirectory, { recursive: true });
+        new NotificationStore(
+          path.join(ctx.hydraHome, 'notifications.json'),
+          1000,
+          new EventLog(eventsAsDirectory, path.join(ctx.hydraHome, 'events-as-directory.state.json')),
+        ).create({
+          kind: 'info',
+          title: 'File-only notification',
+          targetSession: 'repo_copilot',
+        });
+
+        await waitFor(() => service.getUnreadCount() === 1, 'file-only notification reload');
+        assert.equal(service.getLatest(1)[0].title, 'File-only notification');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testInitializeSignatureWindow(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-init-window-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = new NotificationStateService({
+        debounceMs: 5,
+        pollIntervalMs: 50,
+        store: new InitRaceStore(),
+      });
+      try {
+        service.initialize();
+        assert.equal(service.getUnreadCount(), 1);
+        assert.equal(service.getLatest(1)[0].title, 'Created during initialize');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testDuplicateAndMalformedEventTolerance(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-events-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      try {
+        service.initialize();
+        const store = new NotificationStore();
+        const first = store.create({
+          kind: 'info',
+          title: 'Dedupe source',
+          targetSession: 'repo_copilot',
+          dedupeKey: 'dedupe:one',
+        }).notification;
+        store.create({
+          kind: 'info',
+          title: 'Should not appear',
+          targetSession: 'repo_copilot',
+          dedupeKey: 'dedupe:one',
+        });
+
+        await waitFor(() => service.getSnapshot().totalCount === 1, 'deduped notification reload');
+        assert.equal(service.getLatest(1)[0].id, first.id);
+
+        const eventsPath = path.join(ctx.hydraHome, 'events.jsonl');
+        fs.appendFileSync(eventsPath, '{"version":1,"seq":99,"bootId":"partial"\n', 'utf-8');
+        await sleep(150);
+        assert.equal(service.getSnapshot().totalCount, 1, 'partial event tail should be tolerated');
+
+        fs.appendFileSync(
+          eventsPath,
+          `{"version":1,"seq":100,"bootId":"manual","ts":"${new Date().toISOString()}","type":"notify.created","source":"cli"}\n`,
+          'utf-8',
+        );
+        fs.writeFileSync(
+          path.join(ctx.hydraHome, 'notifications.json'),
+          `${JSON.stringify({
+            version: 1,
+            notifications: [{
+              id: 'manual-notification',
+              createdAt: new Date().toISOString(),
+              readAt: null,
+              kind: 'info',
+              title: 'Manual fallback notification',
+              body: '',
+              targetSession: 'repo_copilot',
+              sourceSession: null,
+            }],
+          }, null, 2)}\n`,
+          'utf-8',
+        );
+
+        await waitFor(
+          () => service.getById('manual-notification')?.title === 'Manual fallback notification',
+          'malformed event fallback reload',
+        );
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testCliEndToEnd(): Promise<void> {
+  if (!fs.existsSync(cliPath)) {
+    console.log(`notificationStateServiceSmoke: skipped CLI E2E (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const ctx = setupContext('hydra-notification-state-cli-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      try {
+        service.initialize();
+        const created = parseStdoutJson<{ notification: { id: string } }>(
+          runCli([
+            'notify',
+            'create',
+            '--session',
+            'repo_copilot',
+            '--from',
+            'repo_worker',
+            '--kind',
+            'complete',
+            '--title',
+            'CLI worker completed',
+            '--json',
+          ], ctx.env),
+          'hydra notify create --json',
+        );
+        await waitFor(() => service.getById(created.notification.id) !== undefined, 'CLI create reflected in service');
+        assert.equal(service.getUnreadCount(), 1);
+        assert.equal(service.getBySession('repo_worker')[0].id, created.notification.id);
+
+        parseStdoutJson<{ markedRead: number }>(
+          runCli(['notify', 'read', created.notification.id, '--json'], ctx.env),
+          'hydra notify read --json',
+        );
+        await waitFor(() => service.getUnreadCount() === 0, 'CLI read reflected in service');
+
+        parseStdoutJson<{ cleared: number }>(
+          runCli(['notify', 'clear', '--session', 'repo_worker', '--json'], ctx.env),
+          'hydra notify clear --json',
+        );
+        await waitFor(() => service.getSnapshot().totalCount === 0, 'CLI clear reflected in service');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testDisposeStopsWatchers(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-dispose-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      let changes = 0;
+      service.onDidChange(() => { changes += 1; });
+      service.initialize();
+      service.dispose();
+      new NotificationStore().create({
+        kind: 'info',
+        title: 'After dispose',
+        targetSession: 'repo_copilot',
+      });
+      await sleep(200);
+      assert.equal(changes, 0);
+      assert.equal(service.getSnapshot().totalCount, 0);
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  await testMissingFiles();
+  await testInitialLoadAndIndexes();
+  await testServiceOperationsReloadSynchronously();
+  await testWatcherUpdatesFromNotificationFileOnly();
+  await testInitializeSignatureWindow();
+  await testDuplicateAndMalformedEventTolerance();
+  await testCliEndToEnd();
+  await testDisposeStopsWatchers();
+  console.log('notificationStateServiceSmoke: ok');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add a VS Code-host-side `NotificationStateService` and pure notification read model
- treat `notifications.json` as the authoritative source while using `events.jsonl` as a wake-up signal
- wire notification state changes to refresh existing Hydra tree views without adding visible Inbox UI yet
- add smoke coverage for service reloads, CLI/event integration, malformed event handling, initialization races, and dispose behavior

## Product Impact

This PR does not add the Attention Inbox UI yet. It creates the stable state layer that future UI can consume for unread counts, latest notifications, session/id lookup, mark-read, clear, and open-action handoff.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:notification-state`
- `npm run smoke:events-cli`
- `npm run smoke:notify-cli`
- `npm run smoke:completion-hook`
- `npm test`
- launched VS Code Extension Development Host in an isolated Hydra environment and activated Hydra via `Hydra: Show Logs`
- in that same isolated dev-host environment, verified `hydra notify create/list/read/open/clear` and `hydra events --json/--after/--cursor-file/--follow`
