### PR TITLE
Add worker lifecycle state projection

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -130,10 +130,14 @@ Worker entries include:
 
 `status` is the tmux/session lifecycle (`running` or `stopped`). `runtimeState`
 is the current worker runtime projection. Its `state` is one of `unknown`,
-`running`, `idle`, `needs-input`, or `error`; `complete` remains a notification
-event and usually projects runtime to `idle`. When the tmux session is stopped,
-`runtimeState.state` is reported as `unknown` so stale agent state is not shown
-as current.
+`starting`, `running`, `idle`, `needs-input`, `approving`, `blocked`, `error`, or
+`stopped`; `complete` remains a notification event and usually projects runtime
+to `idle`. When the tmux session is stopped, `runtimeState.state` is reported as
+`stopped` so stale agent hook state is not shown as current.
+
+`starting` and `approving` are reserved lifecycle states for future runtime Feed
+and approval integrations. Current PR3 producers primarily emit `running`,
+`idle`, `needs-input`, `blocked`, `error`, and `stopped`.
 
 ### `hydra session list --json`
 
@@ -198,7 +202,9 @@ Worker projections include `workerId`, `source` (`"repo"` or `"directory"`),
 `type` (`"code"` or `"task"`), `repo`, `repoRoot`, `branch`, `slug`,
 `managedWorkdir`, and `copilotSessionName`. Copilot projections include `mode`.
 `runtimeState` is emitted only for active workers; archived records never reuse
-runtime state keyed by a matching session name.
+runtime state keyed by a matching session name. Active stopped workers project to
+`runtimeState.state: "stopped"` even when the durable runtime store still has an
+older hook or notification state.
 
 `agent-sessions.json` is a rebuildable query surface, not a source of truth.
 Consumers should treat `sessions.json`, `archive.json`, runtime state, and native
@@ -412,7 +418,7 @@ Notification records include:
 
 `--dedupe-key` is an idempotency key. When it matches an existing notification,
 the command returns the existing record and does not append a duplicate.
-`complete`, `needs-input`, and `error` notifications also update
+`complete`, `needs-input`, `blocked`, and `error` notifications also update
 `HYDRA_HOME/worker-runtime-state.json` for the `sourceSession`; reading,
 opening, or clearing notifications does not clear runtime state.
 

--- a/docs/control-plane-roadmap.md
+++ b/docs/control-plane-roadmap.md
@@ -46,9 +46,16 @@ injecting messages.
    - Keep depth over breadth: Claude, Codex, Gemini, Sudo Code, and custom.
 
 6. **Agent lifecycle (#233)**
-   - Track `running`, `idle`, `needs-input`, `error`, `blocked`, and `unknown`.
+   - Track `unknown`, `starting`, `running`, `idle`, `needs-input`, `approving`,
+     `blocked`, `error`, and `stopped`.
+   - Keep the stored runtime snapshot separate from the visible projection used
+     by CLI, session index, and UI consumers.
+   - Treat `starting` and `approving` as reserved states until Feed and approval
+     producers can attach request identity, timeout, and resolution semantics.
    - Feed lifecycle changes from worker creation, hooks, notification events, and
-     stop/delete paths.
+     explicit stop/delete paths.
+   - Defer durable approval Feed, live event streaming, and daemon/socket APIs to
+     later control-plane layers.
 
 7. **Agent session index (#234)**
    - Persist the mapping between Hydra sessions, native agent sessions, transcript

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -4,19 +4,9 @@ import { isDirectoryWorker, isRepoWorker, SessionManager } from '../../core/sess
 import { resolveAgentSessionFile } from '../../core/path';
 import { outputResult, outputError, type OutputOpts } from '../output';
 import {
+  projectWorkerRuntimeState,
   WorkerRuntimeStateStore,
-  type WorkerRuntimeSnapshot,
-  type WorkerRuntimeSignalOrigin,
-  type WorkerRuntimeState,
 } from '../../core/workerRuntimeState';
-
-interface WorkerRuntimeCliSnapshot {
-  state: WorkerRuntimeState;
-  updatedAt: string | null;
-  origin: WorkerRuntimeSignalOrigin;
-  reason?: string;
-  notificationId?: string;
-}
 
 export function registerListCommand(program: Command): void {
   program
@@ -57,7 +47,7 @@ export function registerListCommand(program: Command): void {
             branch: w.branch || null,
             agent: w.agent,
             status: w.status,
-            runtimeState: formatWorkerRuntimeState(w.status, runtimeStateStore.get(w.sessionName || w.tmuxSession)),
+            runtimeState: projectWorkerRuntimeState(w.status, runtimeStateStore.get(w.sessionName || w.tmuxSession)),
             attached: w.attached,
             workdir: w.workdir || null,
             managedWorkdir: w.managedWorkdir === true,
@@ -157,35 +147,4 @@ export function registerListCommand(program: Command): void {
         outputError(error, globalOpts);
       }
     });
-}
-
-function formatWorkerRuntimeState(
-  workerStatus: 'running' | 'stopped',
-  snapshot: WorkerRuntimeSnapshot | undefined,
-): WorkerRuntimeCliSnapshot {
-  if (workerStatus === 'stopped') {
-    return {
-      state: 'unknown',
-      updatedAt: null,
-      origin: 'session-manager',
-      reason: 'session-stopped',
-    };
-  }
-
-  if (!snapshot) {
-    return {
-      state: 'unknown',
-      updatedAt: null,
-      origin: 'session-manager',
-      reason: 'no-runtime-signal',
-    };
-  }
-
-  return {
-    state: snapshot.state,
-    updatedAt: snapshot.updatedAt,
-    origin: snapshot.origin,
-    reason: snapshot.reason,
-    notificationId: snapshot.notificationId,
-  };
 }

--- a/src/core/agentSessionIndex.ts
+++ b/src/core/agentSessionIndex.ts
@@ -18,23 +18,16 @@ import {
   toCanonicalPath,
 } from './path';
 import {
+  projectWorkerRuntimeState,
   WorkerRuntimeStateStore,
-  type WorkerRuntimeSignalOrigin,
-  type WorkerRuntimeSnapshot,
-  type WorkerRuntimeState,
+  type WorkerRuntimeProjection,
 } from './workerRuntimeState';
 
 export type AgentSessionIndexSource = 'active' | 'archive';
 export type AgentSessionRole = 'worker' | 'copilot';
 export type AgentSessionStatus = 'running' | 'stopped' | 'archived';
 
-export interface AgentSessionRuntimeStateProjection {
-  state: WorkerRuntimeState;
-  updatedAt: string | null;
-  origin: WorkerRuntimeSignalOrigin;
-  reason?: string;
-  notificationId?: string;
-}
+export type AgentSessionRuntimeStateProjection = WorkerRuntimeProjection;
 
 export interface AgentSessionWorkerProjection {
   workerId: number | null;
@@ -197,7 +190,7 @@ export class AgentSessionIndexStore {
       archivedAt: null,
       archiveOrdinal: null,
       worker: projectWorker(worker),
-      runtimeState: projectRuntimeState(worker.status, this.runtimeStateStore.get(worker.sessionName)),
+      runtimeState: projectWorkerRuntimeState(worker.status, this.runtimeStateStore.get(worker.sessionName)),
     };
   }
 
@@ -457,37 +450,6 @@ function projectWorker(worker: WorkerInfo): AgentSessionWorkerProjection {
     slug: worker.slug || null,
     managedWorkdir: worker.managedWorkdir === true,
     copilotSessionName: worker.copilotSessionName || null,
-  };
-}
-
-function projectRuntimeState(
-  workerStatus: 'running' | 'stopped',
-  snapshot: WorkerRuntimeSnapshot | undefined,
-): AgentSessionRuntimeStateProjection {
-  if (workerStatus === 'stopped') {
-    return {
-      state: 'unknown',
-      updatedAt: null,
-      origin: 'session-manager',
-      reason: 'session-stopped',
-    };
-  }
-
-  if (!snapshot) {
-    return {
-      state: 'unknown',
-      updatedAt: null,
-      origin: 'session-manager',
-      reason: 'no-runtime-signal',
-    };
-  }
-
-  return {
-    state: snapshot.state,
-    updatedAt: snapshot.updatedAt,
-    origin: snapshot.origin,
-    reason: snapshot.reason,
-    notificationId: snapshot.notificationId,
   };
 }
 

--- a/src/core/sessionManager.ts
+++ b/src/core/sessionManager.ts
@@ -1033,6 +1033,7 @@ export class SessionManager {
     });
     const stoppedWorker = this.readSessionState().workers[sessionName];
     if (stoppedWorker) {
+      this.updateWorkerRuntimeState(stoppedWorker, 'stopped', 'worker-stopped');
       this.emitWorkerEvent('worker.stopped', stoppedWorker);
     }
   }

--- a/src/core/workerRuntimeState.ts
+++ b/src/core/workerRuntimeState.ts
@@ -5,7 +5,16 @@ import { EventLog, type HydraEventSource } from './events';
 import { getHydraHome } from './path';
 import { logger } from './logger';
 
-export type WorkerRuntimeState = 'unknown' | 'running' | 'idle' | 'needs-input' | 'error';
+export type WorkerRuntimeState =
+  | 'unknown'
+  | 'starting'
+  | 'running'
+  | 'idle'
+  | 'needs-input'
+  | 'approving'
+  | 'blocked'
+  | 'error'
+  | 'stopped';
 
 export type WorkerRuntimeSignalOrigin =
   | 'session-manager'
@@ -24,6 +33,14 @@ export interface WorkerRuntimeSnapshot {
   workerId?: number;
   agent?: string | null;
   workdir?: string | null;
+}
+
+export interface WorkerRuntimeProjection {
+  state: WorkerRuntimeState;
+  updatedAt: string | null;
+  origin: WorkerRuntimeSignalOrigin;
+  reason?: string;
+  notificationId?: string;
 }
 
 export interface SetWorkerRuntimeStateInput {
@@ -282,6 +299,8 @@ export function runtimeStateForNotificationKind(kind: string): WorkerRuntimeStat
       return 'idle';
     case 'needs-input':
       return 'needs-input';
+    case 'blocked':
+      return 'blocked';
     case 'error':
       return 'error';
     default:
@@ -291,6 +310,47 @@ export function runtimeStateForNotificationKind(kind: string): WorkerRuntimeStat
 
 export function cloneWorkerRuntimeSnapshot(snapshot: WorkerRuntimeSnapshot): WorkerRuntimeSnapshot {
   return cloneSnapshot(snapshot);
+}
+
+export function projectWorkerRuntimeState(
+  workerStatus: 'running' | 'stopped',
+  snapshot: WorkerRuntimeSnapshot | undefined,
+): WorkerRuntimeProjection {
+  if (workerStatus === 'stopped') {
+    if (snapshot?.state === 'stopped') {
+      return {
+        state: snapshot.state,
+        updatedAt: snapshot.updatedAt,
+        origin: snapshot.origin,
+        reason: snapshot.reason,
+        notificationId: snapshot.notificationId,
+      };
+    }
+
+    return {
+      state: 'stopped',
+      updatedAt: null,
+      origin: 'session-manager',
+      reason: 'session-stopped',
+    };
+  }
+
+  if (!snapshot) {
+    return {
+      state: 'unknown',
+      updatedAt: null,
+      origin: 'session-manager',
+      reason: 'no-runtime-signal',
+    };
+  }
+
+  return {
+    state: snapshot.state,
+    updatedAt: snapshot.updatedAt,
+    origin: snapshot.origin,
+    reason: snapshot.reason,
+    notificationId: snapshot.notificationId,
+  };
 }
 
 function normalizeInput(input: SetWorkerRuntimeStateInput): WorkerRuntimeSnapshot {
@@ -389,9 +449,13 @@ function cloneSnapshot(snapshot: WorkerRuntimeSnapshot): WorkerRuntimeSnapshot {
 
 function isWorkerRuntimeState(value: unknown): value is WorkerRuntimeState {
   return value === 'unknown'
+    || value === 'starting'
     || value === 'running'
     || value === 'idle'
     || value === 'needs-input'
+    || value === 'approving'
+    || value === 'blocked'
+    || value === 'stopped'
     || value === 'error';
 }
 

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -16,7 +16,12 @@ import {
 } from '../core/sessionNotificationSummary';
 import type { HydraNotification, NotificationKind } from '../core/notifications';
 import { getNotificationDecorationUri } from './notificationDecorationProvider';
-import type { WorkerRuntimeSnapshot, WorkerRuntimeState } from '../core/workerRuntimeState';
+import {
+  projectWorkerRuntimeState,
+  type WorkerRuntimeProjection,
+  type WorkerRuntimeSnapshot,
+  type WorkerRuntimeState,
+} from '../core/workerRuntimeState';
 import type { WorkerRuntimeStateSource } from '../core/workerRuntimeStateService';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
@@ -391,7 +396,7 @@ function applyNotificationSummary(
 
 function appendWorkerRuntimeTooltip(
   existing: string | vscode.MarkdownString | undefined,
-  runtimeState: WorkerRuntimeSnapshot | undefined,
+  runtimeState: WorkerRuntimeProjection | undefined,
 ): vscode.MarkdownString {
   const md = existing instanceof vscode.MarkdownString
     ? existing
@@ -527,21 +532,35 @@ function getWorkerRuntimeThemeIcon(state: WorkerRuntimeState | undefined): vscod
   switch (state) {
     case 'running':
       return new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.green'));
+    case 'starting':
+      return new vscode.ThemeIcon('sync~spin', new vscode.ThemeColor('charts.blue'));
     case 'idle':
       return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.green'));
+    case 'approving':
     case 'needs-input':
       return new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
+    case 'blocked':
+      return new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.purple'));
     case 'error':
       return new vscode.ThemeIcon('error', new vscode.ThemeColor('charts.red'));
+    case 'stopped':
+      return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('foreground'));
     case 'unknown':
     default:
       return new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('foreground'));
   }
 }
 
-function formatWorkerRuntimeStateLabel(runtimeState: WorkerRuntimeSnapshot | undefined): string {
+function formatWorkerRuntimeStateLabel(runtimeState: WorkerRuntimeProjection | undefined): string {
   const state = runtimeState?.state ?? 'unknown';
-  return state === 'needs-input' ? 'needs input' : state;
+  switch (state) {
+    case 'needs-input':
+      return 'needs input';
+    case 'approving':
+      return 'approving';
+    default:
+      return state;
+  }
 }
 
 function formatNotificationDetailLabel(notification: HydraNotification): string {
@@ -798,7 +817,7 @@ export class WorktreeItem extends TmuxItem {
     isMainWorktree?: boolean;
     isTaskWorker?: boolean;
     notificationSummary?: SessionNotificationSummary;
-    runtimeState?: WorkerRuntimeSnapshot;
+    runtimeState?: WorkerRuntimeProjection;
   }) {
     const displayLabel = opts.isTaskWorker
       ? (opts.displayName || opts.branchLabel)
@@ -827,11 +846,11 @@ export class WorktreeItem extends TmuxItem {
     if (opts.hasTmux) {
       this.iconPath = getWorkerRuntimeThemeIcon(opts.runtimeState?.state);
     } else if (opts.isTaskWorker) {
-      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.green'));
+      this.iconPath = getWorkerRuntimeThemeIcon(opts.runtimeState?.state ?? 'stopped');
     } else if (!opts.hasGit) {
       this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
     } else {
-      this.iconPath = new vscode.ThemeIcon('circle-outline', new vscode.ThemeColor('charts.green'));
+      this.iconPath = getWorkerRuntimeThemeIcon(opts.runtimeState?.state ?? 'stopped');
     }
     applyNotificationSummary(this, opts.sessionName, opts.notificationSummary);
   }
@@ -1007,7 +1026,7 @@ export class TmuxSessionItem extends WorktreeItem {
     isTaskWorker?: boolean,
     notificationSummary?: SessionNotificationSummary,
     sourceAttentionNotification?: HydraNotification,
-    runtimeState?: WorkerRuntimeSnapshot
+    runtimeState?: WorkerRuntimeProjection
   ) {
     const isRoot = Boolean(worktree?.isMain);
     const branchLabel = branchLabelOverride || worktree?.branch || (isRoot ? 'main' : session.slug);
@@ -1079,7 +1098,8 @@ export class InactiveWorktreeItem extends WorktreeItem {
     displayName?: string,
     isTaskWorker?: boolean,
     notificationSummary?: SessionNotificationSummary,
-    sourceAttentionNotification?: HydraNotification
+    sourceAttentionNotification?: HydraNotification,
+    runtimeState?: WorkerRuntimeProjection
   ) {
     const branchLabel = branchLabelOverride || worktree.branch || (worktree.isMain ? 'main' : path.basename(worktree.path));
 
@@ -1094,7 +1114,8 @@ export class InactiveWorktreeItem extends WorktreeItem {
       hasGit,
       hasTmux: false,
       isMainWorktree: worktree.isMain,
-      isTaskWorker
+      isTaskWorker,
+      runtimeState
     });
 
     this.contextValue = isTaskWorker ? 'inactiveTaskWorkerItem' : 'inactiveWorkerItem';
@@ -1102,15 +1123,16 @@ export class InactiveWorktreeItem extends WorktreeItem {
     this.targetSessionName = targetSessionName;
     this.detailItem = new InactiveDetailItem(worktree, repoName, targetSessionName, extensionUri);
     this.sourceAttentionNotification = sourceAttentionNotification;
+    const descParts = typeof this.description === 'string' && this.description.trim()
+      ? [this.description]
+      : [];
+    descParts.push(formatWorkerRuntimeStateLabel(runtimeState));
     if (notificationSummary || sourceAttentionNotification) {
-      const descParts = typeof this.description === 'string' && this.description.trim()
-        ? [this.description]
-        : [];
       descParts.push(notificationSummary
         ? formatWorkerStatusLabel(notificationSummary.kind)
         : formatWorkerStatusLabel(sourceAttentionNotification!.kind));
-      this.description = descParts.join(' ');
     }
+    this.description = descParts.join(' ');
     applyNotificationSummary(this, targetSessionName, notificationSummary);
     if (sourceAttentionNotification && !notificationSummary) {
       this.tooltip = buildNotificationTooltip(
@@ -1118,6 +1140,7 @@ export class InactiveWorktreeItem extends WorktreeItem {
         'This worker has a recent source notification for its copilot.',
       );
     }
+    this.tooltip = appendWorkerRuntimeTooltip(this.tooltip, runtimeState);
 
     if (gitStatusOverride) {
       const hasGitChanges = gitStatusOverride.commitsAhead > 0 || gitStatusOverride.gitModified > 0 ||
@@ -1556,6 +1579,10 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
       const worktreeBranch = branchLabel;
 
       const pr = prMap.get(branchLabel);
+      const runtimeState = projectWorkerRuntimeState(
+        w.status,
+        getWorkerRuntimeState(this.runtimeStates, w.sessionName),
+      );
 
       if (w.status === 'running') {
         const status = await getSessionStatus(w.sessionName, w.workdir);
@@ -1579,7 +1606,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           this._extensionUri, branchLabel, w.agent, repoRoot, w.workerId, w.displayName, false,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
           getLatestSourceAttentionNotification(this.notifications, w.sessionName),
-          getWorkerRuntimeState(this.runtimeStates, w.sessionName)
+          runtimeState
         ));
       } else {
         const worktree: Worktree = { path: w.workdir, branch: worktreeBranch, isMain: false };
@@ -1602,7 +1629,8 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           worktree, repoName, w.sessionName, isCurrentWs, hasGit,
           this._extensionUri, branchLabel, stoppedStatus, repoRoot, w.displayName, false,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName),
+          runtimeState
         ));
       }
     }
@@ -1621,6 +1649,10 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
         : false;
       const label = w.displayName || w.slug || path.basename(w.workdir);
       const worktree: Worktree = { path: w.workdir, branch: label, isMain: false };
+      const runtimeState = projectWorkerRuntimeState(
+        w.status,
+        getWorkerRuntimeState(this.runtimeStates, w.sessionName),
+      );
 
       if (w.status === 'running') {
         const status = await getSessionStatus(w.sessionName);
@@ -1639,7 +1671,7 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           this._extensionUri, label, w.agent, undefined, w.workerId, w.displayName, true,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
           getLatestSourceAttentionNotification(this.notifications, w.sessionName),
-          getWorkerRuntimeState(this.runtimeStates, w.sessionName)
+          runtimeState
         ));
       } else {
         const stoppedStatus: SessionStatus = {
@@ -1659,7 +1691,8 @@ export class WorkerProvider implements vscode.TreeDataProvider<TmuxItem> {
           worktree, repoName, w.sessionName, isCurrentWs, false,
           this._extensionUri, label, stoppedStatus, undefined, w.displayName, true,
           getTargetSessionNotificationSummary(this.notifications, w.sessionName),
-          getLatestSourceAttentionNotification(this.notifications, w.sessionName)
+          getLatestSourceAttentionNotification(this.notifications, w.sessionName),
+          runtimeState
         ));
       }
     }

--- a/src/smoke/agentSessionIndexSmoke.ts
+++ b/src/smoke/agentSessionIndexSmoke.ts
@@ -67,6 +67,7 @@ interface JsonError {
 }
 
 const ACTIVE_WORKER_SESSION = 'hydra-index-worker';
+const STOPPED_WORKER_SESSION = 'hydra-index-stopped-worker';
 const ACTIVE_COPILOT_SESSION = 'hydra-index-copilot';
 const ARCHIVED_SESSION = 'hydra-index-archived';
 const SUDO_ARCHIVED_SESSION = 'hydra-index-sudo-archived';
@@ -176,8 +177,29 @@ function seedSessions(hydraHome: string, workdir: string): void {
         agentSessionFile: null,
         copilotSessionName: ACTIVE_COPILOT_SESSION,
       },
+      [STOPPED_WORKER_SESSION]: {
+        source: 'repo',
+        sessionName: STOPPED_WORKER_SESSION,
+        displayName: 'index-stopped-worker',
+        workerId: 8,
+        repo: 'fixture',
+        repoRoot: workdir,
+        branch: 'feature/stopped-index',
+        slug: 'feature-stopped-index',
+        status: 'stopped',
+        attached: false,
+        agent: 'claude',
+        workdir,
+        managedWorkdir: false,
+        tmuxSession: STOPPED_WORKER_SESSION,
+        createdAt: now,
+        lastSeenAt: now,
+        sessionId: null,
+        agentSessionFile: null,
+        copilotSessionName: ACTIVE_COPILOT_SESSION,
+      },
     },
-    nextWorkerId: 8,
+    nextWorkerId: 9,
     updatedAt: now,
   };
   fs.writeFileSync(path.join(hydraHome, 'sessions.json'), `${JSON.stringify(sessions, null, 2)}\n`, 'utf-8');
@@ -295,6 +317,17 @@ function seedRuntimeState(hydraHome: string, workdir: string): void {
         agent: 'claude',
         workdir,
       },
+      [STOPPED_WORKER_SESSION]: {
+        sessionName: STOPPED_WORKER_SESSION,
+        state: 'needs-input',
+        updatedAt: new Date().toISOString(),
+        origin: 'hook',
+        reason: 'stale-permission-request',
+        notificationId: 'notification-stopped',
+        workerId: 8,
+        agent: 'claude',
+        workdir,
+      },
     },
   };
   fs.writeFileSync(path.join(hydraHome, 'worker-runtime-state.json'), `${JSON.stringify(runtime, null, 2)}\n`, 'utf-8');
@@ -388,12 +421,12 @@ async function main(): Promise<void> {
       runCli(['session', 'rebuild', '--json'], ctx.env),
     );
     assert.equal(rebuild.status, 'rebuilt');
-    assert.equal(rebuild.count, 6, 'rebuild includes active rows and all archive history');
+    assert.equal(rebuild.count, 7, 'rebuild includes active rows and all archive history');
     assert.equal(rebuild.file, path.join(ctx.hydraHome, 'agent-sessions.json'));
 
     const list = parseJson<SessionListJson>(runCli(['session', 'list', '--json'], ctx.env));
     assert.equal(list.status, 'ok');
-    assert.equal(list.count, 4, 'default list uses active-wins plus latest archived per inactive session');
+    assert.equal(list.count, 5, 'default list uses active-wins plus latest archived per inactive session');
     assert.ok(list.sessions.some(entry => entry.hydraSessionName === ACTIVE_WORKER_SESSION && entry.source === 'active'));
     assert.ok(!list.sessions.some(entry => entry.hydraSessionName === ACTIVE_WORKER_SESSION && entry.source === 'archive'));
     assert.equal(list.sessions.filter(entry => entry.hydraSessionName === ARCHIVED_SESSION).length, 1);
@@ -402,16 +435,22 @@ async function main(): Promise<void> {
     const worker = list.sessions.find(entry => entry.hydraSessionName === ACTIVE_WORKER_SESSION);
     assert.equal(worker?.runtimeState?.state, 'needs-input');
     assert.equal(worker?.runtimeState?.origin, 'hook');
+    const stoppedWorker = list.sessions.find(entry => entry.hydraSessionName === STOPPED_WORKER_SESSION);
+    assert.equal(stoppedWorker?.status, 'stopped');
+    assert.equal(stoppedWorker?.runtimeState?.state, 'stopped');
+    assert.equal(stoppedWorker?.runtimeState?.origin, 'session-manager');
+    assert.equal(stoppedWorker?.runtimeState?.reason, 'session-stopped');
     const archived = list.sessions.find(entry => entry.hydraSessionName === ARCHIVED_SESSION);
     assert.equal(archived?.runtimeState, undefined, 'archived rows must not reuse stale runtime state');
 
     const all = parseJson<SessionListJson>(runCli(['session', 'list', '--all', '--json'], ctx.env));
-    assert.equal(all.count, 6);
+    assert.equal(all.count, 7);
     assert.equal(all.sessions.filter(entry => entry.hydraSessionName === ARCHIVED_SESSION).length, 2);
 
     const workerOnly = parseJson<SessionListJson>(runCli(['session', 'list', '--role', 'worker', '--source', 'active', '--json'], ctx.env));
-    assert.equal(workerOnly.count, 1);
-    assert.equal(workerOnly.sessions[0].hydraSessionName, ACTIVE_WORKER_SESSION);
+    assert.equal(workerOnly.count, 2);
+    assert.ok(workerOnly.sessions.some(entry => entry.hydraSessionName === ACTIVE_WORKER_SESSION));
+    assert.ok(workerOnly.sessions.some(entry => entry.hydraSessionName === STOPPED_WORKER_SESSION));
 
     const inspectCopilotBySession = parseJson<InspectJson>(runCli(['session', 'inspect', ACTIVE_COPILOT_SESSION, '--json'], ctx.env));
     assert.equal(inspectCopilotBySession.session.recordId, `active:copilot:${ACTIVE_COPILOT_SESSION}`);

--- a/src/smoke/notifyCliSmoke.ts
+++ b/src/smoke/notifyCliSmoke.ts
@@ -215,6 +215,53 @@ function main(): void {
     assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4]);
     assert.equal(fs.readFileSync(eventsPath, 'utf-8').includes('Branch: feat/auth'), false);
 
+    const blocked = parseStdoutJson<{
+      status: string;
+      created: boolean;
+      notification: {
+        id: string;
+        kind: string;
+        sourceSession: string | null;
+      };
+    }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'blocked_copilot',
+        '--from',
+        'blocked_worker',
+        '--kind',
+        'blocked',
+        '--title',
+        'Worker is blocked',
+        '--body',
+        'Waiting on an external dependency',
+        '--worker-id',
+        '8',
+        '--branch',
+        'feat/blocked',
+        '--workdir',
+        ctx.tmp,
+        '--agent',
+        'claude',
+        '--json',
+      ], ctx.env),
+      'hydra notify create blocked --json',
+    );
+    assert.equal(blocked.status, 'created');
+    assert.equal(blocked.created, true);
+    assert.equal(blocked.notification.kind, 'blocked');
+    assert.equal(blocked.notification.sourceSession, 'blocked_worker');
+
+    const runtimePath = path.join(ctx.hydraHome, 'worker-runtime-state.json');
+    const runtime = JSON.parse(fs.readFileSync(runtimePath, 'utf-8')) as {
+      workers: Record<string, { state: string; reason?: string; notificationId?: string }>;
+    };
+    assert.equal(runtime.workers.blocked_worker.state, 'blocked');
+    assert.equal(runtime.workers.blocked_worker.reason, 'blocked');
+    assert.equal(runtime.workers.blocked_worker.notificationId, blocked.notification.id);
+
     console.log('notifyCliSmoke: ok');
   } finally {
     fs.rmSync(ctx.tmp, { recursive: true, force: true });

--- a/src/smoke/workerRuntimeStateSmoke.ts
+++ b/src/smoke/workerRuntimeStateSmoke.ts
@@ -13,6 +13,7 @@ import { EventLog } from '../core/events';
 import { NotificationStore } from '../core/notifications';
 import type { WorkerInfo } from '../core/sessionManager';
 import {
+  projectWorkerRuntimeState,
   WorkerRuntimeStateStore,
   type WorkerRuntimeSnapshot,
 } from '../core/workerRuntimeState';
@@ -137,6 +138,18 @@ async function testStoreEventsAndIdempotency(): Promise<void> {
         eventLog,
       );
 
+      const starting = store.set({
+        sessionName: 'repo_worker_runtime',
+        state: 'starting',
+        origin: 'session-manager',
+        reason: 'worker-starting',
+        workerId: 7,
+        agent: 'claude',
+        workdir: '/tmp/hydra-runtime-worktree',
+      }, 'session-manager');
+      assert.equal(starting.changed, true);
+      assert.equal(starting.snapshot.state, 'starting');
+
       const first = store.set({
         sessionName: 'repo_worker_runtime',
         state: 'running',
@@ -173,11 +186,38 @@ async function testStoreEventsAndIdempotency(): Promise<void> {
       assert.equal(changed.changed, true);
       assert.equal(store.get('repo_worker_runtime')?.state, 'idle');
 
+      const approving = store.set({
+        sessionName: 'repo_worker_runtime',
+        state: 'approving',
+        origin: 'hook',
+        reason: 'permission-request',
+        workerId: 7,
+        agent: 'claude',
+        workdir: '/tmp/hydra-runtime-worktree',
+      }, 'hook');
+      assert.equal(approving.changed, true);
+      assert.equal(store.get('repo_worker_runtime')?.state, 'approving');
+
+      const stopped = store.set({
+        sessionName: 'repo_worker_runtime',
+        state: 'stopped',
+        origin: 'session-manager',
+        reason: 'worker-stopped',
+        workerId: 7,
+        agent: 'claude',
+        workdir: '/tmp/hydra-runtime-worktree',
+      }, 'session-manager');
+      assert.equal(stopped.changed, true);
+      assert.equal(store.get('repo_worker_runtime')?.state, 'stopped');
+
       const events = readEvents(ctx).filter(event => event.type === 'worker.runtime.changed');
-      assert.equal(events.length, 2);
-      assert.equal(events[0].payload?.state, 'running');
-      assert.equal(events[1].payload?.state, 'idle');
-      assert.equal(events[1].payload?.previousState, 'running');
+      assert.equal(events.length, 5);
+      assert.equal(events[0].payload?.state, 'starting');
+      assert.equal(events[1].payload?.state, 'running');
+      assert.equal(events[2].payload?.state, 'idle');
+      assert.equal(events[2].payload?.previousState, 'running');
+      assert.equal(events[3].payload?.state, 'approving');
+      assert.equal(events[4].payload?.state, 'stopped');
     });
   } finally {
     fs.rmSync(ctx.tmp, { recursive: true, force: true });
@@ -237,6 +277,36 @@ async function testNotificationProjectionAndReadIsolation(): Promise<void> {
         'notify.read',
         'worker.runtime.changed',
       ]);
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testBlockedNotificationProjectsRuntime(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, () => {
+      const store = new NotificationStore();
+      const created = store.create({
+        kind: 'blocked',
+        title: 'Worker blocked',
+        body: 'Waiting on an external dependency',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker_runtime',
+        dedupeKey: 'blocked:repo_worker_runtime:abc',
+        context: {
+          workerId: 7,
+          branch: 'issue-233',
+          workdir: '/tmp/hydra-runtime-worktree',
+          agent: 'claude',
+        },
+        eventSource: 'hook',
+      });
+      assert.equal(created.created, true);
+      const snapshot = new WorkerRuntimeStateStore().get('repo_worker_runtime');
+      assertRuntime(snapshot, 'blocked', 'blocked');
+      assert.equal(snapshot?.notificationId, created.notification.id);
     });
   } finally {
     fs.rmSync(ctx.tmp, { recursive: true, force: true });
@@ -364,6 +434,148 @@ async function testCodexTranscriptRuntimeSignals(): Promise<void> {
   }
 }
 
+async function testStoppedProjectionOverridesStaleRuntime(): Promise<void> {
+  const ctx = setupContext();
+  try {
+    await withProcessEnv(ctx, () => {
+      const store = new WorkerRuntimeStateStore();
+      const stale = store.set({
+        sessionName: 'repo_worker_runtime',
+        state: 'needs-input',
+        origin: 'hook',
+        reason: 'permission-request',
+        workerId: 7,
+        agent: 'claude',
+        workdir: '/tmp/hydra-runtime-worktree',
+      }, 'hook').snapshot;
+      const projected = projectWorkerRuntimeState('stopped', stale);
+      assert.equal(projected.state, 'stopped');
+      assert.equal(projected.updatedAt, null);
+      assert.equal(projected.origin, 'session-manager');
+      assert.equal(projected.reason, 'session-stopped');
+      assert.equal(projected.notificationId, undefined);
+
+      const stopped = store.set({
+        sessionName: 'repo_worker_runtime',
+        state: 'stopped',
+        origin: 'session-manager',
+        reason: 'worker-stopped',
+        workerId: 7,
+        agent: 'claude',
+        workdir: '/tmp/hydra-runtime-worktree',
+      }, 'session-manager').snapshot;
+      const projectedStopped = projectWorkerRuntimeState('stopped', stopped);
+      assert.equal(projectedStopped.state, 'stopped');
+      assert.equal(projectedStopped.updatedAt, stopped.updatedAt);
+      assert.equal(projectedStopped.origin, 'session-manager');
+      assert.equal(projectedStopped.reason, 'worker-stopped');
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testStoppedReadPathsDoNotWriteRuntimeEvents(): Promise<void> {
+  if (!fs.existsSync(cliPath)) {
+    console.log(`workerRuntimeStateSmoke: skipped stopped read-path check (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const ctx = setupContext();
+  const stoppedWorker = createWorker({
+    sessionName: 'hydra-runtime-read-stopped-worker',
+    tmuxSession: 'hydra-runtime-read-stopped-worker',
+    status: 'stopped',
+    workdir: ctx.tmp,
+    copilotSessionName: null,
+  });
+  try {
+    await withProcessEnv(ctx, () => {
+      writeSessions(ctx, stoppedWorker);
+      new WorkerRuntimeStateStore().set({
+        sessionName: stoppedWorker.sessionName,
+        state: 'needs-input',
+        origin: 'hook',
+        reason: 'stale-permission-request',
+        workerId: stoppedWorker.workerId,
+        agent: stoppedWorker.agent,
+        workdir: stoppedWorker.workdir,
+      }, 'hook');
+    });
+
+    const beforeRuntimeEventCount = readEvents(ctx).filter(event => event.type === 'worker.runtime.changed').length;
+    assert.equal(beforeRuntimeEventCount, 1);
+
+    const listOutput = execFileSync(process.execPath, [cliPath, 'list', '--json'], {
+      env: ctx.env,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const list = JSON.parse(listOutput) as { workers: ListWorker[] };
+    const listedWorker = list.workers.find(entry => entry.session === stoppedWorker.sessionName);
+    assert.equal(listedWorker?.runtimeState?.state, 'stopped');
+    assert.equal(listedWorker?.runtimeState?.reason, 'session-stopped');
+
+    execFileSync(process.execPath, [cliPath, 'session', 'rebuild', '--json'], {
+      env: ctx.env,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const afterRuntimeEventCount = readEvents(ctx).filter(event => event.type === 'worker.runtime.changed').length;
+    assert.equal(afterRuntimeEventCount, beforeRuntimeEventCount, 'list/session rebuild must not write runtime events');
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testWorkerStopWritesStoppedRuntime(): Promise<void> {
+  if (!fs.existsSync(cliPath)) {
+    console.log(`workerRuntimeStateSmoke: skipped worker stop check (CLI not built at ${cliPath})`);
+    return;
+  }
+
+  const ctx = setupContext();
+  const worker = createWorker({
+    sessionName: 'hydra-runtime-stop-worker',
+    tmuxSession: 'hydra-runtime-stop-worker',
+    workdir: ctx.tmp,
+    copilotSessionName: null,
+  });
+  try {
+    await withProcessEnv(ctx, () => {
+      writeSessions(ctx, worker);
+    });
+
+    const output = execFileSync(process.execPath, [cliPath, 'worker', 'stop', worker.sessionName, '--json'], {
+      env: ctx.env,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(output) as { status: string; session: string };
+    assert.equal(parsed.status, 'stopped');
+    assert.equal(parsed.session, worker.sessionName);
+
+    const sessions = JSON.parse(fs.readFileSync(path.join(ctx.hydraHome, 'sessions.json'), 'utf-8')) as {
+      workers: Record<string, { status: string; attached: boolean }>;
+    };
+    assert.equal(sessions.workers[worker.sessionName].status, 'stopped');
+    assert.equal(sessions.workers[worker.sessionName].attached, false);
+
+    const runtime = new WorkerRuntimeStateStore(path.join(ctx.hydraHome, 'worker-runtime-state.json')).get(worker.sessionName);
+    assertRuntime(runtime, 'stopped', 'worker-stopped');
+    assert.ok(runtime?.updatedAt, 'explicit stopped runtime should preserve updatedAt');
+    const projection = projectWorkerRuntimeState('stopped', runtime);
+    assert.equal(projection.updatedAt, runtime!.updatedAt);
+    assert.equal(projection.reason, 'worker-stopped');
+
+    const events = readEvents(ctx);
+    assert.deepEqual(events.map(event => event.type), ['worker.runtime.changed', 'worker.stopped']);
+    assert.equal(events[0].payload?.state, 'stopped');
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
 async function testListJsonRuntimeState(): Promise<void> {
   if (!fs.existsSync(cliPath)) {
     console.log(`workerRuntimeStateSmoke: skipped list check (CLI not built at ${cliPath})`);
@@ -382,9 +594,17 @@ async function testListJsonRuntimeState(): Promise<void> {
     workdir: ctx.tmp,
     copilotSessionName: null,
   });
+  const stoppedWorker = createWorker({
+    sessionName: 'hydra-runtime-list-stopped-worker',
+    tmuxSession: 'hydra-runtime-list-stopped-worker',
+    status: 'stopped',
+    workdir: ctx.tmp,
+    workerId: 8,
+    copilotSessionName: null,
+  });
   try {
     await withProcessEnv(ctx, () => {
-      writeSessions(ctx, worker);
+      writeSessions(ctx, [worker, stoppedWorker]);
       new WorkerRuntimeStateStore().set({
         sessionName: worker.sessionName,
         state: 'needs-input',
@@ -393,6 +613,15 @@ async function testListJsonRuntimeState(): Promise<void> {
         workerId: worker.workerId,
         agent: worker.agent,
         workdir: worker.workdir,
+      }, 'hook');
+      new WorkerRuntimeStateStore().set({
+        sessionName: stoppedWorker.sessionName,
+        state: 'needs-input',
+        origin: 'hook',
+        reason: 'stale-permission-request',
+        workerId: stoppedWorker.workerId,
+        agent: stoppedWorker.agent,
+        workdir: stoppedWorker.workdir,
       }, 'hook');
     });
 
@@ -414,21 +643,26 @@ async function testListJsonRuntimeState(): Promise<void> {
     assert.equal(listedWorker!.status, 'running');
     assert.equal(listedWorker!.runtimeState?.state, 'needs-input');
     assert.equal(listedWorker!.runtimeState?.reason, 'permission-request');
+    const listedStoppedWorker = list.workers.find(entry => entry.session === stoppedWorker.sessionName);
+    assert.ok(listedStoppedWorker, 'expected stopped worker in hydra list output');
+    assert.equal(listedStoppedWorker!.status, 'stopped');
+    assert.equal(listedStoppedWorker!.runtimeState?.state, 'stopped');
+    assert.equal(listedStoppedWorker!.runtimeState?.reason, 'session-stopped');
+    assert.equal(listedStoppedWorker!.runtimeState?.updatedAt, null);
   } finally {
     spawnSync('tmux', ['-L', tmuxSocket, 'kill-server'], { stdio: 'ignore' });
     fs.rmSync(ctx.tmp, { recursive: true, force: true });
   }
 }
 
-function writeSessions(ctx: TestContext, worker: WorkerInfo): void {
+function writeSessions(ctx: TestContext, workers: WorkerInfo | WorkerInfo[]): void {
   const now = new Date().toISOString();
+  const workerList = Array.isArray(workers) ? workers : [workers];
   fs.writeFileSync(
     path.join(ctx.hydraHome, 'sessions.json'),
     JSON.stringify({
       copilots: {},
-      workers: {
-        [worker.sessionName]: worker,
-      },
+      workers: Object.fromEntries(workerList.map(worker => [worker.sessionName, worker])),
       nextWorkerId: 8,
       updatedAt: now,
     }, null, 2),
@@ -453,9 +687,13 @@ function tmuxAvailable(): boolean {
 async function main(): Promise<void> {
   await testStoreEventsAndIdempotency();
   await testNotificationProjectionAndReadIsolation();
+  await testBlockedNotificationProjectsRuntime();
   await testNeedsInputWithoutNotificationTargetStillUpdatesRuntime();
   await testMonitorNeedsInputFallbackUsesInjectedRuntimeStore();
   await testCodexTranscriptRuntimeSignals();
+  await testStoppedProjectionOverridesStaleRuntime();
+  await testStoppedReadPathsDoNotWriteRuntimeEvents();
+  await testWorkerStopWritesStoppedRuntime();
   await testListJsonRuntimeState();
   console.log('workerRuntimeStateSmoke: ok');
 }


### PR DESCRIPTION
## Summary
- add durable worker runtime state projection separate from tmux running/stopped state
- expose runtime state through `hydra list --json`, agent session index, and VS Code worker tree
- project notification signals into worker states such as idle, needs-input, blocked, error, and stopped

## Validation
- `npm run compile`
- `npm run lint`
- `npm run smoke:worker-runtime-state`
- `npm run smoke:agent-session-index`
- `npm run smoke:notify-cli`
- `npm test`
- Extension Development Host launched from the final stacked branch with `/tmp/hydra-e2e-clean-MBJ8wyyP` and loaded `/Users/hanlu/Desktop/ai/hydra`