### PR TITLE
[codex] Emit worker error notifications

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -174,9 +174,9 @@ Current event types:
 
 | Type | Source | Role | Payload contract |
 | --- | --- | --- | --- |
-| `notify.created` | `cli` or `hook` | undefined | `notificationId`, `kind`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
-| `notify.read` | `cli` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
-| `notify.cleared` | `cli` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`. Emitted only when at least one notification is removed. |
+| `notify.created` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `notificationId`, `kind`, `title`, redacted `body`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `workdir`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
+| `notify.read` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
+| `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`. Emitted only when at least one notification is removed. |
 | `worker.created` | `session-manager` | `worker` | `workerId`, `source`, optional `branch`, `repo`, `managedWorkdir`. Emitted for fresh code/task worker creation. |
 | `worker.started` | `session-manager` | `worker` | Worker identity fields plus `resumed`; existing-branch paths also include `alreadyRunning`. Emitted when an existing worker session is started or reused. |
 | `worker.stopped` | `session-manager` | `worker` | Worker identity fields. |

--- a/package.json
+++ b/package.json
@@ -411,6 +411,7 @@
     "smoke:cli-contract": "node out/smoke/cliContractSmoke.js",
     "smoke:events-cli": "node out/smoke/eventsCliSmoke.js",
     "smoke:notify-cli": "node out/smoke/notifyCliSmoke.js",
+    "smoke:worker-attention-notification": "node out/smoke/workerAttentionNotificationSmoke.js",
     "smoke:notification-state": "node out/smoke/notificationStateServiceSmoke.js",
     "smoke:session-notification-summary": "node out/smoke/sessionNotificationSummarySmoke.js",
     "smoke:agent-registry": "node out/smoke/agentRegistrySmoke.js",
@@ -427,7 +428,7 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:notification-state && npm run smoke:session-notification-summary && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:worker-attention-notification && npm run smoke:notification-state && npm run smoke:session-notification-summary && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
     "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {

--- a/src/cli/commands/archive.ts
+++ b/src/cli/commands/archive.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { TmuxBackendCore } from '../../core/tmux';
 import { isDirectoryWorker, SessionManager, ArchivedSessionInfo, type WorkerInfo } from '../../core/sessionManager';
 import { outputResult, outputError, type OutputOpts } from '../output';
+import { awaitWorkerPostCreateOrPublishError } from '../../core/workerAttentionNotifications';
 
 function formatEntry(entry: ArchivedSessionInfo): Record<string, unknown> {
   const worker = entry.type === 'worker' ? entry.data as WorkerInfo : null;
@@ -156,7 +157,7 @@ export function registerArchiveCommands(program: Command): void {
               console.log(`  Session ID: ${workerInfo.sessionId || 'none'}`);
             },
           );
-          await postCreatePromise;
+          await awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'cli' });
         } else {
           const { copilotInfo, postCreatePromise } = await sm.restoreCopilot(sessionName);
           await postCreatePromise;

--- a/src/cli/commands/share.ts
+++ b/src/cli/commands/share.ts
@@ -32,6 +32,7 @@ import { importCodexNativeSession } from '../../share/codexAdapter';
 import { ensureLocalBranchFromRemote, validateRepoMatch } from '../../share/repo';
 import type { HydraShareBundle, ShareHydraWorkerInfo } from '../../share/types';
 import { outputError, outputResult, type OutputOpts } from '../output';
+import { awaitWorkerPostCreateOrPublishError } from '../../core/workerAttentionNotifications';
 
 interface CreateShareOpts {
   bucket?: string;
@@ -349,7 +350,7 @@ async function acceptWorker(
     notifyCopilot: false,
     fetchMode: 'best-effort',
   });
-  await postCreatePromise;
+  await awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'cli' });
   return workerInfo;
 }
 

--- a/src/cli/commands/worker.ts
+++ b/src/cli/commands/worker.ts
@@ -10,6 +10,7 @@ import { detectCurrentTmuxIdentity, detectIdentity, getWorkerCreationBlockedMess
 import { getTelemetry, normalizeAgentForTelemetry } from '../../core/telemetry';
 import { agentSupportsCompletionNotification } from '../../core/agentConfig';
 import { getHydraGlobalDefaultAgent } from '../../core/hydraGlobalConfig';
+import { awaitWorkerPostCreateOrPublishError } from '../../core/workerAttentionNotifications';
 
 type WorkerCreateCliOpts = {
   repo?: string;
@@ -240,7 +241,7 @@ export function registerWorkerCommands(program: Command): void {
         );
 
         // Wait for delayed Enter (Claude trust prompt) before exiting
-        await postCreatePromise;
+        await awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'cli' });
       } catch (error) {
         outputError(error, globalOpts);
       }
@@ -320,7 +321,7 @@ export function registerWorkerCommands(program: Command): void {
           },
         );
 
-        await postCreatePromise;
+        await awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'cli' });
       } catch (error) {
         outputError(error, globalOpts);
       }

--- a/src/commands/newTask.ts
+++ b/src/commands/newTask.ts
@@ -9,6 +9,7 @@ import { getActiveBackend } from '../utils/multiplexer';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { detectIdentity, getWorkerCreationBlockedMessage } from '../core/sessionIdentity';
 import { showHydraCommandError } from './logs';
+import { awaitWorkerPostCreateOrPublishError } from '../core/workerAttentionNotifications';
 
 function getBaseBranchOverride(): string | undefined {
   const hydraOverride = vscode.workspace.getConfiguration('hydra').get<string>('baseBranch');
@@ -91,7 +92,7 @@ async function createCodeWorker(repoRoot: string): Promise<void> {
 
   await refreshHydraViewsBeforeAttach();
   getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
-  void postCreatePromise.catch((error) => {
+  void awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'extension' }).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showWarningMessage(
       `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,
@@ -209,7 +210,7 @@ async function createTaskWorker(workspacePath: string, workspaceIsGitRepo: boole
 
   await refreshHydraViewsBeforeAttach();
   getActiveBackend().attachSession(workerInfo.sessionName, workerInfo.workdir, undefined, 'worker');
-  void postCreatePromise.catch((error) => {
+  void awaitWorkerPostCreateOrPublishError(workerInfo, postCreatePromise, { eventSource: 'extension' }).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     vscode.window.showWarningMessage(
       `Worker "${workerInfo.sessionName}" started, but agent initialization did not complete cleanly: ${message}`,

--- a/src/commands/openHydraSession.ts
+++ b/src/commands/openHydraSession.ts
@@ -11,6 +11,7 @@ import { getActiveBackend } from '../utils/multiplexer';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { sendCopilotOnboarding } from './createCopilot';
 import { openChangesReview } from './reviewChanges';
+import { awaitWorkerPostCreateOrPublishError } from '../core/workerAttentionNotifications';
 
 export async function openHydraSessionByItem(item: TmuxItem): Promise<void> {
   const backend = getActiveBackend();
@@ -103,7 +104,16 @@ async function resumeWorker(sessionName: string, fallbackWorktreePath?: string):
   try {
     const sm = new SessionManager(new TmuxBackendCore());
     const result = await sm.startWorker(sessionName);
-    result.postCreatePromise.catch(() => {});
+    void awaitWorkerPostCreateOrPublishError(
+      result.workerInfo,
+      result.postCreatePromise,
+      { eventSource: 'extension' },
+    ).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showWarningMessage(
+        `Worker "${result.workerInfo.sessionName}" resumed, but agent initialization did not complete cleanly: ${message}`,
+      );
+    });
     workdir = result.workerInfo.workdir || workdir;
   } catch {
     if (!workdir) {

--- a/src/core/notificationStateService.ts
+++ b/src/core/notificationStateService.ts
@@ -8,8 +8,10 @@ import {
 import { logger } from './logger';
 import {
   getHydraNotificationsFile,
+  isNotificationKind,
   NotificationStore,
   type HydraNotification,
+  type NotificationKind,
   type NotificationMarkSessionReadResult,
   type NotificationClearResult,
   type NotificationListFilters,
@@ -59,6 +61,7 @@ export class NotificationStateService implements Disposable {
   private lastNotificationSignature = 'missing';
   private lastEventSignature = 'missing';
   private lastMalformedEventSignature: string | undefined;
+  private sourceAttentionBySession = new Map<string, HydraNotification>();
   private sourceCompletionBySession = new Map<string, HydraNotification>();
   private readonly notificationFileListener = (current: fs.Stats, previous: fs.Stats) => {
     if (!this.didStatChange(current, previous)) {
@@ -152,13 +155,21 @@ export class NotificationStateService implements Disposable {
   }
 
   getLatestSourceCompletion(sessionName: string): HydraNotification | undefined {
-    const stored = this.getLatestStoredSourceCompletion(sessionName);
-    if (stored) {
-      return stored;
+    const projected = this.sourceCompletionBySession.get(sessionName);
+    if (projected) {
+      return cloneNotification(projected);
     }
 
-    const projected = this.sourceCompletionBySession.get(sessionName);
-    return projected ? cloneNotification(projected) : undefined;
+    return this.getLatestStoredSourceCompletion(sessionName);
+  }
+
+  getLatestSourceAttention(sessionName: string): HydraNotification | undefined {
+    const projected = this.sourceAttentionBySession.get(sessionName);
+    if (projected) {
+      return cloneNotification(projected);
+    }
+
+    return this.getLatestStoredSourceAttention(sessionName);
   }
 
   getById(id: string): HydraNotification | undefined {
@@ -284,6 +295,7 @@ export class NotificationStateService implements Disposable {
     }
 
     const previousRevision = this.state.contentRevision;
+    const previousAttentionRevision = buildSourceProjectionRevision(this.sourceAttentionBySession);
     const previousCompletionRevision = buildSourceCompletionRevision(this.sourceCompletionBySession);
     let notifications: HydraNotification[];
     try {
@@ -299,18 +311,27 @@ export class NotificationStateService implements Disposable {
     this.lastNotificationSignature = getFileSignature(this.notificationsFile);
     this.lastEventSeq = Math.max(this.lastEventSeq, this.safeReadLastSeq());
     this.state = buildNotificationState(notifications, this.lastEventSeq);
-    this.rebuildSourceCompletionProjection(notifications);
+    this.rebuildSourceProjections(notifications);
+    const attentionRevision = buildSourceProjectionRevision(this.sourceAttentionBySession);
     const completionRevision = buildSourceCompletionRevision(this.sourceCompletionBySession);
 
     if (
       options.emit &&
       (
         this.state.contentRevision !== previousRevision ||
+        attentionRevision !== previousAttentionRevision ||
         completionRevision !== previousCompletionRevision
       )
     ) {
       this.emitChange();
     }
+  }
+
+  private getLatestStoredSourceAttention(sessionName: string): HydraNotification | undefined {
+    return [...(this.state.indexes.bySourceSession.get(sessionName) || [])]
+      .filter(notification => notification.targetSession !== sessionName)
+      .sort(compareSourceAttentionNotifications)
+      .map(cloneNotification)[0];
   }
 
   private getLatestStoredSourceCompletion(sessionName: string): HydraNotification | undefined {
@@ -323,15 +344,18 @@ export class NotificationStateService implements Disposable {
       .map(cloneNotification)[0];
   }
 
-  private rebuildSourceCompletionProjection(notifications: readonly HydraNotification[]): void {
+  private rebuildSourceProjections(notifications: readonly HydraNotification[]): void {
+    const attention = new Map<string, HydraNotification>();
     const completions = new Map<string, HydraNotification>();
+    const storedNotificationIds = new Set<string>();
 
     for (const notification of notifications) {
-      if (
-        notification.kind === 'complete' &&
-        notification.sourceSession &&
-        notification.targetSession !== notification.sourceSession
-      ) {
+      storedNotificationIds.add(notification.id);
+      if (!notification.sourceSession || notification.targetSession === notification.sourceSession) {
+        continue;
+      }
+      upsertLatestAttention(attention, notification.sourceSession, notification);
+      if (notification.kind === 'complete') {
         upsertLatestCompletion(completions, notification.sourceSession, notification);
       }
     }
@@ -340,7 +364,8 @@ export class NotificationStateService implements Disposable {
     try {
       events = this.eventLog.read({ tolerateIncompleteTail: true });
     } catch (error) {
-      logger.warn('notification-state.events', 'Failed to rebuild source completion projection', { error });
+      logger.warn('notification-state.events', 'Failed to rebuild source notification projections', { error });
+      this.sourceAttentionBySession = attention;
       this.sourceCompletionBySession = completions;
       return;
     }
@@ -350,9 +375,16 @@ export class NotificationStateService implements Disposable {
       if (!notification?.sourceSession) {
         continue;
       }
-      upsertLatestCompletion(completions, notification.sourceSession, notification);
+      if (storedNotificationIds.has(notification.id)) {
+        continue;
+      }
+      upsertLatestAttention(attention, notification.sourceSession, notification);
+      if (notification.kind === 'complete') {
+        upsertLatestCompletion(completions, notification.sourceSession, notification);
+      }
     }
 
+    this.sourceAttentionBySession = attention;
     this.sourceCompletionBySession = completions;
   }
 
@@ -418,12 +450,23 @@ function upsertLatestCompletion(
   }
 }
 
+function upsertLatestAttention(
+  attention: Map<string, HydraNotification>,
+  sessionName: string,
+  notification: HydraNotification,
+): void {
+  const existing = attention.get(sessionName);
+  if (!existing || compareSourceAttentionNotifications(notification, existing) < 0) {
+    attention.set(sessionName, cloneNotification(notification));
+  }
+}
+
 function notificationFromCreatedEvent(event: HydraEvent): HydraNotification | undefined {
   if (event.type !== 'notify.created') {
     return undefined;
   }
   const payload = event.payload || {};
-  if (payload.kind !== 'complete') {
+  if (!isNotificationKind(payload.kind)) {
     return undefined;
   }
   const sourceSession = getStringPayload(payload, 'sourceSession');
@@ -437,18 +480,42 @@ function notificationFromCreatedEvent(event: HydraEvent): HydraNotification | un
     id,
     createdAt: event.ts,
     readAt: null,
-    kind: 'complete',
-    title: 'Worker completed',
-    body: '',
+    kind: payload.kind,
+    title: getStringPayload(payload, 'title') || getDefaultNotificationTitle(payload.kind),
+    body: getStringPayload(payload, 'body') || '',
     targetSession: targetSession || null,
     sourceSession,
     action,
     context: {
       workerId: getNumberPayload(payload, 'workerId'),
       branch: getStringPayload(payload, 'branch') ?? null,
+      workdir: getStringPayload(payload, 'workdir') ?? null,
       agent: getStringPayload(payload, 'agent') ?? null,
     },
   };
+}
+
+const SOURCE_ATTENTION_KIND_PRIORITY: Record<NotificationKind, number> = {
+  error: 0,
+  blocked: 1,
+  'needs-input': 2,
+  complete: 3,
+  info: 4,
+};
+
+function getDefaultNotificationTitle(kind: NotificationKind): string {
+  switch (kind) {
+    case 'complete':
+      return 'Worker completed';
+    case 'error':
+      return 'Worker error';
+    case 'blocked':
+      return 'Worker blocked';
+    case 'needs-input':
+      return 'Worker needs input';
+    case 'info':
+      return 'Worker notification';
+  }
 }
 
 function getActionPayload(payload: Record<string, unknown>): HydraNotification['action'] | undefined {
@@ -478,13 +545,34 @@ function compareNotificationsNewestFirst(a: HydraNotification, b: HydraNotificat
   return b.createdAt.localeCompare(a.createdAt);
 }
 
+function compareSourceAttentionNotifications(a: HydraNotification, b: HydraNotification): number {
+  const newestDiff = compareNotificationsNewestFirst(a, b);
+  if (newestDiff !== 0) {
+    return newestDiff;
+  }
+
+  const priorityDiff = SOURCE_ATTENTION_KIND_PRIORITY[a.kind] - SOURCE_ATTENTION_KIND_PRIORITY[b.kind];
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
 function buildSourceCompletionRevision(completions: ReadonlyMap<string, HydraNotification>): string {
-  return JSON.stringify([...completions.entries()]
+  return buildSourceProjectionRevision(completions);
+}
+
+function buildSourceProjectionRevision(projection: ReadonlyMap<string, HydraNotification>): string {
+  return JSON.stringify([...projection.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([sessionName, notification]) => ({
       sessionName,
       id: notification.id,
       createdAt: notification.createdAt,
+      kind: notification.kind,
+      title: notification.title,
+      body: notification.body,
       targetSession: notification.targetSession,
       sourceSession: notification.sourceSession,
       action: notification.action ? {

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -321,12 +321,15 @@ export class NotificationStore {
         payload: {
           notificationId: notification.id,
           kind: notification.kind,
+          title: notification.title,
+          body: notification.body,
           targetSession: notification.targetSession,
           sourceSession: notification.sourceSession,
           actionType: notification.action?.type,
           actionSession: notification.action?.session,
           workerId: notification.context?.workerId,
           branch: notification.context?.branch,
+          workdir: notification.context?.workdir,
           agent: notification.context?.agent,
         },
       });

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -77,6 +77,10 @@ function countOccurrences(text: string, needle: string): number {
   }
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function rebasePathUnderDirectory(filePath: string | null | undefined, oldDir: string, newDir: string): string | null {
   if (!filePath || !oldDir || !newDir) {
     return null;
@@ -2223,7 +2227,11 @@ export class SessionManager {
       if (notifyCopilot) {
         this.armCompletionNotification(sessionName);
       }
-      await this.backend.sendMessage(sessionName, task);
+      try {
+        await this.backend.sendMessage(sessionName, task);
+      } catch (error) {
+        throw new Error(`Initial prompt delivery failed for "${sessionName}": ${getErrorMessage(error)}`);
+      }
     }
   }
 

--- a/src/core/sessionNotificationSummary.ts
+++ b/src/core/sessionNotificationSummary.ts
@@ -4,6 +4,7 @@ export interface SessionNotificationSource {
   getBySession(sessionName: string): readonly HydraNotification[];
   getByTargetSession(sessionName: string): readonly HydraNotification[];
   getBySourceSession(sessionName: string): readonly HydraNotification[];
+  getLatestSourceAttention?(sessionName: string): HydraNotification | undefined;
   getLatestSourceCompletion?(sessionName: string): HydraNotification | undefined;
 }
 

--- a/src/core/workerAttentionNotifications.ts
+++ b/src/core/workerAttentionNotifications.ts
@@ -1,0 +1,156 @@
+import { type HydraEventSource } from './events';
+import { hashText, redactText, truncateText } from './logRedaction';
+import { logger } from './logger';
+import {
+  NotificationStore,
+  type CreateNotificationResult,
+  type HydraNotification,
+  type NotificationKind,
+} from './notifications';
+import type { WorkerInfo } from './sessionManager';
+
+export type WorkerRuntimeErrorReason = 'post-create' | 'initial-prompt' | 'startup-timeout';
+
+export interface PublishWorkerAttentionNotificationInput {
+  kind: NotificationKind;
+  targetCopilotSession?: string | null;
+  sourceWorkerSession: string;
+  title: string;
+  body?: string;
+  dedupeKey?: string;
+  actionSession?: string;
+  context?: HydraNotification['context'];
+  eventSource?: HydraEventSource;
+  store?: NotificationStore;
+}
+
+export interface PublishWorkerRuntimeErrorOptions {
+  eventSource?: HydraEventSource;
+  reason?: WorkerRuntimeErrorReason;
+  store?: NotificationStore;
+}
+
+export type PublishWorkerAttentionNotificationResult =
+  | (CreateNotificationResult & { skipped?: undefined })
+  | { created: false; notification?: undefined; skipped: 'missing-target' | 'store-failed' };
+
+const ERROR_BODY_LIMIT = 600;
+
+export function publishWorkerAttentionNotification(
+  input: PublishWorkerAttentionNotificationInput,
+): PublishWorkerAttentionNotificationResult {
+  const targetCopilotSession = input.targetCopilotSession?.trim();
+  if (!targetCopilotSession) {
+    return { created: false, skipped: 'missing-target' };
+  }
+
+  try {
+    return (input.store ?? new NotificationStore()).create({
+      kind: input.kind,
+      title: input.title,
+      body: input.body,
+      targetSession: targetCopilotSession,
+      sourceSession: input.sourceWorkerSession,
+      dedupeKey: input.dedupeKey,
+      action: {
+        type: 'open-session',
+        session: input.actionSession || input.sourceWorkerSession,
+      },
+      context: input.context,
+      eventSource: input.eventSource || 'session-manager',
+    });
+  } catch (error) {
+    logger.warn('worker-attention-notification.create', 'Failed to create worker attention notification', {
+      kind: input.kind,
+      targetCopilotSession,
+      sourceWorkerSession: input.sourceWorkerSession,
+      error,
+    });
+    return { created: false, skipped: 'store-failed' };
+  }
+}
+
+export function publishWorkerRuntimeErrorNotification(
+  worker: WorkerInfo,
+  error: unknown,
+  options: PublishWorkerRuntimeErrorOptions = {},
+): PublishWorkerAttentionNotificationResult {
+  const reason = options.reason || classifyRuntimeErrorReason(error);
+  const message = formatErrorMessage(error);
+  const workerLabel = formatWorkerLabel(worker);
+  const title = getWorkerRuntimeErrorTitle(workerLabel, reason);
+
+  return publishWorkerAttentionNotification({
+    kind: 'error',
+    targetCopilotSession: worker.copilotSessionName,
+    sourceWorkerSession: worker.sessionName,
+    title,
+    body: `${message}\n\nOpen the worker session to inspect the terminal output.`,
+    dedupeKey: `worker-error:${worker.sessionName}:${reason}:${hashText(normalizeErrorSignature(message))}`,
+    actionSession: worker.sessionName,
+    context: {
+      workerId: worker.workerId,
+      branch: worker.branch,
+      workdir: worker.workdir,
+      agent: worker.agent,
+    },
+    eventSource: options.eventSource || 'session-manager',
+    store: options.store,
+  });
+}
+
+export async function awaitWorkerPostCreateOrPublishError(
+  worker: WorkerInfo,
+  postCreatePromise: Promise<void>,
+  options: PublishWorkerRuntimeErrorOptions = {},
+): Promise<void> {
+  try {
+    await postCreatePromise;
+  } catch (error) {
+    publishWorkerRuntimeErrorNotification(worker, error, options);
+    throw error;
+  }
+}
+
+export function classifyRuntimeErrorReason(error: unknown): WorkerRuntimeErrorReason {
+  const message = formatErrorMessage(error);
+  if (message.includes('Initial prompt delivery failed')) {
+    return 'initial-prompt';
+  }
+  if (message.includes('Timed out waiting for worker startup')) {
+    return 'startup-timeout';
+  }
+  return 'post-create';
+}
+
+function getWorkerRuntimeErrorTitle(workerLabel: string, reason: WorkerRuntimeErrorReason): string {
+  switch (reason) {
+    case 'initial-prompt':
+      return `${workerLabel} failed to receive its initial task`;
+    case 'startup-timeout':
+    case 'post-create':
+      return `${workerLabel} failed during startup`;
+  }
+}
+
+function formatWorkerLabel(worker: WorkerInfo): string {
+  return worker.workerId != null
+    ? `Worker #${worker.workerId}`
+    : `Worker ${worker.sessionName}`;
+}
+
+function formatErrorMessage(error: unknown): string {
+  const raw = error instanceof Error
+    ? error.message
+    : String(error);
+  const redacted = redactText(raw || 'Unknown runtime error', ERROR_BODY_LIMIT);
+  return truncateText(redacted, ERROR_BODY_LIMIT);
+}
+
+function normalizeErrorSignature(message: string): string {
+  return message
+    .replace(/\b\d{4,}\b/g, '<number>')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}

--- a/src/providers/notificationDecorationProvider.ts
+++ b/src/providers/notificationDecorationProvider.ts
@@ -45,9 +45,10 @@ export class NotificationDecorationProvider implements vscode.FileDecorationProv
 
     const summary = buildSessionNotificationSummary(sessionName, this.notifications.getByTargetSession(sessionName));
     if (!summary) {
-      const completion = this.notifications.getLatestSourceCompletion?.(sessionName);
-      return completion
-        ? new vscode.FileDecoration('C', 'Hydra worker completed', getDecorationColor('complete'))
+      const attention = this.notifications.getLatestSourceAttention?.(sessionName) ||
+        this.notifications.getLatestSourceCompletion?.(sessionName);
+      return attention
+        ? new vscode.FileDecoration(getDecorationBadge(attention.kind), getDecorationTooltip(attention.kind), getDecorationColor(attention.kind))
         : undefined;
     }
 
@@ -60,6 +61,36 @@ export class NotificationDecorationProvider implements vscode.FileDecorationProv
 
   refresh(): void {
     this.onDidChangeEmitter.fire(undefined);
+  }
+}
+
+function getDecorationBadge(kind: NotificationKind): string {
+  switch (kind) {
+    case 'error':
+      return 'E';
+    case 'blocked':
+      return 'B';
+    case 'needs-input':
+      return '?';
+    case 'complete':
+      return 'C';
+    case 'info':
+      return 'i';
+  }
+}
+
+function getDecorationTooltip(kind: NotificationKind): string {
+  switch (kind) {
+    case 'error':
+      return 'Hydra worker error';
+    case 'blocked':
+      return 'Hydra worker blocked';
+    case 'needs-input':
+      return 'Hydra worker needs input';
+    case 'complete':
+      return 'Hydra worker completed';
+    case 'info':
+      return 'Hydra worker notification';
   }
 }
 

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -405,19 +405,18 @@ function getTargetUnreadNotifications(
     : [];
 }
 
-function getLatestSourceCompletionNotification(
+function getLatestSourceAttentionNotification(
   source: SessionNotificationSource | undefined,
   sessionName: string,
 ): HydraNotification | undefined {
   if (!source) return undefined;
-  const projected = source.getLatestSourceCompletion?.(sessionName);
+  const projected = source.getLatestSourceAttention?.(sessionName);
   if (projected) return projected;
   return source.getBySourceSession(sessionName)
     .filter(notification =>
-      notification.kind === 'complete' &&
       notification.targetSession !== sessionName,
     )
-    .sort(compareNotificationsNewestFirst)[0];
+    .sort(compareSourceAttentionNotifications)[0];
 }
 
 function compareNotificationsNewestFirst(a: HydraNotification, b: HydraNotification): number {
@@ -426,6 +425,26 @@ function compareNotificationsNewestFirst(a: HydraNotification, b: HydraNotificat
     return timeDiff;
   }
   return b.createdAt.localeCompare(a.createdAt);
+}
+
+const SOURCE_ATTENTION_KIND_PRIORITY: Record<NotificationKind, number> = {
+  error: 0,
+  blocked: 1,
+  'needs-input': 2,
+  complete: 3,
+  info: 4,
+};
+
+function compareSourceAttentionNotifications(a: HydraNotification, b: HydraNotification): number {
+  const newestDiff = compareNotificationsNewestFirst(a, b);
+  if (newestDiff !== 0) {
+    return newestDiff;
+  }
+  const priorityDiff = SOURCE_ATTENTION_KIND_PRIORITY[a.kind] - SOURCE_ATTENTION_KIND_PRIORITY[b.kind];
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+  return a.id.localeCompare(b.id);
 }
 
 function getNotificationThemeColor(kind: NotificationKind): vscode.ThemeColor {
@@ -903,7 +922,7 @@ export class GitStatusItem extends TmuxItem {
 export class TmuxSessionItem extends WorktreeItem {
   public readonly session: SessionWithStatus;
   public readonly detailItem: TmuxDetailItem;
-  public readonly completionNotification?: HydraNotification;
+  public readonly sourceAttentionNotification?: HydraNotification;
   public readonly gitStatusItem?: GitStatusItem;
 
   constructor(
@@ -920,7 +939,7 @@ export class TmuxSessionItem extends WorktreeItem {
     displayName?: string,
     isTaskWorker?: boolean,
     notificationSummary?: SessionNotificationSummary,
-    completionNotification?: HydraNotification
+    sourceAttentionNotification?: HydraNotification
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -941,7 +960,7 @@ export class TmuxSessionItem extends WorktreeItem {
 
     this.session = session;
     this.detailItem = new TmuxDetailItem(session, repoName, worktree, extensionUri);
-    this.completionNotification = completionNotification;
+    this.sourceAttentionNotification = sourceAttentionNotification;
 
     const descParts: string[] = [];
     if (this.description) descParts.push(String(this.description));
@@ -949,15 +968,15 @@ export class TmuxSessionItem extends WorktreeItem {
     if (agentType) descParts.push(`[${agentType}]`);
     if (notificationSummary) {
       descParts.push(formatWorkerStatusLabel(notificationSummary.kind));
-    } else if (completionNotification) {
-      descParts.push('completed');
+    } else if (sourceAttentionNotification) {
+      descParts.push(formatWorkerStatusLabel(sourceAttentionNotification.kind));
     }
     if (descParts.length > 0) this.description = descParts.join(' ');
     applyNotificationSummary(this, session.name, notificationSummary);
-    if (completionNotification && !notificationSummary) {
+    if (sourceAttentionNotification && !notificationSummary) {
       this.tooltip = buildNotificationTooltip(
-        completionNotification,
-        'This worker has produced a completion notification for its copilot.',
+        sourceAttentionNotification,
+        'This worker has a recent source notification for its copilot.',
       );
     }
 
@@ -971,7 +990,7 @@ export class TmuxSessionItem extends WorktreeItem {
 
 export class InactiveWorktreeItem extends WorktreeItem {
   public readonly detailItem: InactiveDetailItem;
-  public readonly completionNotification?: HydraNotification;
+  public readonly sourceAttentionNotification?: HydraNotification;
   public readonly gitStatusItem?: GitStatusItem;
   public readonly worktree: Worktree;
   public readonly targetSessionName: string;
@@ -989,7 +1008,7 @@ export class InactiveWorktreeItem extends WorktreeItem {
     displayName?: string,
     isTaskWorker?: boolean,
     notificationSummary?: SessionNotificationSummary,
-    completionNotification?: HydraNotification
+    sourceAttentionNotification?: HydraNotification
   ) {
     const branchLabel = branchLabelOverride || worktree.branch || (worktree.isMain ? 'main' : path.basename(worktree.path));
 
@@ -1011,21 +1030,21 @@ export class InactiveWorktreeItem extends WorktreeItem {
     this.worktree = worktree;
     this.targetSessionName = targetSessionName;
     this.detailItem = new InactiveDetailItem(worktree, repoName, targetSessionName, extensionUri);
-    this.completionNotification = completionNotification;
-    if (notificationSummary || completionNotification) {
+    this.sourceAttentionNotification = sourceAttentionNotification;
+    if (notificationSummary || sourceAttentionNotification) {
       const descParts = typeof this.description === 'string' && this.description.trim()
         ? [this.description]
         : [];
       descParts.push(notificationSummary
         ? formatWorkerStatusLabel(notificationSummary.kind)
-        : 'completed');
+        : formatWorkerStatusLabel(sourceAttentionNotification!.kind));
       this.description = descParts.join(' ');
     }
     applyNotificationSummary(this, targetSessionName, notificationSummary);
-    if (completionNotification && !notificationSummary) {
+    if (sourceAttentionNotification && !notificationSummary) {
       this.tooltip = buildNotificationTooltip(
-        completionNotification,
-        'This worker has produced a completion notification for its copilot.',
+        sourceAttentionNotification,
+        'This worker has a recent source notification for its copilot.',
       );
     }
 
@@ -1482,7 +1501,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           session, repoName, worktree, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName, false,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
         ));
       } else {
         const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
@@ -1505,7 +1524,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           worktree, repoName, w.sessionName, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, stoppedStatus, repoRoot, w.displayName, false,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
         ));
       }
     }
@@ -1541,7 +1560,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           session, repoName, worktree, isCurrentWs, false,
           this._extensionUri, label, w.agent, undefined, w.workerId, w.displayName, true,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
         ));
       } else {
         const stoppedStatus: SessionStatus = {
@@ -1561,7 +1580,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           worktree, repoName, w.sessionName, isCurrentWs, false,
           this._extensionUri, label, stoppedStatus, undefined, w.displayName, true,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceCompletionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
         ));
       }
     }

--- a/src/smoke/notificationStateServiceSmoke.ts
+++ b/src/smoke/notificationStateServiceSmoke.ts
@@ -279,6 +279,7 @@ async function testTargetSessionOperationsIgnoreSourceOnlyNotifications(): Promi
         service.initialize();
         assert.deepEqual(service.getByTargetSession('repo_worker').map(notification => notification.id), [targeted.id]);
         assert.deepEqual(service.getBySourceSession('repo_worker').map(notification => notification.id), [sourceOnly.id]);
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.id, sourceOnly.id);
         assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, sourceOnly.id);
 
         const read = service.markTargetSessionRead('repo_worker');
@@ -294,6 +295,9 @@ async function testTargetSessionOperationsIgnoreSourceOnlyNotifications(): Promi
         const clearedCopilotInbox = service.clear({ targetSession: 'repo_copilot' });
         assert.equal(clearedCopilotInbox.cleared, 1);
         assert.equal(service.getById(sourceOnly.id), undefined);
+        const projectedAttention = service.getLatestSourceAttention('repo_worker');
+        assert.equal(projectedAttention?.id, sourceOnly.id);
+        assert.equal(projectedAttention?.kind, 'complete');
         const projectedCompletion = service.getLatestSourceCompletion('repo_worker');
         assert.equal(projectedCompletion?.id, sourceOnly.id);
         assert.equal(projectedCompletion?.kind, 'complete');
@@ -423,6 +427,194 @@ async function testEventOnlyCompletionProjectionEmitsChange(): Promise<void> {
         assert.ok(changes > 0, 'event-only completion projection should emit a change');
       } finally {
         listener.dispose();
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testSourceAttentionProjectionUsesLatestStatus(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-source-attention-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const error = store.create({
+        kind: 'error',
+        title: 'Worker failed during startup',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+      await sleep(10);
+      const complete = store.create({
+        kind: 'complete',
+        title: 'Worker completed',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(
+          service.getLatestSourceAttention('repo_worker')?.id,
+          complete.id,
+          'latest source status should override an older higher-priority error',
+        );
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.kind, 'complete');
+        assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, complete.id);
+
+        await sleep(10);
+        new EventLog().append({
+          type: 'notify.created',
+          source: 'cli',
+          payload: {
+            notificationId: 'event-newer-error',
+            kind: 'error',
+            title: 'Worker failed after store completion',
+            targetSession: 'repo_copilot',
+            sourceSession: 'repo_worker',
+            actionType: 'open-session',
+            actionSession: 'repo_worker',
+          },
+        });
+        await waitFor(
+          () => service.getLatestSourceAttention('repo_worker')?.id === 'event-newer-error',
+          'event source attention overrides older stored notifications',
+        );
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.kind, 'error');
+        assert.equal(
+          service.getLatestSourceCompletion('repo_worker')?.id,
+          complete.id,
+          'completion compatibility projection should remain available while latest attention is error',
+        );
+
+        service.clear({ targetSession: 'repo_copilot' });
+        const projectedAttention = service.getLatestSourceAttention('repo_worker');
+        assert.equal(projectedAttention?.id, 'event-newer-error');
+        assert.equal(projectedAttention?.kind, 'error');
+
+        await sleep(10);
+        const latestComplete = store.create({
+          kind: 'complete',
+          title: 'Worker completed after error',
+          targetSession: 'repo_copilot',
+          sourceSession: 'repo_worker',
+          action: { type: 'open-session', session: 'repo_worker' },
+        }).notification;
+        await waitFor(
+          () => service.getLatestSourceAttention('repo_worker')?.id === latestComplete.id,
+          'latest complete source attention',
+        );
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.kind, 'complete');
+        assert.equal(
+          service.getLatestSourceCompletion('repo_worker')?.id,
+          latestComplete.id,
+          'completion compatibility projection should track latest completion',
+        );
+        assert.notEqual(error.id, latestComplete.id);
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testEventOnlyErrorProjectionEmitsChange(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-event-error-projection-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const service = createService();
+      let changes = 0;
+      const listener = service.onDidChange(() => { changes += 1; });
+      try {
+        service.initialize();
+        new EventLog().append({
+          type: 'notify.created',
+          source: 'cli',
+          payload: {
+            notificationId: 'event-only-error',
+            kind: 'error',
+            title: 'Worker failed during startup',
+            targetSession: 'repo_copilot',
+            sourceSession: 'repo_worker',
+            actionType: 'open-session',
+            actionSession: 'repo_worker',
+            workerId: 4,
+            branch: 'feat/error',
+            workdir: ctx.tmp,
+            agent: 'codex',
+          },
+        });
+
+        await waitFor(
+          () => service.getLatestSourceAttention('repo_worker')?.id === 'event-only-error',
+          'event-only error projection',
+        );
+        assert.equal(service.getSnapshot().totalCount, 0);
+        const projected = service.getLatestSourceAttention('repo_worker');
+        assert.equal(projected?.kind, 'error');
+        assert.equal(projected?.title, 'Worker failed during startup');
+        assert.equal(projected?.action?.session, 'repo_worker');
+        assert.equal(projected?.context?.workerId, 4);
+        assert.equal(projected?.context?.workdir, ctx.tmp);
+        assert.ok(changes > 0, 'event-only error projection should emit a change');
+      } finally {
+        listener.dispose();
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testStoredNotificationWinsOverDuplicateEventProjection(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-duplicate-event-projection-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const stored = store.create({
+        kind: 'error',
+        title: 'Worker failed during startup',
+        body: 'Full pane missing details remain in notifications.json',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.body, stored.body);
+
+        await sleep(10);
+        new EventLog().append({
+          type: 'notify.created',
+          source: 'cli',
+          payload: {
+            notificationId: stored.id,
+            kind: 'error',
+            title: 'Event projection should not replace store title',
+            body: 'Event body is redacted by the event sanitizer',
+            targetSession: 'repo_copilot',
+            sourceSession: 'repo_worker',
+            actionType: 'open-session',
+            actionSession: 'repo_worker',
+          },
+        });
+
+        service.markRead(stored.id);
+        const projected = service.getLatestSourceAttention('repo_worker');
+        assert.equal(projected?.id, stored.id);
+        assert.equal(projected?.title, stored.title);
+        assert.equal(projected?.body, stored.body);
+      } finally {
         service.dispose();
       }
     });
@@ -564,10 +756,11 @@ async function testCliEndToEnd(): Promise<void> {
         );
         await waitFor(() => service.getSnapshot().totalCount === 0, 'CLI clear reflected in service');
         assert.equal(
-          service.getLatestSourceCompletion('repo_worker')?.id,
+          service.getLatestSourceAttention('repo_worker')?.id,
           created.notification.id,
-          'worker completion projection should survive notification clear',
+          'worker source attention projection should survive notification clear',
         );
+        assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, created.notification.id);
       } finally {
         service.dispose();
       }
@@ -608,6 +801,9 @@ async function main(): Promise<void> {
   await testWatcherUpdatesFromNotificationFileOnly();
   await testBatchReadAndClearEventSources();
   await testEventOnlyCompletionProjectionEmitsChange();
+  await testSourceAttentionProjectionUsesLatestStatus();
+  await testEventOnlyErrorProjectionEmitsChange();
+  await testStoredNotificationWinsOverDuplicateEventProjection();
   await testInitializeSignatureWindow();
   await testDuplicateAndMalformedEventTolerance();
   await testCliEndToEnd();

--- a/src/smoke/workerAttentionNotificationSmoke.ts
+++ b/src/smoke/workerAttentionNotificationSmoke.ts
@@ -1,0 +1,231 @@
+/**
+ * Smoke test: worker attention notification publisher.
+ *
+ * Run: node out/smoke/workerAttentionNotificationSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { NotificationStore } from '../core/notifications';
+import type { WorkerInfo } from '../core/sessionManager';
+import {
+  awaitWorkerPostCreateOrPublishError,
+  classifyRuntimeErrorReason,
+  publishWorkerAttentionNotification,
+  publishWorkerRuntimeErrorNotification,
+} from '../core/workerAttentionNotifications';
+
+interface TestContext {
+  tmp: string;
+  home: string;
+  hydraHome: string;
+  configPath: string;
+}
+
+class FailingNotificationStore extends NotificationStore {
+  override create(): never {
+    throw new Error('simulated notification store failure');
+  }
+}
+
+function setupContext(): TestContext {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-attention-'));
+  const home = path.join(tmp, 'home');
+  const hydraHome = path.join(tmp, 'hydra');
+  const configPath = path.join(hydraHome, 'config.json');
+  fs.mkdirSync(home, { recursive: true });
+  return { tmp, home, hydraHome, configPath };
+}
+
+async function withProcessEnv<T>(ctx: TestContext, fn: () => Promise<T> | T): Promise<T> {
+  const previous = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    HYDRA_HOME: process.env.HYDRA_HOME,
+    HYDRA_CONFIG_PATH: process.env.HYDRA_CONFIG_PATH,
+    HYDRA_TELEMETRY: process.env.HYDRA_TELEMETRY,
+  };
+  process.env.HOME = ctx.home;
+  process.env.USERPROFILE = ctx.home;
+  process.env.HYDRA_HOME = ctx.hydraHome;
+  process.env.HYDRA_CONFIG_PATH = ctx.configPath;
+  process.env.HYDRA_TELEMETRY = '0';
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function createWorker(overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+  const now = new Date().toISOString();
+  return {
+    source: 'repo',
+    sessionName: 'repo_worker_feat_error',
+    displayName: 'feat/error',
+    workerId: 4,
+    repo: 'hydra',
+    repoRoot: '/tmp/hydra',
+    branch: 'feat/error',
+    slug: 'feat-error',
+    status: 'running',
+    attached: false,
+    agent: 'codex',
+    workdir: '/tmp/hydra-worktree',
+    tmuxSession: 'repo_worker_feat_error',
+    createdAt: now,
+    lastSeenAt: now,
+    sessionId: null,
+    copilotSessionName: 'repo_copilot',
+    ...overrides,
+  };
+}
+
+function readEvents(ctx: TestContext): Array<{ type?: string; source?: string; payload?: Record<string, unknown> }> {
+  const eventsPath = path.join(ctx.hydraHome, 'events.jsonl');
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+  return fs.readFileSync(eventsPath, 'utf-8')
+    .split('\n')
+    .filter(line => line.trim().length > 0)
+    .map(line => JSON.parse(line) as { type?: string; source?: string; payload?: Record<string, unknown> });
+}
+
+async function testRuntimeErrorNotification(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, async () => {
+      const worker = createWorker();
+      const error = new Error('Initial prompt delivery failed for "repo_worker_feat_error": pane missing');
+
+      const first = publishWorkerRuntimeErrorNotification(worker, error, { eventSource: 'cli' });
+      assert.equal(first.created, true);
+      assert.equal(first.notification.kind, 'error');
+      assert.equal(first.notification.targetSession, 'repo_copilot');
+      assert.equal(first.notification.sourceSession, worker.sessionName);
+      assert.equal(first.notification.action?.type, 'open-session');
+      assert.equal(first.notification.action?.session, worker.sessionName);
+      assert.equal(first.notification.context?.workerId, 4);
+      assert.equal(first.notification.context?.branch, 'feat/error');
+      assert.equal(first.notification.context?.workdir, '/tmp/hydra-worktree');
+      assert.equal(first.notification.context?.agent, 'codex');
+      assert.match(first.notification.title, /failed to receive its initial task/);
+      assert.match(first.notification.body, /pane missing/);
+      assert.match(first.notification.dedupeKey || '', /^worker-error:repo_worker_feat_error:initial-prompt:/);
+
+      const duplicate = publishWorkerRuntimeErrorNotification(worker, error, { eventSource: 'cli' });
+      assert.equal(duplicate.created, false);
+      assert.ok(duplicate.notification);
+      assert.equal(duplicate.notification.id, first.notification.id);
+
+      const stored = new NotificationStore().list().notifications;
+      assert.equal(stored.length, 1);
+      assert.equal(stored[0].id, first.notification.id);
+
+      const events = readEvents(ctx).filter(event => event.type === 'notify.created');
+      assert.equal(events.length, 1);
+      assert.equal(events[0].source, 'cli');
+      assert.equal(events[0].payload?.notificationId, first.notification.id);
+      assert.equal(events[0].payload?.kind, 'error');
+      assert.equal(events[0].payload?.targetSession, 'repo_copilot');
+      assert.equal(events[0].payload?.sourceSession, worker.sessionName);
+      assert.equal(events[0].payload?.actionType, 'open-session');
+      assert.equal(events[0].payload?.actionSession, worker.sessionName);
+      assert.equal(events[0].payload?.workerId, 4);
+      assert.equal(events[0].payload?.branch, 'feat/error');
+      assert.equal(events[0].payload?.workdir, '/tmp/hydra-worktree');
+      assert.equal(events[0].payload?.agent, 'codex');
+
+      assert.equal(classifyRuntimeErrorReason(error), 'initial-prompt');
+      assert.equal(
+        classifyRuntimeErrorReason(new Error('Timed out waiting for worker startup for "repo_worker" after 100ms')),
+        'startup-timeout',
+      );
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testMissingCopilotSkips(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, async () => {
+      const skipped = publishWorkerRuntimeErrorNotification(
+        createWorker({ copilotSessionName: null }),
+        new Error('Initial prompt delivery failed'),
+      );
+      assert.equal(skipped.created, false);
+      assert.equal(skipped.skipped, 'missing-target');
+      assert.equal(new NotificationStore().list().notifications.length, 0);
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testStoreFailureDoesNotThrow(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, async () => {
+      const result = publishWorkerAttentionNotification({
+        kind: 'error',
+        targetCopilotSession: 'repo_copilot',
+        sourceWorkerSession: 'repo_worker',
+        title: 'Worker failed',
+        store: new FailingNotificationStore(),
+      });
+      assert.equal(result.created, false);
+      assert.equal(result.skipped, 'store-failed');
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testPostCreateHelperPublishesAndRethrows(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, async () => {
+      const worker = createWorker({ sessionName: 'repo_worker_start_failed' });
+      const error = new Error('Timed out waiting for worker startup for "repo_worker_start_failed" after 30000ms');
+
+      await assert.rejects(
+        () => awaitWorkerPostCreateOrPublishError(worker, Promise.reject(error), { eventSource: 'cli' }),
+        /Timed out waiting for worker startup/,
+      );
+
+      const stored = new NotificationStore().list().notifications;
+      assert.equal(stored.length, 1);
+      assert.equal(stored[0].kind, 'error');
+      assert.equal(stored[0].sourceSession, worker.sessionName);
+      assert.equal(stored[0].targetSession, worker.copilotSessionName);
+      assert.match(stored[0].title, /failed during startup/);
+      assert.match(stored[0].dedupeKey || '', /^worker-error:repo_worker_start_failed:startup-timeout:/);
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  await testRuntimeErrorNotification();
+  await testMissingCopilotSkips();
+  await testStoreFailureDoesNotThrow();
+  await testPostCreateHelperPublishesAndRethrows();
+  console.log('workerAttentionNotificationSmoke: ok');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- emit structured `kind=error` notifications when observed worker post-create/startup paths fail
- surface worker error attention in VS Code rows/decorations while preserving target copilot unread behavior
- extend notification state projection so event-only error notifications work without replacing full stored notification details

## Details

This wires deterministic Hydra-owned worker runtime failures into the existing notification/event control plane. Worker create/start, archive restore, VS Code worker creation/resume, and shared worker import now use a shared post-create failure helper that publishes a deduped error notification to the owning copilot when available, then preserves the original failure behavior for the caller.

The notification state service now projects all notification kinds as source attention, keeps completion compatibility, and prefers `notifications.json` records over same-id event projections so event redaction does not erase richer local notification details.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:worker-attention-notification`
- `npm run smoke:notification-state`
- `npm run smoke:share`
- `npm test`
- `git diff --check`
- real isolated VS Code Extension Development Host E2E: created a copilot, triggered a real worker initial-prompt failure through tmux, verified `notifications.json`, `events.jsonl`, Copilot error inbox row, Worker error row, open-session action, and read transition

Closes #250
