### PR TITLE
[codex] Fix desktop copilot onboarding

### DIFF
--- a/packages/core/src/core/copilotOnboarding.ts
+++ b/packages/core/src/core/copilotOnboarding.ts
@@ -1,0 +1,44 @@
+import type { CopilotMode } from './types';
+
+export const COPILOT_ONBOARDING_PROMPT = `You are a Hydra copilot - an AI orchestrator that manages parallel AI workers to complete complex tasks.
+
+## Preflight: verify the hydra CLI
+Before anything else, run \`hydra --version\`. If the command is not found, the Hydra VS Code extension installs a wrapper at \`~/.hydra/bin/hydra\` - add it to PATH for this session with \`export PATH="$HOME/.hydra/bin:$PATH"\` and retry. If \`hydra\` is still missing after that, ask the user to (re)install the Hydra VS Code extension before proceeding.
+
+## Key commands
+- \`hydra list --json\`                                   - See all copilots and workers
+- \`hydra worker create --repo <path> --branch <name>\`   - Spawn a code worker
+- \`hydra worker create --dir <path> --name <name>\`      - Spawn a task worker in a folder
+- \`hydra worker create --temp --name <name>\`            - Spawn a managed temp task worker
+- \`hydra worker logs <session> --lines 50\`              - Read worker output
+- \`hydra worker send <session> "<message>"\`              - Send instructions to a worker
+- \`hydra worker delete <session>\`                        - Clean up a finished worker
+
+## Workflow: Plan -> Delegate -> Monitor -> Review -> Ship
+1. Break the task into independent units of work
+2. Create one worker per unit (\`hydra worker create\`)
+3. Monitor progress (\`hydra worker logs\`)
+4. Review code-worker changes (\`git -C <workdir> diff\`) or task-worker output/logs
+5. Iterate if needed (\`hydra worker send\`)
+6. Ship approved work (push branches and create PRs)
+
+Use code workers for repo changes that need branches. Use task workers for research, writing, analysis, or non-git folders. In a git repo, \`hydra worker create\` requires \`--branch\` for code workers; pass \`--dir\` or \`--temp\` when you intentionally want a task worker.
+
+Workers cannot create other workers directly. If a worker reports that more parallel work is needed, you remain responsible for deciding whether to create another worker and assigning that task.
+
+Full reference: https://github.com/sudoprivacy/hydra/blob/main/AGENTS.md`;
+
+export const PLAN_COPILOT_ONBOARDING_PROMPT = `You are a Hydra planner - a plan-only agent that analyzes tasks and produces implementation plans.
+
+## Operating rules
+- Do not edit files, run implementation commands, create workers, commit, push, or open PRs.
+- Read code and documentation as needed.
+- Ask clarifying questions when requirements are ambiguous.
+- Produce a concrete implementation plan that another agent can execute.
+- Include affected files, ordered steps, risks, and verification commands.
+
+This planner cannot create Hydra workers. The user or a separate executor will handle implementation after the plan is approved.`;
+
+export function getCopilotOnboardingPrompt(copilotMode: CopilotMode = 'normal'): string {
+  return copilotMode === 'plan' ? PLAN_COPILOT_ONBOARDING_PROMPT : COPILOT_ONBOARDING_PROMPT;
+}

--- a/packages/extension/src/commands/createCopilot.ts
+++ b/packages/extension/src/commands/createCopilot.ts
@@ -3,59 +3,17 @@ import * as vscode from 'vscode';
 import { getActiveBackend, MultiplexerBackend } from '../utils/multiplexer';
 import { getAgentCommand, pickAgentType, AgentType, AGENT_LABELS } from '../utils/agentConfig';
 import { CopilotMode } from '@hydra/core/types';
+import { getCopilotOnboardingPrompt } from '@hydra/core/copilotOnboarding';
 import { TmuxBackendCore } from '@hydra/core/tmux';
 import { SessionManager } from '@hydra/core/sessionManager';
 import { ensureBackendInstalled } from './ensureBackendInstalled';
 import { showHydraCommandError } from './logs';
 
-const ONBOARDING_PROMPT = `You are a Hydra copilot — an AI orchestrator that manages parallel AI workers to complete complex tasks.
-
-## Preflight: verify the hydra CLI
-Before anything else, run \`hydra --version\`. If the command is not found, the Hydra VS Code extension installs a wrapper at \`~/.hydra/bin/hydra\` — add it to PATH for this session with \`export PATH="$HOME/.hydra/bin:$PATH"\` and retry. If \`hydra\` is still missing after that, ask the user to (re)install the Hydra VS Code extension before proceeding.
-
-## Key commands
-- \`hydra list --json\`                                   — See all copilots and workers
-- \`hydra worker create --repo <path> --branch <name>\`   — Spawn a code worker
-- \`hydra worker create --dir <path> --name <name>\`      — Spawn a task worker in a folder
-- \`hydra worker create --temp --name <name>\`            — Spawn a managed temp task worker
-- \`hydra worker logs <session> --lines 50\`              — Read worker output
-- \`hydra worker send <session> "<message>"\`              — Send instructions to a worker
-- \`hydra worker delete <session>\`                        — Clean up a finished worker
-
-## Workflow: Plan → Delegate → Monitor → Review → Ship
-1. Break the task into independent units of work
-2. Create one worker per unit (\`hydra worker create\`)
-3. Monitor progress (\`hydra worker logs\`)
-4. Review code-worker changes (\`git -C <workdir> diff\`) or task-worker output/logs
-5. Iterate if needed (\`hydra worker send\`)
-6. Ship approved work (push branches and create PRs)
-
-Use code workers for repo changes that need branches. Use task workers for research, writing, analysis, or non-git folders. In a git repo, \`hydra worker create\` requires \`--branch\` for code workers; pass \`--dir\` or \`--temp\` when you intentionally want a task worker.
-
-Workers cannot create other workers directly. If a worker reports that more parallel work is needed, you remain responsible for deciding whether to create another worker and assigning that task.
-
-Full reference: https://github.com/sudoprivacy/hydra/blob/main/AGENTS.md`;
-
-const PLAN_ONBOARDING_PROMPT = `You are a Hydra planner — a plan-only agent that analyzes tasks and produces implementation plans.
-
-## Operating rules
-- Do not edit files, run implementation commands, create workers, commit, push, or open PRs.
-- Read code and documentation as needed.
-- Ask clarifying questions when requirements are ambiguous.
-- Produce a concrete implementation plan that another agent can execute.
-- Include affected files, ordered steps, risks, and verification commands.
-
-This planner cannot create Hydra workers. The user or a separate executor will handle implementation after the plan is approved.`;
-
-function getOnboardingPrompt(copilotMode: CopilotMode): string {
-  return copilotMode === 'plan' ? PLAN_ONBOARDING_PROMPT : ONBOARDING_PROMPT;
-}
-
 export function sendCopilotOnboarding(backend: MultiplexerBackend, sessionName: string, copilotMode: CopilotMode): void {
   (async () => {
     try {
       await new Promise(resolve => setTimeout(resolve, 8000));
-      await backend.sendMessage(sessionName, getOnboardingPrompt(copilotMode));
+      await backend.sendMessage(sessionName, getCopilotOnboardingPrompt(copilotMode));
     } catch {
       // Best-effort — agent may not be ready yet
     }

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -32,6 +32,8 @@
 //  Topic.notifications      NotificationStateService.onDidChange
 //  openTerminal             node-pty ⇄ tmux attach (M3 — not yet implemented)
 
+import * as os from 'node:os';
+
 import { TmuxBackendCore } from '@hydra/core/tmux';
 import {
   isDirectoryWorker,
@@ -49,6 +51,7 @@ import { getRepoRootFromPath, localBranchExists, fetchOriginRequired } from '@hy
 import { resolveRepoInput } from '@hydra/core/repoRegistry';
 import { getHydraGlobalDefaultAgent } from '@hydra/core/hydraGlobalConfig';
 import { DiffService } from '@hydra/core/diff';
+import { getCopilotOnboardingPrompt } from '@hydra/core/copilotOnboarding';
 
 import { collectCodeWorkerGitStatus } from './gitStatus';
 
@@ -329,12 +332,13 @@ export class HydraAppService implements HydraAppServiceApi {
         await fetchOriginRequired(workdir);
       }
     } else {
-      workdir = expandAndResolvePath(input.workdir ?? process.cwd());
+      workdir = expandAndResolvePath(input.workdir ?? os.homedir());
     }
 
     const copilot = await this.sessionManager.createCopilotAndFinalize({
       workdir, agentType, copilotMode, name: input.name, sessionName,
     });
+    await this.sendCopilotOnboarding(copilot.sessionName, copilot.copilotMode);
 
     return {
       status: 'created',
@@ -344,6 +348,14 @@ export class HydraAppService implements HydraAppServiceApi {
       workdir: copilot.workdir,
       agentSessionId: copilot.sessionId,
     };
+  }
+
+  private async sendCopilotOnboarding(sessionName: string, copilotMode: CopilotMode): Promise<void> {
+    try {
+      await this.backend.sendMessage(sessionName, getCopilotOnboardingPrompt(copilotMode));
+    } catch {
+      // Best effort: the copilot itself is already created and ready.
+    }
   }
 
   /** SessionManager.startWorker / startCopilot. */

--- a/packages/sidecar/src/smoke/seamSmoke.ts
+++ b/packages/sidecar/src/smoke/seamSmoke.ts
@@ -80,6 +80,19 @@ async function main(): Promise<void> {
     assert.deepEqual(empty.workers, [], 'no workers initially');
     assert.equal(empty.count, 0, 'count is 0 initially');
 
+    // Desktop-created copilots must receive the same Hydra onboarding prompt
+    // that the VS Code extension sends after creating a copilot.
+    const copilot = await client.createCopilot({ agent: 'claude', name: 'seam-copilot' });
+    assert.equal(copilot.status, 'created', 'copilot created');
+    assert.equal(copilot.workdir, tempHome, 'desktop seam defaults copilot workdir to HOME');
+    assert.ok(
+      backend.messages.some(m =>
+        m.sessionName === copilot.session && m.message.includes('You are a Hydra copilot'),
+      ),
+      'desktop seam sends copilot onboarding prompt',
+    );
+    await client.deleteSession(copilot.session, 'copilot');
+
     // ── Mutation: create + delete a task worker ──
     const created = await client.createWorker({ temp: true, name: 'seam-temp', agent: 'claude' });
     assert.equal(created.status, 'created', 'worker created');


### PR DESCRIPTION
## Summary
- share Hydra copilot/planner onboarding prompts from @hydra/core
- send onboarding from the desktop sidecar after copilot creation finalizes
- default desktop-created copilot workdir to HOME instead of the packaged app cwd
- cover the desktop seam with smoke assertions

## Root cause
Desktop copilot creation called SessionManager directly and did not run the VS Code-only onboarding sender. When no workdir was supplied, the packaged app process cwd was used, so Codex started in / and showed no AGENTS.md.

## Validation
- npm run compile
- npm run lint
- npm run smoke:seam