### PR TITLE
chore: release v0.3.2026062800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.2026062800] - 2026-06-28
+
+### Added
+- Add Antigravity (`agy`) as a first-class agent type for copilots and workers, including ready-state and trust-prompt handling, `--conversation` resume, and per-worker completion-notify hooks isolated by workspace path
+
 ## [0.3.2026062400] - 2026-06-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-code",
-  "version": "0.3.2026062400",
+  "version": "0.3.2026062800",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-code",
-      "version": "0.3.2026062400",
+      "version": "0.3.2026062800",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026062400",
+  "version": "0.3.2026062800",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Release v0.3.2026062800

### Added
- Add Antigravity (`agy`) as a first-class agent type for copilots and workers, including ready-state and trust-prompt handling, `--conversation` resume, and per-worker completion-notify hooks isolated by workspace path (#264).