### PR TITLE
Add notification attention inbox

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -355,7 +355,7 @@ Current event types:
 | --- | --- | --- | --- |
 | `notify.created` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `notificationId`, `kind`, `title`, redacted `body`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `workdir`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
 | `notify.read` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
-| `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`. Emitted only when at least one notification is removed. |
+| `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`, optional `readOnly`. Emitted only when at least one notification is removed. |
 | `worker.created` | `session-manager` | `worker` | `workerId`, `source`, optional `branch`, `repo`, `managedWorkdir`. Emitted for fresh code/task worker creation. |
 | `worker.started` | `session-manager` | `worker` | Worker identity fields plus `resumed`; existing-branch paths also include `alreadyRunning`. Emitted when an existing worker session is started or reused. |
 | `worker.runtime.changed` | `cli`, `extension`, `session-manager`, or `hook` | `worker` | `state`, optional `previousState`, `origin`, `reason`, `notificationId`, `workerId`, `updatedAt`. Emitted when the durable worker runtime projection changes. |
@@ -457,7 +457,9 @@ Returns:
 | `cleared` | number | Number of notifications removed. |
 
 `--session`, `--target`, and `--from` narrow which notifications are cleared.
-With no filter, all notifications are cleared.
+With no filter, all notifications are cleared. `--read` only removes
+notifications that already have `readAt` set; unread notifications are
+preserved. `--read` may be combined with the same session/source/target filters.
 
 ### `hydra notify open <id> --json`
 
@@ -537,7 +539,7 @@ Notify commands:
 | `notify create` | Create a structured local notification. Supports `--session`, `--from`, `--kind`, `--title`, `--body`, `--dedupe-key`, `--action`, and context flags. |
 | `notify list` | List structured notifications. Supports `--session`, `--target`, `--from`, `--kind`, `--unread`, and `--limit`. |
 | `notify read <id>` | Mark one notification read. |
-| `notify clear` | Clear all notifications, or a narrowed session/source/target subset. |
+| `notify clear` | Clear all notifications, a narrowed session/source/target subset, or only read notifications with `--read`. |
 | `notify open <id>` | Mark one notification read and return its suggested action. |
 
 Events command:

--- a/docs/control-plane-roadmap.md
+++ b/docs/control-plane-roadmap.md
@@ -37,7 +37,12 @@ injecting messages.
 
 4. **Attention Inbox**
    - Add a user-facing notification surface in VS Code.
-   - Support unread-first navigation, mark-read, clear, and open-session actions.
+   - Build it as a pure projection over `NotificationStateService` snapshots;
+     opening the view must not mutate `notifications.json`.
+   - Support unread-first navigation, mark-read, clear-read, and open-session
+     actions. Use explicit commands for every write.
+   - Keep this smaller than cmux Feed: no approve/deny flow, blocking hook wait,
+     daemon, socket, or desktop notification in the first inbox version.
    - Only after this exists should paste-to-copilot become optional by default.
 
 5. **AgentRegistry (#230)**

--- a/package.json
+++ b/package.json
@@ -71,6 +71,10 @@
         {
           "id": "hydraWorkers",
           "name": "Workers"
+        },
+        {
+          "id": "hydraInbox",
+          "name": "Inbox"
         }
       ]
     },
@@ -103,6 +107,10 @@
         "view": "hydraCopilots",
         "contents": "No supported agents found on PATH.\nInstall [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or Sudo Code.",
         "when": "hydra.noAgentsAvailable"
+      },
+      {
+        "view": "hydraInbox",
+        "contents": "No unread Hydra notifications."
       }
     ],
     "commands": [
@@ -173,12 +181,24 @@
         "title": "Hydra: Open Notification"
       },
       {
+        "command": "hydra.openInboxNotification",
+        "title": "Hydra: Open Inbox Notification"
+      },
+      {
+        "command": "hydra.markNotificationRead",
+        "title": "Hydra: Mark Notification Read"
+      },
+      {
         "command": "hydra.markSessionNotificationsRead",
         "title": "Hydra: Mark Notifications Read"
       },
       {
         "command": "hydra.clearSessionNotifications",
         "title": "Hydra: Clear Notifications"
+      },
+      {
+        "command": "hydra.clearReadNotifications",
+        "title": "Hydra: Clear Read Notifications"
       },
       {
         "command": "hydra.createCopilot",
@@ -304,16 +324,31 @@
       "view/title": [
         {
           "command": "tmux.refresh",
-          "when": "view == hydraCopilots || view == hydraWorkers",
+          "when": "view == hydraCopilots || view == hydraWorkers || view == hydraInbox",
           "group": "navigation"
         },
         {
           "command": "hydra.createCopilot",
           "when": "view == hydraCopilots",
           "group": "navigation"
+        },
+        {
+          "command": "hydra.clearReadNotifications",
+          "when": "view == hydraInbox",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
+        {
+          "command": "hydra.openInboxNotification",
+          "when": "view == hydraInbox && viewItem == 'inboxNotificationItem'",
+          "group": "1_open@1"
+        },
+        {
+          "command": "hydra.markNotificationRead",
+          "when": "view == hydraInbox && viewItem == 'inboxNotificationItem'",
+          "group": "5_notifications@1"
+        },
         {
           "command": "tmux.reviewChanges",
           "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem')",
@@ -359,6 +394,7 @@
   },
   "activationEvents": [
     "onView:hydraCopilots",
+    "onView:hydraInbox",
     "onCommand:tmux.attachCreate",
     "onCommand:hydra.createWorker",
     "onCommand:tmux.removeTask",
@@ -374,6 +410,9 @@
     "onCommand:tmux.pasteImage",
     "onCommand:tmux.createWorktreeFromBranch",
     "onCommand:hydra.openPR",
+    "onCommand:hydra.openInboxNotification",
+    "onCommand:hydra.markNotificationRead",
+    "onCommand:hydra.clearReadNotifications",
     "onCommand:hydra.createCopilot",
     "onCommand:hydra.startPlanCopilot",
     "onCommand:hydra.startCopilotClaude",
@@ -417,6 +456,7 @@
     "smoke:worker-needs-input": "node out/smoke/workerNeedsInputSmoke.js",
     "smoke:worker-runtime-state": "node out/smoke/workerRuntimeStateSmoke.js",
     "smoke:notification-state": "node out/smoke/notificationStateServiceSmoke.js",
+    "smoke:notification-inbox-projection": "node out/smoke/notificationInboxProjectionSmoke.js",
     "smoke:session-notification-summary": "node out/smoke/sessionNotificationSummarySmoke.js",
     "smoke:agent-registry": "node out/smoke/agentRegistrySmoke.js",
     "smoke:share": "node out/smoke/shareBundleSmoke.js",
@@ -432,7 +472,7 @@
     "smoke:shell-target-e2e": "node out/smoke/shellTargetEndToEndSmoke.js",
     "smoke:pane-shell-probe": "node out/smoke/paneShellProbeSmoke.js",
     "smoke:enhanced-path-windows": "node out/smoke/enhancedPathWindowsSmoke.js",
-    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:agent-session-index && npm run smoke:resume-diagnostics && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:worker-attention-notification && npm run smoke:worker-needs-input && npm run smoke:worker-runtime-state && npm run smoke:notification-state && npm run smoke:session-notification-summary && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
+    "test": "npm run compile && npm run smoke:tmux-attach && npm run smoke:identity && npm run smoke:copilot-env-e2e && npm run smoke:codex-bypass && npm run smoke:completion-hook && npm run smoke:task-worker && npm run smoke:task-worker-cli-e2e && npm run smoke:worker-delete && npm run smoke:telemetry && npm run smoke:telemetry-e2e && npm run smoke:logging && npm run smoke:logging-cli-e2e && npm run smoke:session-file-resolve && npm run smoke:sudocode-agent && npm run smoke:cli-session-fields && npm run smoke:agent-session-index && npm run smoke:resume-diagnostics && npm run smoke:cli-config && npm run smoke:cli-contract && npm run smoke:events-cli && npm run smoke:notify-cli && npm run smoke:worker-attention-notification && npm run smoke:worker-needs-input && npm run smoke:worker-runtime-state && npm run smoke:notification-state && npm run smoke:notification-inbox-projection && npm run smoke:session-notification-summary && npm run smoke:agent-registry && npm run smoke:share && npm run smoke:repo-registry && npm run smoke:windows-format-quoting && npm run smoke:windows-cli-wrapper && npm run smoke:exec-powershell && npm run smoke:notify-hook-windows && npm run smoke:cpu-probe && npm run smoke:shell-quote && npm run smoke:copilot-session-env && npm run smoke:shell-quote-display && npm run smoke:carry-over-quote && npm run smoke:shell-target-e2e && npm run smoke:pane-shell-probe && npm run smoke:enhanced-path-windows",
     "smoke:windows-cli-wrapper": "node out/smoke/windowsCliWrapperSmoke.js"
   },
   "devDependencies": {

--- a/src/cli/commands/notify.ts
+++ b/src/cli/commands/notify.ts
@@ -38,6 +38,7 @@ interface NotifyClearOptions {
   session?: string;
   target?: string;
   from?: string;
+  read?: boolean;
 }
 
 export function registerNotifyCommands(program: Command): void {
@@ -184,14 +185,18 @@ export function registerNotifyCommands(program: Command): void {
     .option('--session <session>', 'Clear notifications for a target or source session')
     .option('--target <session>', 'Clear notifications for a target session')
     .option('--from <session>', 'Clear notifications from a source session')
+    .option('--read', 'Clear read notifications only')
     .action((opts: NotifyClearOptions) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
-        const result = new NotificationStore().clear({
+        const filters = {
           session: opts.session,
           targetSession: opts.target,
           sourceSession: opts.from,
-        });
+        };
+        const result = opts.read
+          ? new NotificationStore().clearRead(filters)
+          : new NotificationStore().clear(filters);
         outputResult(
           {
             status: 'ok',
@@ -199,7 +204,8 @@ export function registerNotifyCommands(program: Command): void {
           },
           globalOpts,
           () => {
-            console.log(`Cleared ${result.cleared} notification${result.cleared === 1 ? '' : 's'}.`);
+            const qualifier = opts.read ? ' read' : '';
+            console.log(`Cleared ${result.cleared}${qualifier} notification${result.cleared === 1 ? '' : 's'}.`);
           },
         );
       } catch (error) {

--- a/src/commands/notificationTreeCommands.ts
+++ b/src/commands/notificationTreeCommands.ts
@@ -8,11 +8,17 @@ import { openHydraSessionByName, reviewHydraSessionByName } from './openHydraSes
 
 export interface NotificationTreeCommands {
   openSessionNotification(item?: TmuxItem): Promise<void>;
+  openInboxNotification(itemOrId?: unknown): Promise<void>;
+  markNotificationRead(itemOrId?: unknown): Promise<void>;
   markSessionNotificationsRead(item?: TmuxItem): Promise<void>;
   clearSessionNotifications(item?: TmuxItem): Promise<void>;
+  clearReadNotifications(): Promise<void>;
 }
 
-function getNotificationId(item?: TmuxItem): string | undefined {
+function getNotificationId(item?: unknown): string | undefined {
+  if (typeof item === 'string' && item) {
+    return item;
+  }
   const candidate = item as unknown as { notificationId?: unknown } | undefined;
   return typeof candidate?.notificationId === 'string' && candidate.notificationId
     ? candidate.notificationId
@@ -22,42 +28,78 @@ function getNotificationId(item?: TmuxItem): string | undefined {
 export function createNotificationTreeCommands(
   notificationState: NotificationStateService,
 ): NotificationTreeCommands {
+  const openNotificationById = async (notificationId: string): Promise<void> => {
+    const result = notificationState.open(notificationId, 'extension');
+    const action = result.action;
+    if (!action) {
+      vscode.window.showInformationMessage(`Marked notification read: ${result.notification.title}`);
+      return;
+    }
+
+    if (action.type === 'open-session') {
+      await openHydraSessionByName(action.session);
+      return;
+    }
+    if (action.type === 'review-diff') {
+      await reviewHydraSessionByName(action.session);
+    }
+  };
+
   return {
     async openSessionNotification(item?: TmuxItem): Promise<void> {
       try {
+        const notificationId = getNotificationId(item);
+        if (notificationId) {
+          await openNotificationById(notificationId);
+          return;
+        }
+
         const sessionName = resolveSessionName(item);
         if (!sessionName) {
           vscode.window.showErrorMessage('No session selected');
           return;
         }
 
-        const notificationId = getNotificationId(item);
-        let targetNotificationId = notificationId;
-        if (!targetNotificationId) {
-          const summary = buildSessionNotificationSummary(sessionName, notificationState.getByTargetSession(sessionName));
-          if (!summary) {
-            vscode.window.showInformationMessage(`No unread notifications for ${sessionName}`);
-            return;
-          }
-          targetNotificationId = summary.attention.id;
-        }
-
-        const result = notificationState.open(targetNotificationId, 'extension');
-        const action = result.action;
-        if (!action) {
-          vscode.window.showInformationMessage(`Marked notification read: ${result.notification.title}`);
+        const summary = buildSessionNotificationSummary(sessionName, notificationState.getByTargetSession(sessionName));
+        if (!summary) {
+          vscode.window.showInformationMessage(`No unread notifications for ${sessionName}`);
           return;
         }
 
-        if (action.type === 'open-session') {
-          await openHydraSessionByName(action.session);
-          return;
-        }
-        if (action.type === 'review-diff') {
-          await reviewHydraSessionByName(action.session);
-        }
+        await openNotificationById(summary.attention.id);
       } catch (error) {
         vscode.window.showErrorMessage(`Failed to open notification: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async openInboxNotification(itemOrId?: unknown): Promise<void> {
+      try {
+        const notificationId = getNotificationId(itemOrId);
+        if (!notificationId) {
+          vscode.window.showErrorMessage('No notification selected');
+          return;
+        }
+        await openNotificationById(notificationId);
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to open notification: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async markNotificationRead(itemOrId?: unknown): Promise<void> {
+      try {
+        const notificationId = getNotificationId(itemOrId);
+        if (!notificationId) {
+          vscode.window.showErrorMessage('No notification selected');
+          return;
+        }
+        const result = notificationState.markRead(notificationId, 'extension');
+        vscode.window.showInformationMessage(
+          result.markedRead === 0
+            ? `Notification already read: ${result.notification.title}`
+            : `Marked notification read: ${result.notification.title}`,
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to mark notification read: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
 
@@ -112,6 +154,34 @@ export function createNotificationTreeCommands(
         );
       } catch (error) {
         vscode.window.showErrorMessage(`Failed to clear notifications: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async clearReadNotifications(): Promise<void> {
+      try {
+        const readCount = notificationState.getSnapshot().notifications
+          .filter(notification => notification.readAt !== null)
+          .length;
+        if (readCount === 0) {
+          vscode.window.showInformationMessage('No read notifications to clear');
+          return;
+        }
+
+        const choice = await vscode.window.showWarningMessage(
+          `Clear ${readCount} read notification${readCount === 1 ? '' : 's'}?`,
+          { modal: true },
+          'Clear Read',
+        );
+        if (choice !== 'Clear Read') {
+          return;
+        }
+
+        const result = notificationState.clearRead({}, 'extension');
+        vscode.window.showInformationMessage(
+          `Cleared ${result.cleared} read notification${result.cleared === 1 ? '' : 's'}`,
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to clear read notifications: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   };

--- a/src/core/notificationInboxProjection.ts
+++ b/src/core/notificationInboxProjection.ts
@@ -1,0 +1,143 @@
+import type { HydraNotification, NotificationKind } from './notifications';
+import { cloneNotification, type NotificationSnapshot } from './notificationState';
+
+export type NotificationInboxGroupSource = 'target' | 'source' | 'unassigned';
+
+export interface NotificationInboxItem {
+  readonly notification: HydraNotification;
+  readonly groupId: string;
+  readonly groupSession: string | null;
+  readonly groupSource: NotificationInboxGroupSource;
+  readonly priority: number;
+}
+
+export interface NotificationInboxGroup {
+  readonly id: string;
+  readonly sessionName: string | null;
+  readonly source: NotificationInboxGroupSource;
+  readonly unreadCount: number;
+  readonly kind: NotificationKind;
+  readonly latestCreatedAt: string;
+  readonly items: readonly NotificationInboxItem[];
+}
+
+export interface NotificationInboxProjection {
+  readonly loadedAt: string;
+  readonly lastEventSeq: number;
+  readonly unreadCount: number;
+  readonly groups: readonly NotificationInboxGroup[];
+  readonly items: readonly NotificationInboxItem[];
+}
+
+const KIND_PRIORITY: Record<NotificationKind, number> = {
+  error: 0,
+  blocked: 1,
+  'needs-input': 2,
+  complete: 3,
+  info: 4,
+};
+
+export function buildNotificationInboxProjection(snapshot: NotificationSnapshot): NotificationInboxProjection {
+  const items = snapshot.notifications
+    .filter(notification => notification.readAt === null)
+    .map(toInboxItem)
+    .sort(compareInboxItems);
+
+  const groupsById = new Map<string, NotificationInboxItem[]>();
+  for (const item of items) {
+    const group = groupsById.get(item.groupId);
+    if (group) {
+      group.push(item);
+    } else {
+      groupsById.set(item.groupId, [item]);
+    }
+  }
+
+  const groups = [...groupsById.entries()]
+    .map(([id, groupItems]): NotificationInboxGroup => {
+      const sortedItems = [...groupItems].sort(compareInboxItems);
+      const attention = sortedItems[0];
+      return {
+        id,
+        sessionName: attention.groupSession,
+        source: attention.groupSource,
+        unreadCount: sortedItems.length,
+        kind: attention.notification.kind,
+        latestCreatedAt: sortedItems.reduce(
+          (latest, item) => compareCreatedAtDescending(item.notification.createdAt, latest) < 0
+            ? item.notification.createdAt
+            : latest,
+          sortedItems[0].notification.createdAt,
+        ),
+        items: sortedItems,
+      };
+    })
+    .sort(compareInboxGroups);
+
+  return {
+    loadedAt: snapshot.loadedAt,
+    lastEventSeq: snapshot.lastEventSeq,
+    unreadCount: items.length,
+    groups,
+    items,
+  };
+}
+
+export function compareInboxItems(a: NotificationInboxItem, b: NotificationInboxItem): number {
+  const priorityDiff = a.priority - b.priority;
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+  const timeDiff = compareCreatedAtDescending(a.notification.createdAt, b.notification.createdAt);
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+  return a.notification.id.localeCompare(b.notification.id);
+}
+
+function compareInboxGroups(a: NotificationInboxGroup, b: NotificationInboxGroup): number {
+  const priorityDiff = KIND_PRIORITY[a.kind] - KIND_PRIORITY[b.kind];
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+  const timeDiff = compareCreatedAtDescending(a.latestCreatedAt, b.latestCreatedAt);
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function toInboxItem(notification: HydraNotification): NotificationInboxItem {
+  const cloned = cloneNotification(notification);
+  const targetSession = normalizeSession(cloned.targetSession);
+  const sourceSession = normalizeSession(cloned.sourceSession);
+  const groupSession = targetSession ?? sourceSession ?? null;
+  const groupSource: NotificationInboxGroupSource = targetSession
+    ? 'target'
+    : sourceSession
+      ? 'source'
+      : 'unassigned';
+  const groupId = groupSession
+    ? `${groupSource}:${groupSession}`
+    : 'unassigned';
+  return {
+    notification: cloned,
+    groupId,
+    groupSession,
+    groupSource,
+    priority: KIND_PRIORITY[cloned.kind],
+  };
+}
+
+function normalizeSession(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function compareCreatedAtDescending(a: string, b: string): number {
+  const timeDiff = Date.parse(b) - Date.parse(a);
+  if (Number.isFinite(timeDiff) && timeDiff !== 0) {
+    return timeDiff;
+  }
+  return b.localeCompare(a);
+}

--- a/src/core/notificationStateService.ts
+++ b/src/core/notificationStateService.ts
@@ -13,6 +13,7 @@ import {
   type HydraNotification,
   type NotificationKind,
   type NotificationMarkSessionReadResult,
+  type NotificationClearReadResult,
   type NotificationClearResult,
   type NotificationListFilters,
   type NotificationOpenResult,
@@ -214,6 +215,15 @@ export class NotificationStateService implements Disposable {
     return result;
   }
 
+  clearRead(
+    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    eventSource: HydraEventSource = 'extension',
+  ): NotificationClearReadResult {
+    const result = this.store.clearRead(filters, eventSource);
+    this.reloadNow({ emit: true, reason: 'clear-read' });
+    return result;
+  }
+
   open(id: string, eventSource: HydraEventSource = 'extension'): NotificationOpenResult {
     const result = this.store.open(id, eventSource);
     this.reloadNow({ emit: true, reason: 'open' });
@@ -380,6 +390,15 @@ export class NotificationStateService implements Disposable {
         continue;
       }
 
+      if (event.type === 'notify.read') {
+        const id = getStringPayload(event.payload || {}, 'notificationId');
+        const existing = id ? eventOnlyNotifications.get(id) : undefined;
+        if (existing && existing.readAt === null) {
+          eventOnlyNotifications.set(id!, { ...existing, readAt: event.ts });
+        }
+        continue;
+      }
+
       if (event.type !== 'notify.cleared') {
         continue;
       }
@@ -514,6 +533,11 @@ function notificationFromCreatedEvent(event: HydraEvent): HydraNotification | un
 
 function notificationMatchesClearEvent(notification: HydraNotification, event: HydraEvent): boolean {
   const payload = event.payload || {};
+  const readOnly = payload.readOnly === true;
+  if (readOnly && notification.readAt === null) {
+    return false;
+  }
+
   const session = getStringPayload(payload, 'session');
   const targetSession = getStringPayload(payload, 'targetSession');
   const sourceSession = getStringPayload(payload, 'sourceSession');

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -86,6 +86,10 @@ export interface NotificationClearResult {
   cleared: number;
 }
 
+export interface NotificationClearReadResult {
+  cleared: number;
+}
+
 export interface NotificationOpenResult {
   notification: HydraNotification;
   action: NotificationAction | null;
@@ -241,6 +245,25 @@ export class NotificationStore {
     });
   }
 
+  clearRead(
+    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    eventSource: HydraEventSource = 'cli',
+  ): NotificationClearReadResult {
+    return this.withLock(() => {
+      const store = this.readStore();
+      const before = store.notifications.length;
+      store.notifications = store.notifications.filter(notification =>
+        notification.readAt === null || !matchesFilters(notification, filters),
+      );
+      const cleared = before - store.notifications.length;
+      if (cleared > 0) {
+        this.writeStore(store);
+        this.emitClearEvent(cleared, filters, eventSource, true);
+      }
+      return { cleared };
+    });
+  }
+
   open(id: string, eventSource: HydraEventSource = 'cli'): NotificationOpenResult {
     const read = this.markRead(id, eventSource);
     return {
@@ -369,18 +392,23 @@ export class NotificationStore {
     cleared: number,
     filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>,
     source: HydraEventSource,
+    readOnly = false,
   ): void {
     try {
+      const payload: Record<string, unknown> = {
+        cleared,
+        session: filters.session,
+        targetSession: filters.targetSession,
+        sourceSession: filters.sourceSession,
+      };
+      if (readOnly) {
+        payload.readOnly = true;
+      }
       this.eventLog.append({
         type: 'notify.cleared',
         source,
         session: filters.session || filters.targetSession || filters.sourceSession,
-        payload: {
-          cleared,
-          session: filters.session,
-          targetSession: filters.targetSession,
-          sourceSession: filters.sourceSession,
-        },
+        payload,
       });
     } catch (error) {
       logger.warn('notifications.event', 'Failed to append notification clear event', {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { CopilotProvider, WorkerProvider, TmuxItem } from './providers/tmuxSessionProvider';
+import { NotificationInboxProvider } from './providers/notificationInboxProvider';
 import { attachCreate } from './commands/attachCreate';
 import { newTask } from './commands/newTask';
 import { removeTask } from './commands/removeTask';
@@ -67,9 +68,11 @@ export function activate(context: vscode.ExtensionContext) {
   copilotProvider.setExtensionUri(context.extensionUri);
   const workerProvider = new WorkerProvider(notificationState, workerRuntimeState);
   workerProvider.setExtensionUri(context.extensionUri);
+  const inboxProvider = new NotificationInboxProvider(notificationState);
 
   const copilotView = vscode.window.createTreeView('hydraCopilots', { treeDataProvider: copilotProvider });
   const workerView = vscode.window.createTreeView('hydraWorkers', { treeDataProvider: workerProvider });
+  const inboxView = vscode.window.createTreeView('hydraInbox', { treeDataProvider: inboxProvider });
   let selectedHydraItem: TmuxItem | undefined;
   let selectedHydraItemAt = 0;
   const rememberHydraSelection = (event: vscode.TreeViewSelectionChangeEvent<TmuxItem>) => {
@@ -145,7 +148,7 @@ export function activate(context: vscode.ExtensionContext) {
   };
 
   let syncWorkerGitHeadWatchers: () => void = () => {};
-  const refreshTreeViews = () => { copilotProvider.refresh(); workerProvider.refresh(); };
+  const refreshTreeViews = () => { copilotProvider.refresh(); workerProvider.refresh(); inboxProvider.refresh(); };
   const refreshAll = () => {
     refreshTreeViews();
     syncWorkerGitHeadWatchers();
@@ -155,6 +158,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     copilotView,
     workerView,
+    inboxView,
     vscode.commands.registerCommand('tmux.attachCreate', attachCreate),
     vscode.commands.registerCommand('hydra.createWorker', newTask),
     vscode.commands.registerCommand('tmux.removeTask', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], removeTask, ...args)),
@@ -167,8 +171,11 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.newPane', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newPane, ...args)),
     vscode.commands.registerCommand('tmux.newWindow', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newWindow, ...args)),
     vscode.commands.registerCommand('hydra.openSessionNotification', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.openSessionNotification, ...args)),
+    vscode.commands.registerCommand('hydra.openInboxNotification', notificationCommands.openInboxNotification),
+    vscode.commands.registerCommand('hydra.markNotificationRead', notificationCommands.markNotificationRead),
     vscode.commands.registerCommand('hydra.markSessionNotificationsRead', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.markSessionNotificationsRead, ...args)),
     vscode.commands.registerCommand('hydra.clearSessionNotifications', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.clearSessionNotifications, ...args)),
+    vscode.commands.registerCommand('hydra.clearReadNotifications', notificationCommands.clearReadNotifications),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),
     vscode.commands.registerCommand('tmux.createWorktreeFromBranch', (item) => createWorktreeFromBranch(item)),

--- a/src/providers/notificationInboxProvider.ts
+++ b/src/providers/notificationInboxProvider.ts
@@ -1,0 +1,135 @@
+import * as vscode from 'vscode';
+import {
+  buildNotificationInboxProjection,
+  type NotificationInboxGroup,
+  type NotificationInboxProjection,
+} from '../core/notificationInboxProjection';
+import type { NotificationStateService } from '../core/notificationStateService';
+import type { HydraNotification } from '../core/notifications';
+import {
+  buildNotificationTooltip,
+  formatNotificationAge,
+  formatNotificationDescription,
+  formatNotificationDetailLabel,
+  formatNotificationSessionLabel,
+  getNotificationIcon,
+  getNotificationThemeColor,
+} from './notificationPresentation';
+
+type NotificationInboxTreeItem = NotificationInboxGroupItem | NotificationInboxNotificationItem;
+
+export class NotificationInboxGroupItem extends vscode.TreeItem {
+  public readonly groupId: string;
+  public readonly sessionName: string | null;
+
+  constructor(group: NotificationInboxGroup) {
+    const label = formatNotificationSessionLabel(group.sessionName) ?? 'Unassigned';
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    this.groupId = group.id;
+    this.sessionName = group.sessionName;
+    this.id = `inbox-group:${group.id}`;
+    this.contextValue = 'inboxGroupItem';
+    this.description = `${group.unreadCount} unread`;
+    this.iconPath = new vscode.ThemeIcon(
+      getNotificationIcon(group.kind),
+      getNotificationThemeColor(group.kind),
+    );
+    this.tooltip = buildGroupTooltip(group);
+  }
+}
+
+export class NotificationInboxNotificationItem extends vscode.TreeItem {
+  public readonly notificationId: string;
+  public readonly sessionName: string | null;
+  public readonly notification: HydraNotification;
+
+  constructor(group: NotificationInboxGroup, notification: HydraNotification) {
+    super(formatNotificationDetailLabel(notification), vscode.TreeItemCollapsibleState.None);
+    this.notification = notification;
+    this.notificationId = notification.id;
+    this.sessionName = group.sessionName;
+    this.id = `inbox-notification:${notification.id}`;
+    this.contextValue = 'inboxNotificationItem';
+    this.description = formatNotificationDescription(notification) ?? formatNotificationAge(notification.createdAt);
+    this.iconPath = new vscode.ThemeIcon(
+      getNotificationIcon(notification.kind),
+      getNotificationThemeColor(notification.kind),
+    );
+    this.tooltip = buildNotificationTooltip(notification, 'Click to open this notification and mark it read.');
+    this.command = {
+      command: 'hydra.openInboxNotification',
+      title: 'Open Notification',
+      arguments: [this],
+    };
+  }
+}
+
+export class NotificationInboxProvider implements vscode.TreeDataProvider<NotificationInboxTreeItem> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<NotificationInboxTreeItem | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  private projection: NotificationInboxProjection | undefined;
+
+  constructor(private readonly notifications: NotificationStateService) {}
+
+  refresh(): void {
+    this.projection = undefined;
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  getTreeItem(element: NotificationInboxTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getParent(element: NotificationInboxTreeItem): NotificationInboxTreeItem | undefined {
+    if (element instanceof NotificationInboxGroupItem) {
+      return undefined;
+    }
+    const projection = this.getProjection();
+    const group = projection.groups.find(candidate =>
+      candidate.items.some(item => item.notification.id === element.notificationId),
+    );
+    return group ? new NotificationInboxGroupItem(group) : undefined;
+  }
+
+  getChildren(element?: NotificationInboxTreeItem): NotificationInboxTreeItem[] {
+    if (!element) {
+      return this.getProjection().groups.map(group => new NotificationInboxGroupItem(group));
+    }
+    if (element instanceof NotificationInboxGroupItem) {
+      const group = this.getProjection().groups.find(candidate => candidate.id === element.groupId);
+      return group
+        ? group.items.map(item => new NotificationInboxNotificationItem(group, item.notification))
+        : [];
+    }
+    return [];
+  }
+
+  private getProjection(): NotificationInboxProjection {
+    if (!this.projection) {
+      this.projection = buildNotificationInboxProjection(this.notifications.getSnapshot());
+    }
+    return this.projection;
+  }
+}
+
+function buildGroupTooltip(group: NotificationInboxGroup): vscode.MarkdownString {
+  const md = new vscode.MarkdownString();
+  md.appendMarkdown('**Hydra inbox group**\n\n');
+  md.appendMarkdown('- Unread: ');
+  md.appendText(String(group.unreadCount));
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Top kind: ');
+  md.appendText(group.kind);
+  md.appendMarkdown('\n');
+  if (group.sessionName) {
+    md.appendMarkdown('- Session: ');
+    md.appendText(group.sessionName);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('- Grouped by: ');
+  md.appendText(group.source);
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Latest: ');
+  md.appendText(group.latestCreatedAt);
+  return md;
+}

--- a/src/providers/notificationPresentation.ts
+++ b/src/providers/notificationPresentation.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode';
+import type { HydraNotification, NotificationKind } from '../core/notifications';
+
+export function getNotificationThemeColor(kind: NotificationKind): vscode.ThemeColor {
+  switch (kind) {
+    case 'error':
+      return new vscode.ThemeColor('charts.red');
+    case 'blocked':
+      return new vscode.ThemeColor('charts.purple');
+    case 'needs-input':
+      return new vscode.ThemeColor('charts.yellow');
+    case 'complete':
+      return new vscode.ThemeColor('charts.green');
+    case 'info':
+      return new vscode.ThemeColor('charts.blue');
+  }
+}
+
+export function getNotificationIcon(kind: NotificationKind): string {
+  switch (kind) {
+    case 'error':
+      return 'error';
+    case 'blocked':
+    case 'needs-input':
+      return 'warning';
+    case 'complete':
+      return 'pass';
+    case 'info':
+      return 'info';
+  }
+}
+
+export function formatNotificationDetailLabel(notification: HydraNotification): string {
+  const title = notification.title || notification.body || 'Notification';
+  return notification.kind === 'complete'
+    ? title
+    : `${notification.kind}: ${title}`;
+}
+
+export function formatNotificationSessionLabel(sessionName: string | null): string | undefined {
+  if (!sessionName) return undefined;
+  return sessionName.replace(/^task_/, '');
+}
+
+export function formatNotificationDescription(notification: HydraNotification): string | undefined {
+  const parts = [
+    formatNotificationSessionLabel(notification.sourceSession),
+    formatNotificationAge(notification.createdAt),
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(' - ') : undefined;
+}
+
+export function formatNotificationAge(createdAt: string): string | undefined {
+  const timestamp = Date.parse(createdAt);
+  if (!Number.isFinite(timestamp)) {
+    return undefined;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const diffSec = now - Math.floor(timestamp / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+
+  if (diffMin < 1) return 'now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export function buildNotificationTooltip(
+  notification: HydraNotification,
+  footer: string,
+): vscode.MarkdownString {
+  const md = new vscode.MarkdownString();
+  md.appendMarkdown('**Hydra notification**\n\n');
+  md.appendMarkdown('- Kind: ');
+  md.appendText(notification.kind);
+  md.appendMarkdown('\n');
+  md.appendMarkdown('- Title: ');
+  md.appendText(notification.title);
+  md.appendMarkdown('\n');
+  if (notification.body) {
+    md.appendMarkdown('- Body: ');
+    md.appendText(notification.body);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('- Created: ');
+  md.appendText(notification.createdAt);
+  md.appendMarkdown('\n');
+  if (notification.targetSession) {
+    md.appendMarkdown('- Target: ');
+    md.appendText(notification.targetSession);
+    md.appendMarkdown('\n');
+  }
+  if (notification.sourceSession) {
+    md.appendMarkdown('- Source: ');
+    md.appendText(notification.sourceSession);
+    md.appendMarkdown('\n');
+  }
+  if (notification.action) {
+    md.appendMarkdown('- Action: ');
+    md.appendText(`${notification.action.type}:${notification.action.session}`);
+    md.appendMarkdown('\n');
+  }
+  md.appendMarkdown('\n');
+  md.appendText(footer);
+  return md;
+}

--- a/src/providers/tmuxSessionProvider.ts
+++ b/src/providers/tmuxSessionProvider.ts
@@ -23,6 +23,13 @@ import {
   type WorkerRuntimeState,
 } from '../core/workerRuntimeState';
 import type { WorkerRuntimeStateSource } from '../core/workerRuntimeStateService';
+import {
+  buildNotificationTooltip,
+  formatNotificationDescription,
+  formatNotificationDetailLabel,
+  getNotificationIcon,
+  getNotificationThemeColor,
+} from './notificationPresentation';
 
 export type Classification = 'attached' | 'alive' | 'idle' | 'stopped' | 'orphan';
 
@@ -499,35 +506,6 @@ function compareSourceAttentionNotifications(a: HydraNotification, b: HydraNotif
   return a.id.localeCompare(b.id);
 }
 
-function getNotificationThemeColor(kind: NotificationKind): vscode.ThemeColor {
-  switch (kind) {
-    case 'error':
-      return new vscode.ThemeColor('charts.red');
-    case 'blocked':
-      return new vscode.ThemeColor('charts.purple');
-    case 'needs-input':
-      return new vscode.ThemeColor('charts.yellow');
-    case 'complete':
-      return new vscode.ThemeColor('charts.green');
-    case 'info':
-      return new vscode.ThemeColor('charts.blue');
-  }
-}
-
-function getNotificationIcon(kind: NotificationKind): string {
-  switch (kind) {
-    case 'error':
-      return 'error';
-    case 'blocked':
-    case 'needs-input':
-      return 'warning';
-    case 'complete':
-      return 'pass';
-    case 'info':
-      return 'info';
-  }
-}
-
 function getWorkerRuntimeThemeIcon(state: WorkerRuntimeState | undefined): vscode.ThemeIcon {
   switch (state) {
     case 'running':
@@ -561,74 +539,6 @@ function formatWorkerRuntimeStateLabel(runtimeState: WorkerRuntimeProjection | u
     default:
       return state;
   }
-}
-
-function formatNotificationDetailLabel(notification: HydraNotification): string {
-  const title = notification.title || notification.body || 'Notification';
-  return notification.kind === 'complete'
-    ? title
-    : `${notification.kind}: ${title}`;
-}
-
-function formatNotificationSessionLabel(sessionName: string | null): string | undefined {
-  if (!sessionName) return undefined;
-  return sessionName.replace(/^task_/, '');
-}
-
-function formatNotificationDescription(notification: HydraNotification): string | undefined {
-  const parts = [
-    formatNotificationSessionLabel(notification.sourceSession),
-    formatNotificationAge(notification.createdAt),
-  ].filter(Boolean);
-  return parts.length > 0 ? parts.join(' · ') : undefined;
-}
-
-function formatNotificationAge(createdAt: string): string | undefined {
-  const timestamp = Date.parse(createdAt);
-  if (!Number.isFinite(timestamp)) {
-    return undefined;
-  }
-  return formatLastActive(Math.floor(timestamp / 1000));
-}
-
-function buildNotificationTooltip(
-  notification: HydraNotification,
-  footer: string,
-): vscode.MarkdownString {
-  const md = new vscode.MarkdownString();
-  md.appendMarkdown('**Hydra notification**\n\n');
-  md.appendMarkdown('- Kind: ');
-  md.appendText(notification.kind);
-  md.appendMarkdown('\n');
-  md.appendMarkdown('- Title: ');
-  md.appendText(notification.title);
-  md.appendMarkdown('\n');
-  if (notification.body) {
-    md.appendMarkdown('- Body: ');
-    md.appendText(notification.body);
-    md.appendMarkdown('\n');
-  }
-  md.appendMarkdown('- Created: ');
-  md.appendText(notification.createdAt);
-  md.appendMarkdown('\n');
-  if (notification.targetSession) {
-    md.appendMarkdown('- Target: ');
-    md.appendText(notification.targetSession);
-    md.appendMarkdown('\n');
-  }
-  if (notification.sourceSession) {
-    md.appendMarkdown('- Source: ');
-    md.appendText(notification.sourceSession);
-    md.appendMarkdown('\n');
-  }
-  if (notification.action) {
-    md.appendMarkdown('- Action: ');
-    md.appendText(`${notification.action.type}:${notification.action.session}`);
-    md.appendMarkdown('\n');
-  }
-  md.appendMarkdown('\n');
-  md.appendText(footer);
-  return md;
 }
 
 function formatWorkerStatusLabel(kind: NotificationKind): string {

--- a/src/smoke/notificationInboxProjectionSmoke.ts
+++ b/src/smoke/notificationInboxProjectionSmoke.ts
@@ -1,0 +1,115 @@
+/**
+ * Smoke test: notification inbox projection.
+ *
+ * Run: node out/smoke/notificationInboxProjectionSmoke.js
+ */
+
+import assert from 'node:assert/strict';
+import { buildNotificationInboxProjection } from '../core/notificationInboxProjection';
+import type { NotificationSnapshot } from '../core/notificationState';
+import type { HydraNotification, NotificationKind } from '../core/notifications';
+
+function notification(
+  id: string,
+  kind: NotificationKind,
+  createdAt: string,
+  overrides: Partial<HydraNotification> = {},
+): HydraNotification {
+  return {
+    id,
+    createdAt,
+    readAt: null,
+    kind,
+    title: `${kind} title`,
+    body: '',
+    targetSession: 'repo_copilot',
+    sourceSession: 'repo_worker',
+    ...overrides,
+  };
+}
+
+function snapshot(notifications: HydraNotification[]): NotificationSnapshot {
+  return {
+    loadedAt: '2026-06-24T00:00:00.000Z',
+    lastEventSeq: 42,
+    notifications,
+    totalCount: notifications.length,
+    unreadCount: notifications.filter(item => item.readAt === null).length,
+  };
+}
+
+function testUnreadOnlyAndNoDuplicateTargetSource(): void {
+  const projection = buildNotificationInboxProjection(snapshot([
+    notification('read', 'error', '2026-06-24T00:00:00.000Z', {
+      readAt: '2026-06-24T00:01:00.000Z',
+    }),
+    notification('target-source', 'complete', '2026-06-24T00:02:00.000Z', {
+      targetSession: 'repo_copilot',
+      sourceSession: 'repo_worker',
+    }),
+  ]));
+
+  assert.equal(projection.loadedAt, '2026-06-24T00:00:00.000Z');
+  assert.equal(projection.lastEventSeq, 42);
+  assert.equal(projection.unreadCount, 1);
+  assert.deepEqual(projection.items.map(item => item.notification.id), ['target-source']);
+  assert.equal(projection.groups.length, 1);
+  assert.equal(projection.groups[0].id, 'target:repo_copilot');
+  assert.equal(projection.groups[0].source, 'target');
+  assert.equal(projection.groups[0].items.length, 1);
+}
+
+function testPriorityAndNewestOrdering(): void {
+  const projection = buildNotificationInboxProjection(snapshot([
+    notification('complete-newest', 'complete', '2026-06-24T00:10:00.000Z'),
+    notification('needs-input-old', 'needs-input', '2026-06-24T00:00:00.000Z'),
+    notification('blocked-middle', 'blocked', '2026-06-24T00:05:00.000Z'),
+    notification('needs-input-new', 'needs-input', '2026-06-24T00:06:00.000Z'),
+  ]));
+
+  assert.deepEqual(
+    projection.items.map(item => item.notification.id),
+    ['blocked-middle', 'needs-input-new', 'needs-input-old', 'complete-newest'],
+  );
+  assert.equal(projection.groups[0].kind, 'blocked');
+}
+
+function testSourceAndUnassignedFallbackGroups(): void {
+  const projection = buildNotificationInboxProjection(snapshot([
+    notification('source-only', 'info', '2026-06-24T00:00:00.000Z', {
+      targetSession: null,
+      sourceSession: 'orphan_worker',
+    }),
+    notification('unassigned', 'error', '2026-06-24T00:01:00.000Z', {
+      targetSession: null,
+      sourceSession: null,
+    }),
+  ]));
+
+  assert.deepEqual(
+    projection.groups.map(group => group.id),
+    ['unassigned', 'source:orphan_worker'],
+  );
+  assert.equal(projection.groups[0].source, 'unassigned');
+  assert.equal(projection.groups[1].source, 'source');
+  assert.equal(projection.groups[1].sessionName, 'orphan_worker');
+}
+
+function testStableTieBreakById(): void {
+  const projection = buildNotificationInboxProjection(snapshot([
+    notification('b', 'info', '2026-06-24T00:00:00.000Z'),
+    notification('a', 'info', '2026-06-24T00:00:00.000Z'),
+  ]));
+
+  assert.deepEqual(projection.items.map(item => item.notification.id), ['a', 'b']);
+}
+
+function main(): void {
+  testUnreadOnlyAndNoDuplicateTargetSource();
+  testPriorityAndNewestOrdering();
+  testSourceAndUnassignedFallbackGroups();
+  testStableTieBreakById();
+  console.log('notificationInboxProjectionSmoke: ok');
+}
+
+main();

--- a/src/smoke/notificationStateServiceSmoke.ts
+++ b/src/smoke/notificationStateServiceSmoke.ts
@@ -112,7 +112,7 @@ function parseStdoutJson<T>(proc: SpawnSyncReturns<string>, label: string): T {
   return JSON.parse(proc.stdout) as T;
 }
 
-function readEventLines(ctx: TestContext): Array<{ type?: string; source?: string; payload?: { notificationId?: string } }> {
+function readEventLines(ctx: TestContext): Array<{ type?: string; source?: string; payload?: { notificationId?: string; readOnly?: boolean } }> {
   const eventsPath = path.join(ctx.hydraHome, 'events.jsonl');
   if (!fs.existsSync(eventsPath)) {
     return [];
@@ -413,13 +413,17 @@ async function testBatchReadAndClearEventSources(): Promise<void> {
         );
         assert.equal(readEvents.length, 2, 'batch read should emit one extension notify.read per notification');
 
-        const cleared = service.clear({ session: 'repo_worker' }, 'extension');
+        const cleared = service.clearRead({ session: 'repo_worker' }, 'extension');
         assert.equal(cleared.cleared, 2);
+        assert.equal(service.getById(first.id), undefined);
+        assert.equal(service.getById(second.id), undefined);
+        assert.equal(service.getUnreadCount(), 1, 'clearRead should preserve unread notifications');
         const clearEvents = readEventLines(ctx).filter(event =>
           event.type === 'notify.cleared' &&
-          event.source === 'extension'
+          event.source === 'extension' &&
+          event.payload?.readOnly === true
         );
-        assert.equal(clearEvents.length, 1, 'clear should emit an extension notify.cleared event');
+        assert.equal(clearEvents.length, 1, 'clearRead should emit an extension notify.cleared event');
       } finally {
         service.dispose();
       }
@@ -460,6 +464,73 @@ async function testEventOnlyCompletionProjectionEmitsChange(): Promise<void> {
         assert.ok(changes > 0, 'event-only completion projection should emit a change');
       } finally {
         listener.dispose();
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testEventOnlyClearReadPreservesUnreadProjection(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-event-clear-read-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const eventLog = new EventLog();
+      eventLog.append({
+        type: 'notify.created',
+        source: 'hook',
+        payload: {
+          notificationId: 'event-unread-complete',
+          kind: 'complete',
+          targetSession: 'repo_copilot',
+          sourceSession: 'unread_worker',
+          actionType: 'open-session',
+          actionSession: 'unread_worker',
+        },
+      });
+      eventLog.append({
+        type: 'notify.created',
+        source: 'hook',
+        payload: {
+          notificationId: 'event-read-complete',
+          kind: 'complete',
+          targetSession: 'repo_copilot',
+          sourceSession: 'read_worker',
+          actionType: 'open-session',
+          actionSession: 'read_worker',
+        },
+      });
+      eventLog.append({
+        type: 'notify.read',
+        source: 'extension',
+        payload: {
+          notificationId: 'event-read-complete',
+        },
+      });
+      eventLog.append({
+        type: 'notify.cleared',
+        source: 'extension',
+        payload: {
+          readOnly: true,
+          cleared: 1,
+        },
+      });
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(
+          service.getLatestSourceAttention('unread_worker')?.id,
+          'event-unread-complete',
+          'read-only clear must preserve unread event-only source attention',
+        );
+        assert.equal(
+          service.getLatestSourceAttention('read_worker'),
+          undefined,
+          'read-only clear should remove read event-only source attention',
+        );
+      } finally {
         service.dispose();
       }
     });
@@ -830,6 +901,7 @@ async function main(): Promise<void> {
   await testWatcherUpdatesFromNotificationFileOnly();
   await testBatchReadAndClearEventSources();
   await testEventOnlyCompletionProjectionEmitsChange();
+  await testEventOnlyClearReadPreservesUnreadProjection();
   await testSourceAttentionProjectionUsesLatestStatus();
   await testEventOnlyErrorProjectionEmitsChange();
   await testStoredNotificationWinsOverDuplicateEventProjection();

--- a/src/smoke/notifyCliSmoke.ts
+++ b/src/smoke/notifyCliSmoke.ts
@@ -215,6 +215,62 @@ function main(): void {
     assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4]);
     assert.equal(fs.readFileSync(eventsPath, 'utf-8').includes('Branch: feat/auth'), false);
 
+    const readClearTarget = parseStdoutJson<{ notification: { id: string } }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'read_clear_target',
+        '--kind',
+        'info',
+        '--title',
+        'Read notification',
+        '--json',
+      ], ctx.env),
+      'hydra notify create read-clear target --json',
+    );
+    const unreadPreserved = parseStdoutJson<{ notification: { id: string } }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'read_clear_target',
+        '--kind',
+        'info',
+        '--title',
+        'Unread notification',
+        '--json',
+      ], ctx.env),
+      'hydra notify create unread preserved --json',
+    );
+    parseStdoutJson<{ markedRead: number }>(
+      runCli(['notify', 'read', readClearTarget.notification.id, '--json'], ctx.env),
+      'hydra notify read read-clear target --json',
+    );
+    const readCleared = parseStdoutJson<{ status: string; cleared: number }>(
+      runCli(['notify', 'clear', '--target', 'read_clear_target', '--read', '--json'], ctx.env),
+      'hydra notify clear --read --json',
+    );
+    assert.equal(readCleared.status, 'ok');
+    assert.equal(readCleared.cleared, 1);
+    const preservedAfterReadClear = parseStdoutJson<{
+      notifications: Array<{ id: string; readAt: string | null }>;
+      count: number;
+      unreadCount: number;
+      totalCount: number;
+    }>(
+      runCli(['notify', 'list', '--target', 'read_clear_target', '--json'], ctx.env),
+      'hydra notify list after clear --read --json',
+    );
+    assert.equal(preservedAfterReadClear.count, 1);
+    assert.equal(preservedAfterReadClear.unreadCount, 1);
+    assert.equal(preservedAfterReadClear.notifications[0].id, unreadPreserved.notification.id);
+    assert.equal(preservedAfterReadClear.notifications[0].readAt, null);
+    parseStdoutJson<{ cleared: number }>(
+      runCli(['notify', 'clear', '--target', 'read_clear_target', '--json'], ctx.env),
+      'hydra notify clear read-clear target --json',
+    );
+
     const blocked = parseStdoutJson<{
       status: string;
       created: boolean;


### PR DESCRIPTION
## Summary
- add the VS Code `hydraInbox` view for unread-first Hydra notifications
- add a pure inbox projection over notification state snapshots
- add mark-read and clear-read actions, including `hydra notify clear --read`
- extract shared notification presentation helpers for worker tree and inbox rows

## Validation
- `npm run compile`
- `npm run lint`
- `npm run smoke:notification-inbox-projection`
- `npm run smoke:notification-state`
- `npm run smoke:notify-cli`
- `npm run smoke:session-notification-summary`
- `npm test`
- Extension Development Host launched from the final stacked branch with `/tmp/hydra-e2e-clean-MBJ8wyyP` and loaded `/Users/hanlu/Desktop/ai/hydra`