### PR TITLE
[codex] Add notification tree attention states

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,18 @@
         "title": "Hydra: Open PR"
       },
       {
+        "command": "hydra.openSessionNotification",
+        "title": "Hydra: Open Notification"
+      },
+      {
+        "command": "hydra.markSessionNotificationsRead",
+        "title": "Hydra: Mark Notifications Read"
+      },
+      {
+        "command": "hydra.clearSessionNotifications",
+        "title": "Hydra: Clear Notifications"
+      },
+      {
         "command": "hydra.createCopilot",
         "title": "Hydra: Create Copilot",
         "icon": "$(add)"
@@ -318,6 +330,21 @@
           "group": "1_open@3"
         },
         {
+          "command": "hydra.openSessionNotification",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
+          "group": "1_open@4"
+        },
+        {
+          "command": "hydra.markSessionNotificationsRead",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
+          "group": "5_notifications@1"
+        },
+        {
+          "command": "hydra.clearSessionNotifications",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
+          "group": "5_notifications@2"
+        },
+        {
           "command": "tmux.copyPath",
           "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem')",
           "group": "2_copy"
@@ -385,6 +412,7 @@
     "smoke:events-cli": "node out/smoke/eventsCliSmoke.js",
     "smoke:notify-cli": "node out/smoke/notifyCliSmoke.js",
     "smoke:notification-state": "node out/smoke/notificationStateServiceSmoke.js",
+    "smoke:session-notification-summary": "node out/smoke/sessionNotificationSummarySmoke.js",
     "smoke:agent-registry": "node out/smoke/agentRegistrySmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
     "smoke:repo-registry": "node out/smoke/repoRegistrySmoke.js",
@@ -399,7 +427,7 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:notification-state && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:notification-state && npm run smoke:session-notification-summary && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
     "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {

--- a/src/commands/attachCreate.ts
+++ b/src/commands/attachCreate.ts
@@ -1,13 +1,11 @@
 import * as vscode from 'vscode';
 import { getRepoRoot } from '../utils/git';
 import { getActiveBackend } from '../utils/multiplexer';
-import { InactiveWorktreeItem, InactiveDetailItem, CopilotItem, TmuxItem } from '../providers/tmuxSessionProvider';
+import { TmuxItem } from '../providers/tmuxSessionProvider';
 import { createRepoSessionPrefixConfig, isWorkdirInRepo } from '../utils/sessionCompatibility';
-import { SessionManager } from '../core/sessionManager';
-import { TmuxBackendCore } from '../core/tmux';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
-import { sendCopilotOnboarding } from './createCopilot';
 import { showHydraCommandError } from './logs';
+import { openHydraSessionByItem } from './openHydraSession';
 
 async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
   const backend = getActiveBackend();
@@ -34,58 +32,7 @@ async function findSessionsForWorkspace(repoRoot: string): Promise<string[]> {
 }
 
 async function handleTreeViewItem(item: TmuxItem): Promise<void> {
-    const backend = getActiveBackend();
-    const sessionName = item.sessionName || item.label;
-
-    const sessions = await backend.listSessions();
-    const exists = sessions.some(s => s.name === sessionName);
-
-    if (exists) {
-        const workdir = await backend.getSessionWorkdir(sessionName);
-        const role = await backend.getSessionRole(sessionName);
-        backend.attachSession(sessionName, workdir, undefined, role);
-        return;
-    }
-
-    // Stopped copilot: resume via SessionManager
-    if (item instanceof CopilotItem && item.classification === 'stopped') {
-        const sm = new SessionManager(new TmuxBackendCore());
-        const result = await sm.startCopilot(sessionName);
-        result.postCreatePromise.catch(() => {});
-        const { workdir, copilotMode } = result.copilotInfo;
-        if (!result.resumed) {
-            sendCopilotOnboarding(backend, sessionName, copilotMode ?? 'normal');
-        }
-        backend.attachSession(sessionName, workdir, undefined, 'copilot');
-        vscode.window.showInformationMessage(`Resumed copilot: ${sessionName}`);
-        vscode.commands.executeCommand('tmux.refresh');
-        return;
-    }
-
-    // Inactive worktree: resume the agent via SessionManager
-    if (item instanceof InactiveWorktreeItem || item instanceof InactiveDetailItem) {
-        const worktreePath = item instanceof InactiveWorktreeItem
-            ? item.worktree.path
-            : item.worktree!.path;
-
-        try {
-            const sm = new SessionManager(new TmuxBackendCore());
-            const result = await sm.startWorker(sessionName);
-            result.postCreatePromise.catch(() => {});
-        } catch {
-            // Fallback for worktrees without sessions.json entries (legacy)
-            await backend.createSession(sessionName, worktreePath);
-            await backend.setSessionWorkdir(sessionName, worktreePath);
-            await backend.setSessionRole(sessionName, 'worker');
-        }
-
-        backend.attachSession(sessionName, worktreePath, undefined, 'worker');
-        vscode.window.showInformationMessage(`Launched session: ${sessionName}`);
-        vscode.commands.executeCommand('tmux.refresh');
-        return;
-    }
-
-    vscode.window.showErrorMessage(`Session '${sessionName}' not found and cannot be created automatically.`);
+  await openHydraSessionByItem(item);
 }
 
 async function handleCommandExecution(): Promise<void> {

--- a/src/commands/notificationTreeCommands.ts
+++ b/src/commands/notificationTreeCommands.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+import { NotificationStateService } from '../core/notificationStateService';
+import { buildSessionNotificationSummary } from '../core/sessionNotificationSummary';
+import { TmuxItem } from '../providers/tmuxSessionProvider';
+import { resolveSessionName } from './treeItemResolver';
+import { openHydraSessionByName, reviewHydraSessionByName } from './openHydraSession';
+
+export interface NotificationTreeCommands {
+  openSessionNotification(item?: TmuxItem): Promise<void>;
+  markSessionNotificationsRead(item?: TmuxItem): Promise<void>;
+  clearSessionNotifications(item?: TmuxItem): Promise<void>;
+}
+
+function getNotificationId(item?: TmuxItem): string | undefined {
+  const candidate = item as unknown as { notificationId?: unknown } | undefined;
+  return typeof candidate?.notificationId === 'string' && candidate.notificationId
+    ? candidate.notificationId
+    : undefined;
+}
+
+export function createNotificationTreeCommands(
+  notificationState: NotificationStateService,
+): NotificationTreeCommands {
+  return {
+    async openSessionNotification(item?: TmuxItem): Promise<void> {
+      try {
+        const sessionName = resolveSessionName(item);
+        if (!sessionName) {
+          vscode.window.showErrorMessage('No session selected');
+          return;
+        }
+
+        const notificationId = getNotificationId(item);
+        let targetNotificationId = notificationId;
+        if (!targetNotificationId) {
+          const summary = buildSessionNotificationSummary(sessionName, notificationState.getByTargetSession(sessionName));
+          if (!summary) {
+            vscode.window.showInformationMessage(`No unread notifications for ${sessionName}`);
+            return;
+          }
+          targetNotificationId = summary.attention.id;
+        }
+
+        const result = notificationState.open(targetNotificationId, 'extension');
+        const action = result.action;
+        if (!action) {
+          vscode.window.showInformationMessage(`Marked notification read: ${result.notification.title}`);
+          return;
+        }
+
+        if (action.type === 'open-session') {
+          await openHydraSessionByName(action.session);
+          return;
+        }
+        if (action.type === 'review-diff') {
+          await reviewHydraSessionByName(action.session);
+        }
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to open notification: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async markSessionNotificationsRead(item?: TmuxItem): Promise<void> {
+      try {
+        const sessionName = resolveSessionName(item);
+        if (!sessionName) {
+          vscode.window.showErrorMessage('No session selected');
+          return;
+        }
+
+        const result = notificationState.markTargetSessionRead(sessionName, 'extension');
+        vscode.window.showInformationMessage(
+          result.markedRead === 0
+            ? `No unread notifications for ${sessionName}`
+            : `Marked ${result.markedRead} notification${result.markedRead === 1 ? '' : 's'} read`,
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to mark notifications read: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async clearSessionNotifications(item?: TmuxItem): Promise<void> {
+      try {
+        const sessionName = resolveSessionName(item);
+        if (!sessionName) {
+          vscode.window.showErrorMessage('No session selected');
+          return;
+        }
+
+        const count = notificationState.getByTargetSession(sessionName).length;
+        if (count === 0) {
+          vscode.window.showInformationMessage(`No notifications for ${sessionName}`);
+          return;
+        }
+
+        const choice = await vscode.window.showWarningMessage(
+          `Clear ${count} notification${count === 1 ? '' : 's'} for ${sessionName}?`,
+          { modal: true },
+          'Clear',
+        );
+        if (choice !== 'Clear') {
+          return;
+        }
+
+        const result = notificationState.clear({ targetSession: sessionName }, 'extension');
+        vscode.window.showInformationMessage(
+          `Cleared ${result.cleared} notification${result.cleared === 1 ? '' : 's'}`,
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to clear notifications: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  };
+}

--- a/src/commands/openHydraSession.ts
+++ b/src/commands/openHydraSession.ts
@@ -1,0 +1,120 @@
+import * as vscode from 'vscode';
+import {
+  CopilotItem,
+  InactiveDetailItem,
+  InactiveWorktreeItem,
+  TmuxItem,
+} from '../providers/tmuxSessionProvider';
+import { SessionManager } from '../core/sessionManager';
+import { TmuxBackendCore } from '../core/tmux';
+import { getActiveBackend } from '../utils/multiplexer';
+import { ensureBackendInstalled } from './ensureBackendInstalled';
+import { sendCopilotOnboarding } from './createCopilot';
+import { openChangesReview } from './reviewChanges';
+
+export async function openHydraSessionByItem(item: TmuxItem): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await ensureBackendInstalled(backend)) {
+    return;
+  }
+
+  const sessionName = item.sessionName || item.label;
+  if (await attachExistingSession(sessionName)) {
+    return;
+  }
+
+  if (item instanceof CopilotItem && item.classification === 'stopped') {
+    await resumeCopilot(sessionName);
+    return;
+  }
+
+  if (item instanceof InactiveWorktreeItem || item instanceof InactiveDetailItem) {
+    const worktreePath = item instanceof InactiveWorktreeItem
+      ? item.worktree.path
+      : item.worktree!.path;
+    await resumeWorker(sessionName, worktreePath);
+    return;
+  }
+
+  throw new Error(`Session '${sessionName}' not found and cannot be created automatically.`);
+}
+
+export async function openHydraSessionByName(sessionName: string): Promise<void> {
+  const backend = getActiveBackend();
+  if (!await ensureBackendInstalled(backend)) {
+    return;
+  }
+
+  if (await attachExistingSession(sessionName)) {
+    return;
+  }
+
+  const sm = new SessionManager(new TmuxBackendCore());
+  const [workers, copilots] = await Promise.all([sm.listWorkers(), sm.listCopilots()]);
+  if (workers.some(worker => worker.sessionName === sessionName)) {
+    await resumeWorker(sessionName);
+    return;
+  }
+  if (copilots.some(copilot => copilot.sessionName === sessionName)) {
+    await resumeCopilot(sessionName);
+    return;
+  }
+
+  throw new Error(`Session '${sessionName}' not found and cannot be created automatically.`);
+}
+
+export async function reviewHydraSessionByName(sessionName: string): Promise<void> {
+  const sm = new SessionManager(new TmuxBackendCore());
+  const worker = (await sm.listWorkers()).find(entry => entry.sessionName === sessionName);
+  if (!worker?.workdir) {
+    throw new Error(`Session '${sessionName}' does not have a reviewable worker workdir.`);
+  }
+  await openChangesReview(worker.workdir);
+}
+
+async function attachExistingSession(sessionName: string): Promise<boolean> {
+  const backend = getActiveBackend();
+  if (!await backend.hasSession(sessionName)) {
+    return false;
+  }
+  const workdir = await backend.getSessionWorkdir(sessionName);
+  const role = await backend.getSessionRole(sessionName);
+  backend.attachSession(sessionName, workdir, undefined, role);
+  return true;
+}
+
+async function resumeCopilot(sessionName: string): Promise<void> {
+  const backend = getActiveBackend();
+  const sm = new SessionManager(new TmuxBackendCore());
+  const result = await sm.startCopilot(sessionName);
+  result.postCreatePromise.catch(() => {});
+  const { workdir, copilotMode } = result.copilotInfo;
+  if (!result.resumed) {
+    sendCopilotOnboarding(backend, sessionName, copilotMode ?? 'normal');
+  }
+  backend.attachSession(sessionName, workdir, undefined, 'copilot');
+  vscode.window.showInformationMessage(`Resumed copilot: ${sessionName}`);
+  vscode.commands.executeCommand('tmux.refresh');
+}
+
+async function resumeWorker(sessionName: string, fallbackWorktreePath?: string): Promise<void> {
+  const backend = getActiveBackend();
+  let workdir = fallbackWorktreePath;
+  try {
+    const sm = new SessionManager(new TmuxBackendCore());
+    const result = await sm.startWorker(sessionName);
+    result.postCreatePromise.catch(() => {});
+    workdir = result.workerInfo.workdir || workdir;
+  } catch {
+    if (!workdir) {
+      throw new Error(`Worker "${sessionName}" not found in sessions.json`);
+    }
+    await backend.createSession(sessionName, workdir);
+    await backend.setSessionWorkdir(sessionName, workdir);
+    await backend.setSessionRole(sessionName, 'worker');
+  }
+
+  backend.attachSession(sessionName, workdir, undefined, 'worker');
+  vscode.window.showInformationMessage(`Launched session: ${sessionName}`);
+  vscode.commands.executeCommand('tmux.refresh');
+}

--- a/src/core/notificationState.ts
+++ b/src/core/notificationState.ts
@@ -11,6 +11,8 @@ export interface NotificationSnapshot {
 export interface NotificationStateIndexes {
   readonly byId: ReadonlyMap<string, HydraNotification>;
   readonly bySession: ReadonlyMap<string, readonly HydraNotification[]>;
+  readonly byTargetSession: ReadonlyMap<string, readonly HydraNotification[]>;
+  readonly bySourceSession: ReadonlyMap<string, readonly HydraNotification[]>;
 }
 
 export interface NotificationState {
@@ -82,27 +84,39 @@ export function getLatestNotifications(snapshot: NotificationSnapshot, limit?: n
 function buildIndexes(notifications: readonly HydraNotification[]): NotificationStateIndexes {
   const byId = new Map<string, HydraNotification>();
   const bySession = new Map<string, HydraNotification[]>();
+  const byTargetSession = new Map<string, HydraNotification[]>();
+  const bySourceSession = new Map<string, HydraNotification[]>();
 
   for (const notification of notifications) {
     byId.set(notification.id, notification);
     const sessions = new Set<string>();
     if (notification.targetSession) {
       sessions.add(notification.targetSession);
+      addToIndex(byTargetSession, notification.targetSession, notification);
     }
     if (notification.sourceSession) {
       sessions.add(notification.sourceSession);
+      addToIndex(bySourceSession, notification.sourceSession, notification);
     }
     for (const session of sessions) {
-      const existing = bySession.get(session);
-      if (existing) {
-        existing.push(notification);
-      } else {
-        bySession.set(session, [notification]);
-      }
+      addToIndex(bySession, session, notification);
     }
   }
 
-  return { byId, bySession };
+  return { byId, bySession, byTargetSession, bySourceSession };
+}
+
+function addToIndex(
+  index: Map<string, HydraNotification[]>,
+  sessionName: string,
+  notification: HydraNotification,
+): void {
+  const existing = index.get(sessionName);
+  if (existing) {
+    existing.push(notification);
+  } else {
+    index.set(sessionName, [notification]);
+  }
 }
 
 function buildContentRevision(notifications: readonly HydraNotification[]): string {

--- a/src/core/notificationStateService.ts
+++ b/src/core/notificationStateService.ts
@@ -3,12 +3,14 @@ import {
   EventLog,
   getHydraEventsFile,
   type HydraEvent,
+  type HydraEventSource,
 } from './events';
 import { logger } from './logger';
 import {
   getHydraNotificationsFile,
   NotificationStore,
   type HydraNotification,
+  type NotificationMarkSessionReadResult,
   type NotificationClearResult,
   type NotificationListFilters,
   type NotificationOpenResult,
@@ -57,6 +59,7 @@ export class NotificationStateService implements Disposable {
   private lastNotificationSignature = 'missing';
   private lastEventSignature = 'missing';
   private lastMalformedEventSignature: string | undefined;
+  private sourceCompletionBySession = new Map<string, HydraNotification>();
   private readonly notificationFileListener = (current: fs.Stats, previous: fs.Stats) => {
     if (!this.didStatChange(current, previous)) {
       return;
@@ -138,25 +141,70 @@ export class NotificationStateService implements Disposable {
     return notifications.map(cloneNotification);
   }
 
+  getByTargetSession(sessionName: string): readonly HydraNotification[] {
+    const notifications = this.state.indexes.byTargetSession.get(sessionName) || [];
+    return notifications.map(cloneNotification);
+  }
+
+  getBySourceSession(sessionName: string): readonly HydraNotification[] {
+    const notifications = this.state.indexes.bySourceSession.get(sessionName) || [];
+    return notifications.map(cloneNotification);
+  }
+
+  getLatestSourceCompletion(sessionName: string): HydraNotification | undefined {
+    const stored = this.getLatestStoredSourceCompletion(sessionName);
+    if (stored) {
+      return stored;
+    }
+
+    const projected = this.sourceCompletionBySession.get(sessionName);
+    return projected ? cloneNotification(projected) : undefined;
+  }
+
   getById(id: string): HydraNotification | undefined {
     const notification = this.state.indexes.byId.get(id);
     return notification ? cloneNotification(notification) : undefined;
   }
 
-  markRead(id: string): NotificationReadResult {
-    const result = this.store.markRead(id);
+  markRead(id: string, eventSource: HydraEventSource = 'extension'): NotificationReadResult {
+    const result = this.store.markRead(id, eventSource);
     this.reloadNow({ emit: true, reason: 'mark-read' });
     return result;
   }
 
-  clear(filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {}): NotificationClearResult {
-    const result = this.store.clear(filters);
+  markSessionRead(sessionName: string, eventSource: HydraEventSource = 'extension'): NotificationMarkSessionReadResult {
+    const result = this.store.markSessionRead(sessionName, eventSource);
+    this.reloadNow({ emit: true, reason: 'mark-session-read' });
+    return result;
+  }
+
+  markTargetSessionRead(sessionName: string, eventSource: HydraEventSource = 'extension'): NotificationMarkSessionReadResult {
+    const unread = this.store.list({ targetSession: sessionName, unread: true }).notifications;
+    const notifications: HydraNotification[] = [];
+    for (const notification of unread) {
+      const result = this.store.markRead(notification.id, eventSource);
+      if (result.markedRead > 0) {
+        notifications.push(result.notification);
+      }
+    }
+    this.reloadNow({ emit: true, reason: 'mark-target-session-read' });
+    return {
+      notifications,
+      markedRead: notifications.length,
+    };
+  }
+
+  clear(
+    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    eventSource: HydraEventSource = 'extension',
+  ): NotificationClearResult {
+    const result = this.store.clear(filters, eventSource);
     this.reloadNow({ emit: true, reason: 'clear' });
     return result;
   }
 
-  open(id: string): NotificationOpenResult {
-    const result = this.store.open(id);
+  open(id: string, eventSource: HydraEventSource = 'extension'): NotificationOpenResult {
+    const result = this.store.open(id, eventSource);
     this.reloadNow({ emit: true, reason: 'open' });
     return result;
   }
@@ -236,6 +284,7 @@ export class NotificationStateService implements Disposable {
     }
 
     const previousRevision = this.state.contentRevision;
+    const previousCompletionRevision = buildSourceCompletionRevision(this.sourceCompletionBySession);
     let notifications: HydraNotification[];
     try {
       notifications = this.store.list().notifications;
@@ -250,10 +299,61 @@ export class NotificationStateService implements Disposable {
     this.lastNotificationSignature = getFileSignature(this.notificationsFile);
     this.lastEventSeq = Math.max(this.lastEventSeq, this.safeReadLastSeq());
     this.state = buildNotificationState(notifications, this.lastEventSeq);
+    this.rebuildSourceCompletionProjection(notifications);
+    const completionRevision = buildSourceCompletionRevision(this.sourceCompletionBySession);
 
-    if (options.emit && this.state.contentRevision !== previousRevision) {
+    if (
+      options.emit &&
+      (
+        this.state.contentRevision !== previousRevision ||
+        completionRevision !== previousCompletionRevision
+      )
+    ) {
       this.emitChange();
     }
+  }
+
+  private getLatestStoredSourceCompletion(sessionName: string): HydraNotification | undefined {
+    return [...(this.state.indexes.bySourceSession.get(sessionName) || [])]
+      .filter(notification =>
+        notification.kind === 'complete' &&
+        notification.targetSession !== sessionName,
+      )
+      .sort(compareNotificationsNewestFirst)
+      .map(cloneNotification)[0];
+  }
+
+  private rebuildSourceCompletionProjection(notifications: readonly HydraNotification[]): void {
+    const completions = new Map<string, HydraNotification>();
+
+    for (const notification of notifications) {
+      if (
+        notification.kind === 'complete' &&
+        notification.sourceSession &&
+        notification.targetSession !== notification.sourceSession
+      ) {
+        upsertLatestCompletion(completions, notification.sourceSession, notification);
+      }
+    }
+
+    let events: HydraEvent[];
+    try {
+      events = this.eventLog.read({ tolerateIncompleteTail: true });
+    } catch (error) {
+      logger.warn('notification-state.events', 'Failed to rebuild source completion projection', { error });
+      this.sourceCompletionBySession = completions;
+      return;
+    }
+
+    for (const event of events) {
+      const notification = notificationFromCreatedEvent(event);
+      if (!notification?.sourceSession) {
+        continue;
+      }
+      upsertLatestCompletion(completions, notification.sourceSession, notification);
+    }
+
+    this.sourceCompletionBySession = completions;
   }
 
   private emitChange(): void {
@@ -305,4 +405,91 @@ function getFileStatSignature(stat: fs.Stats): string {
     return 'missing';
   }
   return `${stat.mtimeMs}:${stat.size}`;
+}
+
+function upsertLatestCompletion(
+  completions: Map<string, HydraNotification>,
+  sessionName: string,
+  notification: HydraNotification,
+): void {
+  const existing = completions.get(sessionName);
+  if (!existing || compareNotificationsNewestFirst(notification, existing) < 0) {
+    completions.set(sessionName, cloneNotification(notification));
+  }
+}
+
+function notificationFromCreatedEvent(event: HydraEvent): HydraNotification | undefined {
+  if (event.type !== 'notify.created') {
+    return undefined;
+  }
+  const payload = event.payload || {};
+  if (payload.kind !== 'complete') {
+    return undefined;
+  }
+  const sourceSession = getStringPayload(payload, 'sourceSession');
+  const targetSession = getStringPayload(payload, 'targetSession');
+  if (!sourceSession || targetSession === sourceSession) {
+    return undefined;
+  }
+  const id = getStringPayload(payload, 'notificationId') || `event:${event.seq}`;
+  const action = getActionPayload(payload);
+  return {
+    id,
+    createdAt: event.ts,
+    readAt: null,
+    kind: 'complete',
+    title: 'Worker completed',
+    body: '',
+    targetSession: targetSession || null,
+    sourceSession,
+    action,
+    context: {
+      workerId: getNumberPayload(payload, 'workerId'),
+      branch: getStringPayload(payload, 'branch') ?? null,
+      agent: getStringPayload(payload, 'agent') ?? null,
+    },
+  };
+}
+
+function getActionPayload(payload: Record<string, unknown>): HydraNotification['action'] | undefined {
+  const type = getStringPayload(payload, 'actionType');
+  const session = getStringPayload(payload, 'actionSession');
+  if ((type === 'open-session' || type === 'review-diff') && session) {
+    return { type, session };
+  }
+  return undefined;
+}
+
+function getStringPayload(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function getNumberPayload(payload: Record<string, unknown>, key: string): number | undefined {
+  const value = payload[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function compareNotificationsNewestFirst(a: HydraNotification, b: HydraNotification): number {
+  const timeDiff = Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  if (Number.isFinite(timeDiff) && timeDiff !== 0) {
+    return timeDiff;
+  }
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+function buildSourceCompletionRevision(completions: ReadonlyMap<string, HydraNotification>): string {
+  return JSON.stringify([...completions.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([sessionName, notification]) => ({
+      sessionName,
+      id: notification.id,
+      createdAt: notification.createdAt,
+      targetSession: notification.targetSession,
+      sourceSession: notification.sourceSession,
+      action: notification.action ? {
+        type: notification.action.type,
+        session: notification.action.session,
+      } : null,
+    })));
 }

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -73,6 +73,11 @@ export interface NotificationReadResult {
   markedRead: number;
 }
 
+export interface NotificationMarkSessionReadResult {
+  notifications: HydraNotification[];
+  markedRead: number;
+}
+
 export interface NotificationClearResult {
   cleared: number;
 }
@@ -159,7 +164,7 @@ export class NotificationStore {
     };
   }
 
-  markRead(id: string): NotificationReadResult {
+  markRead(id: string, eventSource: HydraEventSource = 'cli'): NotificationReadResult {
     return this.withLock(() => {
       const store = this.readStore();
       const index = store.notifications.findIndex(notification => notification.id === id);
@@ -173,12 +178,46 @@ export class NotificationStore {
       const updated = { ...existing, readAt: new Date().toISOString() };
       store.notifications[index] = updated;
       this.writeStore(store);
-      this.emitNotificationEvent('notify.read', updated, 'cli');
+      this.emitNotificationEvent('notify.read', updated, eventSource);
       return { notification: updated, markedRead: 1 };
     });
   }
 
-  clear(filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {}): NotificationClearResult {
+  markSessionRead(sessionName: string, eventSource: HydraEventSource = 'cli'): NotificationMarkSessionReadResult {
+    return this.withLock(() => {
+      const store = this.readStore();
+      const readAt = new Date().toISOString();
+      const updatedNotifications: HydraNotification[] = [];
+      store.notifications = store.notifications.map(notification => {
+        if (
+          notification.readAt !== null ||
+          (notification.targetSession !== sessionName && notification.sourceSession !== sessionName)
+        ) {
+          return notification;
+        }
+        const updated = { ...notification, readAt };
+        updatedNotifications.push(updated);
+        return updated;
+      });
+
+      if (updatedNotifications.length > 0) {
+        this.writeStore(store);
+        for (const notification of updatedNotifications) {
+          this.emitNotificationEvent('notify.read', notification, eventSource);
+        }
+      }
+
+      return {
+        notifications: updatedNotifications,
+        markedRead: updatedNotifications.length,
+      };
+    });
+  }
+
+  clear(
+    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    eventSource: HydraEventSource = 'cli',
+  ): NotificationClearResult {
     return this.withLock(() => {
       const store = this.readStore();
       const before = store.notifications.length;
@@ -186,14 +225,14 @@ export class NotificationStore {
       const cleared = before - store.notifications.length;
       if (cleared > 0) {
         this.writeStore(store);
-        this.emitClearEvent(cleared, filters);
+        this.emitClearEvent(cleared, filters, eventSource);
       }
       return { cleared };
     });
   }
 
-  open(id: string): NotificationOpenResult {
-    const read = this.markRead(id);
+  open(id: string, eventSource: HydraEventSource = 'cli'): NotificationOpenResult {
+    const read = this.markRead(id, eventSource);
     return {
       notification: read.notification,
       action: read.notification.action ?? null,
@@ -300,11 +339,15 @@ export class NotificationStore {
     }
   }
 
-  private emitClearEvent(cleared: number, filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>): void {
+  private emitClearEvent(
+    cleared: number,
+    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>,
+    source: HydraEventSource,
+  ): void {
     try {
       this.eventLog.append({
         type: 'notify.cleared',
-        source: 'cli',
+        source,
         session: filters.session || filters.targetSession || filters.sourceSession,
         payload: {
           cleared,

--- a/src/core/sessionNotificationSummary.ts
+++ b/src/core/sessionNotificationSummary.ts
@@ -1,0 +1,86 @@
+import type { HydraNotification, NotificationKind } from './notifications';
+
+export interface SessionNotificationSource {
+  getBySession(sessionName: string): readonly HydraNotification[];
+  getByTargetSession(sessionName: string): readonly HydraNotification[];
+  getBySourceSession(sessionName: string): readonly HydraNotification[];
+  getLatestSourceCompletion?(sessionName: string): HydraNotification | undefined;
+}
+
+export interface SessionNotificationSummary {
+  readonly sessionName: string;
+  readonly unreadCount: number;
+  readonly attention: HydraNotification;
+  readonly kind: NotificationKind;
+  readonly badge: string;
+  readonly description: string;
+}
+
+const KIND_PRIORITY: Record<NotificationKind, number> = {
+  error: 0,
+  blocked: 1,
+  'needs-input': 2,
+  complete: 3,
+  info: 4,
+};
+
+const KIND_BADGE: Record<NotificationKind, string> = {
+  error: 'E',
+  blocked: 'B',
+  'needs-input': '?',
+  complete: 'C',
+  info: 'i',
+};
+
+const MAX_DESCRIPTION_TEXT_LENGTH = 72;
+
+export function buildSessionNotificationSummary(
+  sessionName: string,
+  notifications: readonly HydraNotification[],
+): SessionNotificationSummary | undefined {
+  const unread = notifications
+    .filter(notification => notification.readAt === null)
+    .sort(compareAttentionNotifications);
+
+  const attention = unread[0];
+  if (!attention) {
+    return undefined;
+  }
+
+  const text = truncateSummaryText(normalizeSummaryText(attention.title || attention.body));
+  const unreadLabel = `${unread.length} unread`;
+  const kind = attention.kind;
+  return {
+    sessionName,
+    unreadCount: unread.length,
+    attention,
+    kind,
+    badge: KIND_BADGE[kind],
+    description: text ? `${unreadLabel} · ${kind}: ${text}` : `${unreadLabel} · ${kind}`,
+  };
+}
+
+function compareAttentionNotifications(a: HydraNotification, b: HydraNotification): number {
+  const priorityDiff = KIND_PRIORITY[a.kind] - KIND_PRIORITY[b.kind];
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+
+  const timeDiff = Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  if (Number.isFinite(timeDiff) && timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+function normalizeSummaryText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncateSummaryText(value: string): string {
+  if (value.length <= MAX_DESCRIPTION_TEXT_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_DESCRIPTION_TEXT_LENGTH - 3).trimEnd()}...`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,8 @@ import { NotificationStateService } from './core/notificationStateService';
 import { HydraSessionKind, hasHydraItemIdentity, listHydraSessionChoices } from './commands/treeItemResolver';
 import { configureLoggerFromVSCode, logExtensionActivated, registerHydraLogCommands } from './commands/logs';
 import { exec } from './utils/exec';
+import { NotificationDecorationProvider } from './providers/notificationDecorationProvider';
+import { createNotificationTreeCommands } from './commands/notificationTreeCommands';
 
 const SESSION_REFRESH_DEBOUNCE_MS = 200;
 const SESSION_REFRESH_POLL_INTERVAL_MS = 1000;
@@ -51,9 +53,13 @@ export function activate(context: vscode.ExtensionContext) {
   registerHydraLogCommands(context, hydraOutputChannel);
   logExtensionActivated(context);
 
-  const copilotProvider = new CopilotProvider();
+  const notificationState = new NotificationStateService();
+  notificationState.initialize();
+  const notificationDecorations = new NotificationDecorationProvider(notificationState);
+
+  const copilotProvider = new CopilotProvider(notificationState);
   copilotProvider.setExtensionUri(context.extensionUri);
-  const workerProvider = new WorkerProvider();
+  const workerProvider = new WorkerProvider(notificationState);
   workerProvider.setExtensionUri(context.extensionUri);
 
   const copilotView = vscode.window.createTreeView('hydraCopilots', { treeDataProvider: copilotProvider });
@@ -138,6 +144,7 @@ export function activate(context: vscode.ExtensionContext) {
     refreshTreeViews();
     syncWorkerGitHeadWatchers();
   };
+  const notificationCommands = createNotificationTreeCommands(notificationState);
 
   context.subscriptions.push(
     copilotView,
@@ -153,6 +160,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.copyPath', async (...args: unknown[]) => runWithHydraItem(['worker'], copyPath, ...args)),
     vscode.commands.registerCommand('tmux.newPane', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newPane, ...args)),
     vscode.commands.registerCommand('tmux.newWindow', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newWindow, ...args)),
+    vscode.commands.registerCommand('hydra.openSessionNotification', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.openSessionNotification, ...args)),
+    vscode.commands.registerCommand('hydra.markSessionNotificationsRead', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.markSessionNotificationsRead, ...args)),
+    vscode.commands.registerCommand('hydra.clearSessionNotifications', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.clearSessionNotifications, ...args)),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),
@@ -165,14 +175,16 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('hydra.startCopilotSudoCode', () => createCopilotWithAgent('sudocode')),
     copilotView.onDidChangeSelection(rememberHydraSelection),
     workerView.onDidChangeSelection(rememberHydraSelection),
+    vscode.window.registerFileDecorationProvider(notificationDecorations),
   );
 
   ensureHydraGlobalConfig();
-  const notificationState = new NotificationStateService();
-  notificationState.initialize();
   context.subscriptions.push(
     notificationState,
-    notificationState.onDidChange(refreshTreeViews),
+    notificationState.onDidChange(() => {
+      refreshTreeViews();
+      notificationDecorations.refresh();
+    }),
   );
   silentInstallCli(context);
   seedDefaultAgentToHydraConfig();

--- a/src/providers/notificationDecorationProvider.ts
+++ b/src/providers/notificationDecorationProvider.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import {
+  buildSessionNotificationSummary,
+  type SessionNotificationSource,
+} from '../core/sessionNotificationSummary';
+import type { NotificationKind } from '../core/notifications';
+
+const NOTIFICATION_DECORATION_SCHEME = 'hydra-notification';
+const NOTIFICATION_DECORATION_AUTHORITY = 'session';
+
+export function getNotificationDecorationUri(sessionName: string): vscode.Uri {
+  return vscode.Uri.from({
+    scheme: NOTIFICATION_DECORATION_SCHEME,
+    authority: NOTIFICATION_DECORATION_AUTHORITY,
+    path: `/${encodeURIComponent(sessionName)}`,
+  });
+}
+
+export function parseNotificationDecorationUri(uri: vscode.Uri): string | undefined {
+  if (uri.scheme !== NOTIFICATION_DECORATION_SCHEME || uri.authority !== NOTIFICATION_DECORATION_AUTHORITY) {
+    return undefined;
+  }
+  const encoded = uri.path.replace(/^\//, '');
+  if (!encoded) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+export class NotificationDecorationProvider implements vscode.FileDecorationProvider {
+  private readonly onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
+  readonly onDidChangeFileDecorations = this.onDidChangeEmitter.event;
+
+  constructor(private readonly notifications: SessionNotificationSource) {}
+
+  provideFileDecoration(uri: vscode.Uri): vscode.ProviderResult<vscode.FileDecoration> {
+    const sessionName = parseNotificationDecorationUri(uri);
+    if (!sessionName) {
+      return undefined;
+    }
+
+    const summary = buildSessionNotificationSummary(sessionName, this.notifications.getByTargetSession(sessionName));
+    if (!summary) {
+      const completion = this.notifications.getLatestSourceCompletion?.(sessionName);
+      return completion
+        ? new vscode.FileDecoration('C', 'Hydra worker completed', getDecorationColor('complete'))
+        : undefined;
+    }
+
+    return new vscode.FileDecoration(
+      summary.badge,
+      `${summary.unreadCount} unread Hydra notification${summary.unreadCount === 1 ? '' : 's'}`,
+      getDecorationColor(summary.kind),
+    );
+  }
+
+  refresh(): void {
+    this.onDidChangeEmitter.fire(undefined);
+  }
+}
+
+function getDecorationColor(kind: NotificationKind): vscode.ThemeColor {
+  switch (kind) {
+    case 'error':
+      return new vscode.ThemeColor('charts.red');
+    case 'blocked':
+      return new vscode.ThemeColor('charts.purple');
+    case 'needs-input':
+      return new vscode.ThemeColor('charts.yellow');
+    case 'complete':
+      return new vscode.ThemeColor('charts.green');
+    case 'info':
+      return new vscode.ThemeColor('charts.blue');
+  }
+}

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -9,6 +9,13 @@ import { toCanonicalPath } from '../utils/path';
 import { parseCpuPercentSum } from '../utils/cpuPercent';
 import { isDirectoryWorker, isRepoWorker, SessionManager, WorkerInfo } from '../core/sessionManager';
 import { CopilotMode, Worktree } from '../core/types';
+import {
+  buildSessionNotificationSummary,
+  type SessionNotificationSource,
+  type SessionNotificationSummary,
+} from '../core/sessionNotificationSummary';
+import type { HydraNotification, NotificationKind } from '../core/notifications';
+import { getNotificationDecorationUri } from './notificationDecorationProvider';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
 
@@ -311,6 +318,217 @@ export class TmuxItem extends vscode.TreeItem {
   }
 }
 
+function appendNotificationTooltip(
+  existing: string | vscode.MarkdownString | undefined,
+  summary: SessionNotificationSummary,
+  options: { unreadLabel?: string; footer?: string } = {},
+): vscode.MarkdownString {
+  const md = existing instanceof vscode.MarkdownString
+    ? existing
+    : new vscode.MarkdownString();
+  if (typeof existing === 'string' && existing.trim()) {
+    md.appendText(existing);
+  }
+
+  md.appendMarkdown('\n\n---\n\n**Hydra notification**\n\n');
+  md.appendMarkdown('- ');
+  md.appendText(options.unreadLabel ?? 'Unread');
+  md.appendMarkdown(': ');
+  md.appendText(String(summary.unreadCount));
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Kind: ');
+  md.appendText(summary.kind);
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Title: ');
+  md.appendText(summary.attention.title);
+  md.appendMarkdown('\n');
+  if (summary.attention.body) {
+    md.appendMarkdown('- Body: ');
+    md.appendText(summary.attention.body);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('- Created: ');
+  md.appendText(summary.attention.createdAt);
+  md.appendMarkdown('\n');
+  if (summary.attention.targetSession) {
+    md.appendMarkdown('- Target: ');
+    md.appendText(summary.attention.targetSession);
+    md.appendMarkdown('\n');
+  }
+  if (summary.attention.sourceSession) {
+    md.appendMarkdown('- Source: ');
+    md.appendText(summary.attention.sourceSession);
+    md.appendMarkdown('\n');
+  }
+  if (summary.attention.action) {
+    md.appendMarkdown('- Action: ');
+    md.appendText(`${summary.attention.action.type}:${summary.attention.action.session}`);
+    md.appendMarkdown('\n');
+  }
+  if (options.footer) {
+    md.appendMarkdown('\n');
+    md.appendText(options.footer);
+  } else {
+    md.appendMarkdown('\nRight-click this session to open, mark read, or clear notifications.');
+  }
+  return md;
+}
+
+function applyNotificationSummary(
+  item: vscode.TreeItem,
+  sessionName: string,
+  summary?: SessionNotificationSummary,
+): void {
+  item.resourceUri = getNotificationDecorationUri(sessionName);
+  if (!summary) {
+    return;
+  }
+
+  item.tooltip = appendNotificationTooltip(item.tooltip, summary);
+}
+
+function getTargetSessionNotificationSummary(
+  source: SessionNotificationSource | undefined,
+  sessionName: string,
+): SessionNotificationSummary | undefined {
+  return source
+    ? buildSessionNotificationSummary(sessionName, source.getByTargetSession(sessionName))
+    : undefined;
+}
+
+function getTargetUnreadNotifications(
+  source: SessionNotificationSource | undefined,
+  sessionName: string,
+): readonly HydraNotification[] {
+  return source
+    ? source.getByTargetSession(sessionName).filter(notification => notification.readAt === null)
+    : [];
+}
+
+function getLatestSourceCompletionNotification(
+  source: SessionNotificationSource | undefined,
+  sessionName: string,
+): HydraNotification | undefined {
+  if (!source) return undefined;
+  const projected = source.getLatestSourceCompletion?.(sessionName);
+  if (projected) return projected;
+  return source.getBySourceSession(sessionName)
+    .filter(notification =>
+      notification.kind === 'complete' &&
+      notification.targetSession !== sessionName,
+    )
+    .sort(compareNotificationsNewestFirst)[0];
+}
+
+function compareNotificationsNewestFirst(a: HydraNotification, b: HydraNotification): number {
+  const timeDiff = Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  if (Number.isFinite(timeDiff) && timeDiff !== 0) {
+    return timeDiff;
+  }
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+function getNotificationThemeColor(kind: NotificationKind): vscode.ThemeColor {
+  switch (kind) {
+    case 'error':
+      return new vscode.ThemeColor('charts.red');
+    case 'blocked':
+      return new vscode.ThemeColor('charts.purple');
+    case 'needs-input':
+      return new vscode.ThemeColor('charts.yellow');
+    case 'complete':
+      return new vscode.ThemeColor('charts.green');
+    case 'info':
+      return new vscode.ThemeColor('charts.blue');
+  }
+}
+
+function getNotificationIcon(kind: NotificationKind): string {
+  switch (kind) {
+    case 'error':
+      return 'error';
+    case 'blocked':
+    case 'needs-input':
+      return 'warning';
+    case 'complete':
+      return 'pass';
+    case 'info':
+      return 'info';
+  }
+}
+
+function formatNotificationDetailLabel(notification: HydraNotification): string {
+  const title = notification.title || notification.body || 'Notification';
+  return notification.kind === 'complete'
+    ? title
+    : `${notification.kind}: ${title}`;
+}
+
+function formatNotificationSessionLabel(sessionName: string | null): string | undefined {
+  if (!sessionName) return undefined;
+  return sessionName.replace(/^task_/, '');
+}
+
+function formatNotificationDescription(notification: HydraNotification): string | undefined {
+  const parts = [
+    formatNotificationSessionLabel(notification.sourceSession),
+    formatNotificationAge(notification.createdAt),
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+function formatNotificationAge(createdAt: string): string | undefined {
+  const timestamp = Date.parse(createdAt);
+  if (!Number.isFinite(timestamp)) {
+    return undefined;
+  }
+  return formatLastActive(Math.floor(timestamp / 1000));
+}
+
+function buildNotificationTooltip(
+  notification: HydraNotification,
+  footer: string,
+): vscode.MarkdownString {
+  const md = new vscode.MarkdownString();
+  md.appendMarkdown('**Hydra notification**\n\n');
+  md.appendMarkdown('- Kind: ');
+  md.appendText(notification.kind);
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Title: ');
+  md.appendText(notification.title);
+  md.appendMarkdown('\n');
+  if (notification.body) {
+    md.appendMarkdown('- Body: ');
+    md.appendText(notification.body);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('- Created: ');
+  md.appendText(notification.createdAt);
+  md.appendMarkdown('\n');
+  if (notification.targetSession) {
+    md.appendMarkdown('- Target: ');
+    md.appendText(notification.targetSession);
+    md.appendMarkdown('\n');
+  }
+  if (notification.sourceSession) {
+    md.appendMarkdown('- Source: ');
+    md.appendText(notification.sourceSession);
+    md.appendMarkdown('\n');
+  }
+  if (notification.action) {
+    md.appendMarkdown('- Action: ');
+    md.appendText(`${notification.action.type}:${notification.action.session}`);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('\n');
+  md.appendText(footer);
+  return md;
+}
+
+function formatWorkerStatusLabel(kind: NotificationKind): string {
+  return kind === 'complete' ? 'completed' : kind;
+}
+
 
 // ─── Copilot Item (Level 2) ──────────────────────────────
 
@@ -370,6 +588,7 @@ export class CopilotItem extends TmuxItem {
   public readonly copilotMode: CopilotMode;
   public readonly classification: Classification;
   public readonly workerSummary: CopilotWorkerSummary;
+  public readonly notificationDetailItems: NotificationDetailItem[];
 
   constructor(opts: {
     sessionName: string;
@@ -379,6 +598,8 @@ export class CopilotItem extends TmuxItem {
     worktreePath?: string;
     classification: Classification;
     workerSummary?: CopilotWorkerSummary;
+    notificationSummary?: SessionNotificationSummary;
+    notifications?: readonly HydraNotification[];
   }) {
     const label = opts.displayName || opts.sessionName;
     const copilotMode = opts.copilotMode || 'normal';
@@ -404,6 +625,10 @@ export class CopilotItem extends TmuxItem {
     this.description = description;
     this.tooltip = buildCopilotTooltip(label, opts.agentType, copilotMode, workerSummary);
     this.contextValue = 'copilotItem';
+    applyNotificationSummary(this, opts.sessionName, opts.notificationSummary);
+    this.notificationDetailItems = (opts.notifications ?? []).map(notification =>
+      new NotificationDetailItem(opts.sessionName, notification),
+    );
     this.command = {
       command: 'tmux.attachCreate',
       title: 'Open Session',
@@ -485,6 +710,7 @@ export class WorktreeItem extends TmuxItem {
     hasTmux: boolean;
     isMainWorktree?: boolean;
     isTaskWorker?: boolean;
+    notificationSummary?: SessionNotificationSummary;
   }) {
     const displayLabel = opts.isTaskWorker
       ? (opts.displayName || opts.branchLabel)
@@ -521,6 +747,7 @@ export class WorktreeItem extends TmuxItem {
     } else {
       this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.green'));
     }
+    applyNotificationSummary(this, opts.sessionName, opts.notificationSummary);
   }
 }
 
@@ -593,6 +820,37 @@ export class InactiveDetailItem extends TmuxItem {
   }
 }
 
+export class NotificationDetailItem extends TmuxItem {
+  public readonly notificationId: string;
+
+  constructor(
+    sessionName: string,
+    public readonly notification: HydraNotification,
+  ) {
+    super(
+      formatNotificationDetailLabel(notification),
+      vscode.TreeItemCollapsibleState.None,
+      undefined,
+      sessionName,
+    );
+
+    this.notificationId = notification.id;
+    this.id = `notification:target:${sessionName}:${notification.id}`;
+    this.contextValue = 'notificationDetailItem';
+    this.description = formatNotificationDescription(notification);
+    this.iconPath = new vscode.ThemeIcon(
+      getNotificationIcon(notification.kind),
+      getNotificationThemeColor(notification.kind),
+    );
+    this.tooltip = buildNotificationTooltip(notification, 'Click to open this notification and mark it read.');
+    this.command = {
+      command: 'hydra.openSessionNotification',
+      title: 'Open Notification',
+      arguments: [this],
+    };
+  }
+}
+
 export class GitStatusItem extends TmuxItem {
   public readonly worktreePath?: string;
   public readonly prNumber?: number;
@@ -645,6 +903,7 @@ export class GitStatusItem extends TmuxItem {
 export class TmuxSessionItem extends WorktreeItem {
   public readonly session: SessionWithStatus;
   public readonly detailItem: TmuxDetailItem;
+  public readonly completionNotification?: HydraNotification;
   public readonly gitStatusItem?: GitStatusItem;
 
   constructor(
@@ -659,7 +918,9 @@ export class TmuxSessionItem extends WorktreeItem {
     repoRoot?: string,
     workerId?: number,
     displayName?: string,
-    isTaskWorker?: boolean
+    isTaskWorker?: boolean,
+    notificationSummary?: SessionNotificationSummary,
+    completionNotification?: HydraNotification
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -680,12 +941,25 @@ export class TmuxSessionItem extends WorktreeItem {
 
     this.session = session;
     this.detailItem = new TmuxDetailItem(session, repoName, worktree, extensionUri);
+    this.completionNotification = completionNotification;
 
     const descParts: string[] = [];
     if (this.description) descParts.push(String(this.description));
     if (workerId != null) descParts.push(`#${workerId}`);
     if (agentType) descParts.push(`[${agentType}]`);
+    if (notificationSummary) {
+      descParts.push(formatWorkerStatusLabel(notificationSummary.kind));
+    } else if (completionNotification) {
+      descParts.push('completed');
+    }
     if (descParts.length > 0) this.description = descParts.join(' ');
+    applyNotificationSummary(this, session.name, notificationSummary);
+    if (completionNotification && !notificationSummary) {
+      this.tooltip = buildNotificationTooltip(
+        completionNotification,
+        'This worker has produced a completion notification for its copilot.',
+      );
+    }
 
     const hasGitChanges = session.status.commitsAhead > 0 || session.status.gitModified > 0 ||
       session.status.gitDeleted > 0 || session.status.gitAdded > 0 || session.status.gitUntracked > 0;
@@ -697,6 +971,7 @@ export class TmuxSessionItem extends WorktreeItem {
 
 export class InactiveWorktreeItem extends WorktreeItem {
   public readonly detailItem: InactiveDetailItem;
+  public readonly completionNotification?: HydraNotification;
   public readonly gitStatusItem?: GitStatusItem;
   public readonly worktree: Worktree;
   public readonly targetSessionName: string;
@@ -712,7 +987,9 @@ export class InactiveWorktreeItem extends WorktreeItem {
     gitStatusOverride?: SessionStatus,
     repoRoot?: string,
     displayName?: string,
-    isTaskWorker?: boolean
+    isTaskWorker?: boolean,
+    notificationSummary?: SessionNotificationSummary,
+    completionNotification?: HydraNotification
   ) {
     const branchLabel = branchLabelOverride || worktree.branch || (worktree.isMain ? 'main' : path.basename(worktree.path));
 
@@ -734,6 +1011,23 @@ export class InactiveWorktreeItem extends WorktreeItem {
     this.worktree = worktree;
     this.targetSessionName = targetSessionName;
     this.detailItem = new InactiveDetailItem(worktree, repoName, targetSessionName, extensionUri);
+    this.completionNotification = completionNotification;
+    if (notificationSummary || completionNotification) {
+      const descParts = typeof this.description === 'string' && this.description.trim()
+        ? [this.description]
+        : [];
+      descParts.push(notificationSummary
+        ? formatWorkerStatusLabel(notificationSummary.kind)
+        : 'completed');
+      this.description = descParts.join(' ');
+    }
+    applyNotificationSummary(this, targetSessionName, notificationSummary);
+    if (completionNotification && !notificationSummary) {
+      this.tooltip = buildNotificationTooltip(
+        completionNotification,
+        'This worker has produced a completion notification for its copilot.',
+      );
+    }
 
     if (gitStatusOverride) {
       const hasGitChanges = gitStatusOverride.commitsAhead > 0 || gitStatusOverride.gitModified > 0 ||
@@ -849,6 +1143,8 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
   private _extensionUri: vscode.Uri | undefined;
   private _copilotItems: CopilotItem[] = [];
 
+  constructor(private readonly notifications?: SessionNotificationSource) {}
+
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
   refresh(): void { this._onDidChangeTreeData.fire(undefined); }
   getTreeItem(element: TmuxItem): vscode.TreeItem { return element; }
@@ -902,6 +1198,8 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
           worktreePath: c.workdir,
           classification,
           workerSummary: summariesByCopilot.get(c.sessionName),
+          notificationSummary: getTargetSessionNotificationSummary(this.notifications, c.sessionName),
+          notifications: getTargetUnreadNotifications(this.notifications, c.sessionName),
         }));
       }
 
@@ -930,7 +1228,9 @@ export class CopilotProvider implements vscode.TreeDataProvider<TmuxItem> {
       hydraAgent: copilot.agentType,
       hydraCopilotMode: copilot.copilotMode,
     };
-    return [new TmuxDetailItem(session, '', undefined, this._extensionUri)];
+    const children: TmuxItem[] = [new TmuxDetailItem(session, '', undefined, this._extensionUri)];
+    children.push(...copilot.notificationDetailItems);
+    return children;
   }
 }
 
@@ -945,6 +1245,8 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
   private _taskGroup: TaskGroupItem | undefined;
   private _workerItemsByRepo = new Map<string, TmuxItem[]>();
   private _taskWorkerItems: TmuxItem[] = [];
+
+  constructor(private readonly notifications?: SessionNotificationSource) {}
 
   setExtensionUri(uri: vscode.Uri): void { this._extensionUri = uri; }
   refresh(): void {
@@ -966,23 +1268,35 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       }
       return this._repoGroups.find(g => g.repoName === element.repoName);
     }
-    // Detail items (TmuxDetailItem, GitStatusItem) are children of a WorktreeItem
+    // Detail items are children of a WorktreeItem.
     for (const items of this._workerItemsByRepo.values()) {
       for (const item of items) {
         if (item instanceof TmuxSessionItem) {
-          if (item.detailItem === element || item.gitStatusItem === element) return item;
+          if (
+            item.detailItem === element ||
+            item.gitStatusItem === element
+          ) return item;
         }
         if (item instanceof InactiveWorktreeItem) {
-          if (item.detailItem === element || item.gitStatusItem === element) return item;
+          if (
+            item.detailItem === element ||
+            item.gitStatusItem === element
+          ) return item;
         }
       }
     }
     for (const item of this._taskWorkerItems) {
       if (item instanceof TmuxSessionItem) {
-        if (item.detailItem === element || item.gitStatusItem === element) return item;
+        if (
+          item.detailItem === element ||
+          item.gitStatusItem === element
+        ) return item;
       }
       if (item instanceof InactiveWorktreeItem) {
-        if (item.detailItem === element || item.gitStatusItem === element) return item;
+        if (
+          item.detailItem === element ||
+          item.gitStatusItem === element
+        ) return item;
       }
     }
     return undefined;
@@ -1166,7 +1480,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
         items.push(new TmuxSessionItem(
           session, repoName, worktree, isCurrentWs, hasGit,
-          this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName
+          this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName, false,
+          getTargetSessionNotificationSummary(this.notifications, w.sessionName),
+          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
         ));
       } else {
         const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
@@ -1187,7 +1503,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         }
         items.push(new InactiveWorktreeItem(
           worktree, repoName, w.sessionName, isCurrentWs, hasGit,
-          this._extensionUri, branchLabel, stoppedStatus, repoRoot, w.displayName
+          this._extensionUri, branchLabel, stoppedStatus, repoRoot, w.displayName, false,
+          getTargetSessionNotificationSummary(this.notifications, w.sessionName),
+          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
         ));
       }
     }
@@ -1221,7 +1539,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         };
         items.push(new TmuxSessionItem(
           session, repoName, worktree, isCurrentWs, false,
-          this._extensionUri, label, w.agent, undefined, w.workerId, w.displayName, true
+          this._extensionUri, label, w.agent, undefined, w.workerId, w.displayName, true,
+          getTargetSessionNotificationSummary(this.notifications, w.sessionName),
+          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
         ));
       } else {
         const stoppedStatus: SessionStatus = {
@@ -1239,7 +1559,9 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         };
         items.push(new InactiveWorktreeItem(
           worktree, repoName, w.sessionName, isCurrentWs, false,
-          this._extensionUri, label, stoppedStatus, undefined, w.displayName, true
+          this._extensionUri, label, stoppedStatus, undefined, w.displayName, true,
+          getTargetSessionNotificationSummary(this.notifications, w.sessionName),
+          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
         ));
       }
     }

--- a/src/smoke/notificationStateServiceSmoke.ts
+++ b/src/smoke/notificationStateServiceSmoke.ts
@@ -111,6 +111,17 @@ function parseStdoutJson<T>(proc: SpawnSyncReturns<string>, label: string): T {
   return JSON.parse(proc.stdout) as T;
 }
 
+function readEventLines(ctx: TestContext): Array<{ type?: string; source?: string; payload?: { notificationId?: string } }> {
+  const eventsPath = path.join(ctx.hydraHome, 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+  return fs.readFileSync(eventsPath, 'utf-8')
+    .split('\n')
+    .filter(line => line.trim().length > 0)
+    .map(line => JSON.parse(line) as { type?: string; source?: string; payload?: { notificationId?: string } });
+}
+
 async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3000): Promise<void> {
   const started = Date.now();
   while (Date.now() - started < timeoutMs) {
@@ -174,10 +185,17 @@ async function testInitialLoadAndIndexes(): Promise<void> {
         assert.equal(service.getLatest(1)[0].id, second.id);
         assert.equal(service.getById(first.id)?.title, 'Worker completed');
         assert.deepEqual(service.getBySession('repo_worker').map(notification => notification.id), [first.id]);
+        assert.deepEqual(service.getByTargetSession('repo_worker').map(notification => notification.id), []);
+        assert.deepEqual(service.getBySourceSession('repo_worker').map(notification => notification.id), [first.id]);
         assert.deepEqual(
           service.getBySession('repo_copilot').map(notification => notification.id),
           [second.id, first.id],
         );
+        assert.deepEqual(
+          service.getByTargetSession('repo_copilot').map(notification => notification.id),
+          [second.id, first.id],
+        );
+        assert.deepEqual(service.getBySourceSession('repo_copilot').map(notification => notification.id), []);
 
         const snapshot = service.getSnapshot();
         (snapshot.notifications as unknown as { pop(): unknown }).pop();
@@ -237,6 +255,58 @@ async function testServiceOperationsReloadSynchronously(): Promise<void> {
   }
 }
 
+async function testTargetSessionOperationsIgnoreSourceOnlyNotifications(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-target-ops-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const sourceOnly = store.create({
+        kind: 'complete',
+        title: 'Worker completed',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+      const targeted = store.create({
+        kind: 'needs-input',
+        title: 'Worker needs input',
+        targetSession: 'repo_worker',
+        sourceSession: 'repo_copilot',
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.deepEqual(service.getByTargetSession('repo_worker').map(notification => notification.id), [targeted.id]);
+        assert.deepEqual(service.getBySourceSession('repo_worker').map(notification => notification.id), [sourceOnly.id]);
+        assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, sourceOnly.id);
+
+        const read = service.markTargetSessionRead('repo_worker');
+        assert.equal(read.markedRead, 1);
+        assert.equal(service.getById(targeted.id)?.readAt !== null, true);
+        assert.equal(service.getById(sourceOnly.id)?.readAt, null, 'source-only completion should remain unread for copilot');
+
+        const cleared = service.clear({ targetSession: 'repo_worker' });
+        assert.equal(cleared.cleared, 1);
+        assert.equal(service.getById(targeted.id), undefined);
+        assert.equal(service.getById(sourceOnly.id)?.id, sourceOnly.id);
+
+        const clearedCopilotInbox = service.clear({ targetSession: 'repo_copilot' });
+        assert.equal(clearedCopilotInbox.cleared, 1);
+        assert.equal(service.getById(sourceOnly.id), undefined);
+        const projectedCompletion = service.getLatestSourceCompletion('repo_worker');
+        assert.equal(projectedCompletion?.id, sourceOnly.id);
+        assert.equal(projectedCompletion?.kind, 'complete');
+        assert.equal(projectedCompletion?.action?.session, 'repo_worker');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
 async function testWatcherUpdatesFromNotificationFileOnly(): Promise<void> {
   const ctx = setupContext('hydra-notification-state-file-only-');
   try {
@@ -259,6 +329,100 @@ async function testWatcherUpdatesFromNotificationFileOnly(): Promise<void> {
         await waitFor(() => service.getUnreadCount() === 1, 'file-only notification reload');
         assert.equal(service.getLatest(1)[0].title, 'File-only notification');
       } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testBatchReadAndClearEventSources(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-batch-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const first = store.create({
+        kind: 'info',
+        title: 'First unread',
+        targetSession: 'repo_worker',
+      }).notification;
+      const second = store.create({
+        kind: 'blocked',
+        title: 'Second unread',
+        sourceSession: 'repo_worker',
+      }).notification;
+      store.create({
+        kind: 'complete',
+        title: 'Other unread',
+        targetSession: 'other_worker',
+      });
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(service.getUnreadCount(), 3);
+
+        const read = service.markSessionRead('repo_worker', 'extension');
+        assert.equal(read.markedRead, 2);
+        assert.equal(service.getById(first.id)?.readAt !== null, true);
+        assert.equal(service.getById(second.id)?.readAt !== null, true);
+        assert.equal(service.getUnreadCount(), 1);
+
+        const readEvents = readEventLines(ctx).filter(event =>
+          event.type === 'notify.read' &&
+          event.source === 'extension' &&
+          (event.payload?.notificationId === first.id || event.payload?.notificationId === second.id)
+        );
+        assert.equal(readEvents.length, 2, 'batch read should emit one extension notify.read per notification');
+
+        const cleared = service.clear({ session: 'repo_worker' }, 'extension');
+        assert.equal(cleared.cleared, 2);
+        const clearEvents = readEventLines(ctx).filter(event =>
+          event.type === 'notify.cleared' &&
+          event.source === 'extension'
+        );
+        assert.equal(clearEvents.length, 1, 'clear should emit an extension notify.cleared event');
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testEventOnlyCompletionProjectionEmitsChange(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-event-projection-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      let changes = 0;
+      const listener = service.onDidChange(() => { changes += 1; });
+      try {
+        service.initialize();
+        new EventLog().append({
+          type: 'notify.created',
+          source: 'hook',
+          payload: {
+            notificationId: 'event-only-complete',
+            kind: 'complete',
+            targetSession: 'repo_copilot',
+            sourceSession: 'repo_worker',
+            actionType: 'open-session',
+            actionSession: 'repo_worker',
+          },
+        });
+
+        await waitFor(
+          () => service.getLatestSourceCompletion('repo_worker')?.id === 'event-only-complete',
+          'event-only completion projection',
+        );
+        assert.equal(service.getSnapshot().totalCount, 0);
+        assert.equal(service.getLatestSourceCompletion('repo_worker')?.action?.session, 'repo_worker');
+        assert.ok(changes > 0, 'event-only completion projection should emit a change');
+      } finally {
+        listener.dispose();
         service.dispose();
       }
     });
@@ -385,6 +549,8 @@ async function testCliEndToEnd(): Promise<void> {
         await waitFor(() => service.getById(created.notification.id) !== undefined, 'CLI create reflected in service');
         assert.equal(service.getUnreadCount(), 1);
         assert.equal(service.getBySession('repo_worker')[0].id, created.notification.id);
+        assert.equal(service.getByTargetSession('repo_copilot')[0].id, created.notification.id);
+        assert.equal(service.getBySourceSession('repo_worker')[0].id, created.notification.id);
 
         parseStdoutJson<{ markedRead: number }>(
           runCli(['notify', 'read', created.notification.id, '--json'], ctx.env),
@@ -397,6 +563,11 @@ async function testCliEndToEnd(): Promise<void> {
           'hydra notify clear --json',
         );
         await waitFor(() => service.getSnapshot().totalCount === 0, 'CLI clear reflected in service');
+        assert.equal(
+          service.getLatestSourceCompletion('repo_worker')?.id,
+          created.notification.id,
+          'worker completion projection should survive notification clear',
+        );
       } finally {
         service.dispose();
       }
@@ -433,7 +604,10 @@ async function main(): Promise<void> {
   await testMissingFiles();
   await testInitialLoadAndIndexes();
   await testServiceOperationsReloadSynchronously();
+  await testTargetSessionOperationsIgnoreSourceOnlyNotifications();
   await testWatcherUpdatesFromNotificationFileOnly();
+  await testBatchReadAndClearEventSources();
+  await testEventOnlyCompletionProjectionEmitsChange();
   await testInitializeSignatureWindow();
   await testDuplicateAndMalformedEventTolerance();
   await testCliEndToEnd();

--- a/src/smoke/sessionNotificationSummarySmoke.ts
+++ b/src/smoke/sessionNotificationSummarySmoke.ts
@@ -1,0 +1,114 @@
+/**
+ * Smoke test: session notification summary projection.
+ *
+ * Run: node out/smoke/sessionNotificationSummarySmoke.js
+ */
+
+import * as assert from 'assert';
+import { buildSessionNotificationSummary } from '../core/sessionNotificationSummary';
+import type { HydraNotification, NotificationKind } from '../core/notifications';
+
+function notification(
+  id: string,
+  kind: NotificationKind,
+  createdAt: string,
+  overrides: Partial<HydraNotification> = {},
+): HydraNotification {
+  return {
+    id,
+    createdAt,
+    readAt: null,
+    kind,
+    title: `${kind} title`,
+    body: '',
+    targetSession: 'worker_a',
+    sourceSession: null,
+    ...overrides,
+  };
+}
+
+function testNoUnread(): void {
+  const summary = buildSessionNotificationSummary('worker_a', [
+    notification('read', 'error', '2026-01-01T00:00:00.000Z', { readAt: '2026-01-01T00:01:00.000Z' }),
+  ]);
+  assert.equal(summary, undefined);
+}
+
+function testPriorityWins(): void {
+  const summary = buildSessionNotificationSummary('worker_a', [
+    notification('complete-newer', 'complete', '2026-01-01T00:10:00.000Z'),
+    notification('error-older', 'error', '2026-01-01T00:00:00.000Z'),
+    notification('blocked', 'blocked', '2026-01-01T00:05:00.000Z'),
+  ]);
+  assert.ok(summary);
+  assert.equal(summary.attention.id, 'error-older');
+  assert.equal(summary.kind, 'error');
+  assert.equal(summary.badge, 'E');
+  assert.match(summary.description, /^3 unread .* error: error title$/);
+}
+
+function testNewestWinsWithinPriority(): void {
+  const summary = buildSessionNotificationSummary('worker_a', [
+    notification('old', 'needs-input', '2026-01-01T00:00:00.000Z'),
+    notification('new', 'needs-input', '2026-01-01T00:10:00.000Z'),
+  ]);
+  assert.ok(summary);
+  assert.equal(summary.attention.id, 'new');
+  assert.equal(summary.badge, '?');
+}
+
+function testTextNormalizationAndTruncation(): void {
+  const longTitle = [
+    'This',
+    'notification',
+    'title',
+    'has',
+    'a',
+    'large',
+    'amount',
+    'of',
+    'spacing',
+    'and',
+    'content',
+    'that',
+    'must',
+    'be',
+    'truncated',
+  ].join('\n  ');
+  const summary = buildSessionNotificationSummary('worker_a', [
+    notification('long', 'info', '2026-01-01T00:00:00.000Z', { title: longTitle }),
+  ]);
+  assert.ok(summary);
+  assert.equal(summary.badge, 'i');
+  assert.ok(!summary.description.includes('\n'));
+  assert.ok(summary.description.endsWith('...'));
+  assert.ok(summary.description.length < 120);
+}
+
+function testBadgeMapping(): void {
+  const cases: Array<[NotificationKind, string]> = [
+    ['error', 'E'],
+    ['blocked', 'B'],
+    ['needs-input', '?'],
+    ['complete', 'C'],
+    ['info', 'i'],
+  ];
+  for (const [kind, badge] of cases) {
+    const summary = buildSessionNotificationSummary('worker_a', [
+      notification(kind, kind, '2026-01-01T00:00:00.000Z'),
+    ]);
+    assert.ok(summary);
+    assert.equal(summary.badge, badge);
+  }
+}
+
+function main(): void {
+  testNoUnread();
+  testPriorityWins();
+  testNewestWinsWithinPriority();
+  testTextNormalizationAndTruncation();
+  testBadgeMapping();
+  console.log('sessionNotificationSummarySmoke: ok');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add structured notification attention states to Copilot and Worker TreeViews
- keep Copilot as the unread inbox while projecting Worker completion state from notifications and events
- add notification tree commands, file decorations, and focused smoke coverage for target/source notification boundaries

## Validation
- npm run compile
- npm run lint
- npm run smoke:notification-state
- npm run smoke:session-notification-summary
- npm run smoke:notify-cli
- npm run smoke:events-cli
- npm run smoke:completion-hook
- git diff --check
- npm test
