### PR TITLE
[codex] Fix worker delete stale runtime state

### DIFF
--- a/packages/core/src/core/sessionManager.ts
+++ b/packages/core/src/core/sessionManager.ts
@@ -354,6 +354,7 @@ export class SessionManager {
   async sync(): Promise<SessionState> {
     const liveSessions = await this.backend.listSessions();
     const liveSessionMap = new Map(liveSessions.map(s => [s.name, s]));
+    const orphanedWorkerSessions: string[] = [];
     const discoveredSessions = new Map<string, {
       role: 'worker' | 'copilot';
       agent: string;
@@ -376,7 +377,7 @@ export class SessionManager {
       });
     }));
 
-    return this.updateSessionState((state) => {
+    const state = await this.updateSessionState((state) => {
       const now = new Date().toISOString();
       let dirty = false;
 
@@ -410,6 +411,7 @@ export class SessionManager {
           if (worker.attached !== false) { worker.attached = false; dirty = true; }
         } else {
           // Orphan: tmux dead + no worktree
+          orphanedWorkerSessions.push(worker.sessionName);
           delete state.workers[key];
           dirty = true;
         }
@@ -495,6 +497,10 @@ export class SessionManager {
       markSessionStateDirty(state, dirty);
       return state;
     });
+    for (const sessionName of orphanedWorkerSessions) {
+      this.clearWorkerRuntimeState(sessionName, 'sync-orphan');
+    }
+    return state;
   }
 
   async listWorkers(repoRoot?: string): Promise<WorkerInfo[]> {
@@ -920,61 +926,77 @@ export class SessionManager {
             throw error;
           }
         }
-      } else if (worker && worker.workdir && worker.repoRoot && fs.existsSync(worker.workdir)) {
-        logger.info('session.delete', 'Removing worker worktree', {
-          ...context,
-          phase: 'removeWorktree',
-          repoRoot: worker.repoRoot,
-        });
-        try {
-          await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
-          removedWorktree = true;
-          logger.info('session.delete', 'Removed worker worktree', {
+      } else if (worker && isRepoWorker(worker) && worker.workdir) {
+        const workdirExists = fs.existsSync(worker.workdir);
+        const canRunGitCleanup = workdirExists && await this.canRunRepoWorkerGitCleanup(worker);
+        if (workdirExists && canRunGitCleanup && worker.repoRoot) {
+          logger.info('session.delete', 'Removing worker worktree', {
             ...context,
             phase: 'removeWorktree',
-            repoRoot: worker.repoRoot,
-          });
-        } catch (error) {
-          await this.updateSessionState((state) => {
-            if (state.workers[sessionName]) {
-              state.workers[sessionName].status = 'stopped';
-              state.workers[sessionName].attached = false;
-              state.updatedAt = new Date().toISOString();
-            }
-          });
-          logger.error('session.delete', 'Failed to remove worker worktree', {
-            ...context,
-            phase: 'removeWorktree',
-            repoRoot: worker.repoRoot,
-            error,
-          });
-          throw error;
-        }
-
-        if (worker.branch) {
-          logger.info('session.delete', 'Deleting worker branch', {
-            ...context,
-            phase: 'deleteBranch',
             repoRoot: worker.repoRoot,
           });
           try {
-            await exec(`git branch -D ${shellQuote(worker.branch)}`, {
-              cwd: worker.repoRoot,
-              logFailure: false,
-            });
-            deletedBranch = true;
-            logger.info('session.delete', 'Deleted worker branch', {
+            await coreGit.removeWorktree(worker.repoRoot, worker.workdir);
+            removedWorktree = true;
+            logger.info('session.delete', 'Removed worker worktree', {
               ...context,
-              phase: 'deleteBranch',
+              phase: 'removeWorktree',
               repoRoot: worker.repoRoot,
             });
-          } catch {
-            logger.debug('session.delete', 'Worker branch was not deleted', {
-              ...context,
-              phase: 'deleteBranch',
-              repoRoot: worker.repoRoot,
+          } catch (error) {
+            await this.updateSessionState((state) => {
+              if (state.workers[sessionName]) {
+                state.workers[sessionName].status = 'stopped';
+                state.workers[sessionName].attached = false;
+                state.updatedAt = new Date().toISOString();
+              }
             });
+            logger.error('session.delete', 'Failed to remove worker worktree', {
+              ...context,
+              phase: 'removeWorktree',
+              repoRoot: worker.repoRoot,
+              error,
+            });
+            throw error;
           }
+
+          if (worker.branch) {
+            logger.info('session.delete', 'Deleting worker branch', {
+              ...context,
+              phase: 'deleteBranch',
+              repoRoot: worker.repoRoot,
+            });
+            try {
+              await exec(`git branch -D ${shellQuote(worker.branch)}`, {
+                cwd: worker.repoRoot,
+                logFailure: false,
+              });
+              deletedBranch = true;
+              logger.info('session.delete', 'Deleted worker branch', {
+                ...context,
+                phase: 'deleteBranch',
+                repoRoot: worker.repoRoot,
+              });
+            } catch {
+              logger.debug('session.delete', 'Worker branch was not deleted', {
+                ...context,
+                phase: 'deleteBranch',
+                repoRoot: worker.repoRoot,
+              });
+            }
+          }
+        } else if (workdirExists) {
+          logger.warn('session.delete', 'Skipping worker worktree cleanup because repo root is unavailable', {
+            ...context,
+            phase: 'skipWorktreeCleanup',
+            repoRoot: worker.repoRoot,
+          });
+        } else {
+          logger.info('session.delete', 'Skipping worker worktree cleanup because workdir is already absent', {
+            ...context,
+            phase: 'skipWorktreeCleanup',
+            repoRoot: worker.repoRoot,
+          });
         }
       }
 
@@ -994,6 +1016,7 @@ export class SessionManager {
           state.updatedAt = new Date().toISOString();
         }
       });
+      this.clearWorkerRuntimeState(sessionName, 'worker-deleted');
 
       // agy stores completion hooks in a single global file; removing the
       // worker means its named entry there is dead weight that fires (as a
@@ -1812,6 +1835,25 @@ export class SessionManager {
         error,
       });
     }
+  }
+
+  private clearWorkerRuntimeState(sessionName: string, reason: string): void {
+    try {
+      this.runtimeStateStore.clear(sessionName);
+    } catch (error) {
+      logger.warn('session.worker-runtime-state', 'Failed to clear worker runtime state', {
+        sessionName,
+        reason,
+        error,
+      });
+    }
+  }
+
+  private async canRunRepoWorkerGitCleanup(worker: WorkerInfo): Promise<boolean> {
+    if (!worker.repoRoot || !fs.existsSync(worker.repoRoot)) {
+      return false;
+    }
+    return coreGit.isGitRepo(worker.repoRoot);
   }
 
   private emitCopilotEvent(type: string, copilot: CopilotInfo, payload: Record<string, unknown> = {}): void {

--- a/packages/core/src/smoke/workerDeleteFailClosedSmoke.ts
+++ b/packages/core/src/smoke/workerDeleteFailClosedSmoke.ts
@@ -221,6 +221,29 @@ function writeWorkerState(sessionsFile: string, worker: WorkerRecord): void {
   });
 }
 
+function writeWorkerRuntimeState(runtimeStateFile: string, worker: WorkerRecord): void {
+  writeJson(runtimeStateFile, {
+    version: 1,
+    workers: {
+      [worker.sessionName]: {
+        sessionName: worker.sessionName,
+        state: 'running',
+        updatedAt: new Date().toISOString(),
+        origin: 'session-manager',
+        reason: 'worker-created',
+        workerId: worker.workerId,
+        agent: worker.agent,
+        workdir: worker.workdir,
+      },
+    },
+  });
+}
+
+function readWorkerRuntimeState(runtimeStateFile: string, sessionName: string): unknown {
+  const state = readJson<{ workers?: Record<string, unknown> }>(runtimeStateFile, { workers: {} });
+  return state.workers?.[sessionName];
+}
+
 async function main(): Promise<void> {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-'));
   process.env.HOME = tempHome;
@@ -231,6 +254,7 @@ async function main(): Promise<void> {
 
   const sessionsFile = path.join(hydraDir, 'sessions.json');
   const archiveFile = path.join(hydraDir, 'archive.json');
+  const runtimeStateFile = path.join(hydraDir, 'worker-runtime-state.json');
 
   const coreExec = await import('../core/exec') as unknown as Record<string, unknown>;
   const coreGit = await import('../core/git') as unknown as Record<string, unknown>;
@@ -250,6 +274,7 @@ async function main(): Promise<void> {
     let removeWorktreeCalls = 0;
     const branchDeleteCommands: string[] = [];
     const restoreCoreGit = patchModule(coreGit, {
+      isGitRepo: async () => true,
       removeWorktree: async () => {
         removeWorktreeCalls += 1;
       },
@@ -294,6 +319,7 @@ async function main(): Promise<void> {
     let removeWorktreeCalls = 0;
     const branchDeleteCommands: string[] = [];
     const restoreCoreGit = patchModule(coreGit, {
+      isGitRepo: async () => true,
       removeWorktree: async () => {
         removeWorktreeCalls += 1;
       },
@@ -328,6 +354,7 @@ async function main(): Promise<void> {
     const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-worktree-'));
     const worker = buildWorker('worker-delete-worktree-fails', repoRoot, workdir);
     writeWorkerState(sessionsFile, worker);
+    writeWorkerRuntimeState(runtimeStateFile, worker);
     writeJson(archiveFile, { entries: [] });
 
     const backend = new DeleteWorkerBackend([worker.sessionName]);
@@ -335,6 +362,7 @@ async function main(): Promise<void> {
     let removeWorktreeCalls = 0;
     const branchDeleteCommands: string[] = [];
     const restoreCoreGit = patchModule(coreGit, {
+      isGitRepo: async () => true,
       removeWorktree: async () => {
         removeWorktreeCalls += 1;
         throw makeExecError('worktree remove failed', 'contains modified or untracked files');
@@ -371,6 +399,123 @@ async function main(): Promise<void> {
     assert.equal(branchDeleteCommands.length, 0);
     assert.equal(await backend.hasSession(worker.sessionName), false);
     assert.ok(fs.existsSync(workdir), 'worktree should remain after worktree removal failure');
+    assert.ok(readWorkerRuntimeState(runtimeStateFile, worker.sessionName), 'runtime state should remain after worktree removal failure');
+  }
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-repo-'));
+    const workdir = path.join(os.tmpdir(), `hydra-worker-delete-missing-${Date.now()}`);
+    const worker = buildWorker('worker-delete-workdir-missing', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeWorkerRuntimeState(runtimeStateFile, worker);
+    writeJson(archiveFile, { entries: [] });
+
+    const backend = new DeleteWorkerBackend();
+    backend.killError = makeExecError('kill-session failed', `can't find session: ${worker.sessionName}`);
+
+    let isGitRepoCalls = 0;
+    let removeWorktreeCalls = 0;
+    const branchDeleteCommands: string[] = [];
+    const restoreCoreGit = patchModule(coreGit, {
+      isGitRepo: async () => {
+        isGitRepoCalls += 1;
+        return true;
+      },
+      removeWorktree: async () => {
+        removeWorktreeCalls += 1;
+      },
+    });
+    const restoreExec = patchModule(coreExec, {
+      exec: async (command: string) => {
+        branchDeleteCommands.push(command);
+        return '';
+      },
+    });
+
+    try {
+      const sm = new SessionManager(backend);
+      await sm.deleteWorker(worker.sessionName);
+    } finally {
+      restoreExec();
+      restoreCoreGit();
+    }
+
+    const archive = readJson<{ entries: Array<{ sessionName: string }> }>(archiveFile, { entries: [] });
+    const state = readJson<{ workers: Record<string, unknown> }>(sessionsFile, { workers: {} });
+    assert.equal(archive.entries.length, 1);
+    assert.equal(archive.entries[0]?.sessionName, worker.sessionName);
+    assert.equal(state.workers[worker.sessionName], undefined);
+    assert.equal(isGitRepoCalls, 0);
+    assert.equal(removeWorktreeCalls, 0);
+    assert.equal(branchDeleteCommands.length, 0);
+    assert.equal(readWorkerRuntimeState(runtimeStateFile, worker.sessionName), undefined);
+  }
+
+  {
+    const repoRoot = path.join(os.tmpdir(), `hydra-worker-delete-missing-repo-${Date.now()}`);
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-worktree-'));
+    const worker = buildWorker('worker-delete-repo-root-missing', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeWorkerRuntimeState(runtimeStateFile, worker);
+    writeJson(archiveFile, { entries: [] });
+
+    const backend = new DeleteWorkerBackend();
+    backend.killError = makeExecError('kill-session failed', `can't find session: ${worker.sessionName}`);
+
+    let isGitRepoCalls = 0;
+    let removeWorktreeCalls = 0;
+    const branchDeleteCommands: string[] = [];
+    const restoreCoreGit = patchModule(coreGit, {
+      isGitRepo: async () => {
+        isGitRepoCalls += 1;
+        return true;
+      },
+      removeWorktree: async () => {
+        removeWorktreeCalls += 1;
+      },
+    });
+    const restoreExec = patchModule(coreExec, {
+      exec: async (command: string) => {
+        branchDeleteCommands.push(command);
+        return '';
+      },
+    });
+
+    try {
+      const sm = new SessionManager(backend);
+      await sm.deleteWorker(worker.sessionName);
+    } finally {
+      restoreExec();
+      restoreCoreGit();
+    }
+
+    const archive = readJson<{ entries: Array<{ sessionName: string }> }>(archiveFile, { entries: [] });
+    const state = readJson<{ workers: Record<string, unknown> }>(sessionsFile, { workers: {} });
+    assert.equal(archive.entries.length, 1);
+    assert.equal(archive.entries[0]?.sessionName, worker.sessionName);
+    assert.equal(state.workers[worker.sessionName], undefined);
+    assert.equal(isGitRepoCalls, 0);
+    assert.equal(removeWorktreeCalls, 0);
+    assert.equal(branchDeleteCommands.length, 0);
+    assert.ok(fs.existsSync(workdir), 'workdir should not be deleted when repo root is missing');
+    assert.equal(readWorkerRuntimeState(runtimeStateFile, worker.sessionName), undefined);
+  }
+
+  {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-worker-delete-repo-'));
+    const workdir = path.join(os.tmpdir(), `hydra-worker-delete-sync-orphan-${Date.now()}`);
+    const worker = buildWorker('worker-sync-orphan-runtime-clear', repoRoot, workdir);
+    writeWorkerState(sessionsFile, worker);
+    writeWorkerRuntimeState(runtimeStateFile, worker);
+
+    const backend = new DeleteWorkerBackend();
+    const sm = new SessionManager(backend);
+    const synced = await sm.sync();
+
+    const state = readJson<{ workers: Record<string, unknown> }>(sessionsFile, { workers: {} });
+    assert.equal(synced.workers[worker.sessionName], undefined);
+    assert.equal(state.workers[worker.sessionName], undefined);
+    assert.equal(readWorkerRuntimeState(runtimeStateFile, worker.sessionName), undefined);
   }
 
   {


### PR DESCRIPTION
## Summary
- make worker delete resilient when the saved repo root or workdir is already gone
- clear worker runtime state after successful deletes and sync orphan cleanup
- cover missing repo/workdir and runtime-state cleanup in worker-delete smoke tests

## Root Cause
`deleteWorker()` could enter git cleanup based only on the worker workdir existing, then run `git worktree remove` with `repoRoot` as cwd. If `repoRoot` was already gone, Node failed before shell startup with `spawn /bin/sh ENOENT`. Successful worker deletion and sync orphan cleanup also did not clear `worker-runtime-state.json`.

## Validation
- `npm run compile`
- `npm run smoke:worker-delete`
- `npm run smoke:worker-runtime-state`
- `npm run smoke:task-worker`
- `npm run smoke:task-worker-cli-e2e`
- `npm run e2e:isolated -- -- hydra list --json`
- `npm run lint`
- `git diff --check`

Fixes #266