### PR TITLE
[codex] Add completion notification acknowledgements

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -184,7 +184,7 @@ Current event types:
 | --- | --- | --- | --- |
 | `notify.created` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `notificationId`, `kind`, `title`, redacted `body`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `workdir`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
 | `notify.read` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
-| `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`. Emitted only when at least one notification is removed. |
+| `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`, `kind`. Emitted only when at least one notification is removed. |
 | `worker.created` | `session-manager` | `worker` | `workerId`, `source`, optional `branch`, `repo`, `managedWorkdir`. Emitted for fresh code/task worker creation. |
 | `worker.started` | `session-manager` | `worker` | Worker identity fields plus `resumed`; existing-branch paths also include `alreadyRunning`. Emitted when an existing worker session is started or reused. |
 | `worker.runtime.changed` | `cli`, `extension`, `session-manager`, or `hook` | `worker` | `state`, optional `previousState`, `origin`, `reason`, `notificationId`, `workerId`, `updatedAt`. Emitted when the durable worker runtime projection changes. |
@@ -285,7 +285,7 @@ Returns:
 | `status` | string | `"ok"`. |
 | `cleared` | number | Number of notifications removed. |
 
-`--session`, `--target`, and `--from` narrow which notifications are cleared.
+`--session`, `--target`, `--from`, and `--kind` narrow which notifications are cleared.
 With no filter, all notifications are cleared.
 
 ### `hydra notify open <id> --json`
@@ -366,7 +366,7 @@ Notify commands:
 | `notify create` | Create a structured local notification. Supports `--session`, `--from`, `--kind`, `--title`, `--body`, `--dedupe-key`, `--action`, and context flags. |
 | `notify list` | List structured notifications. Supports `--session`, `--target`, `--from`, `--kind`, `--unread`, and `--limit`. |
 | `notify read <id>` | Mark one notification read. |
-| `notify clear` | Clear all notifications, or a narrowed session/source/target subset. |
+| `notify clear` | Clear all notifications, or a narrowed session/source/target/kind subset. |
 | `notify open <id>` | Mark one notification read and return its suggested action. |
 
 Events command:

--- a/packages/cli/src/cli/commands/notify.ts
+++ b/packages/cli/src/cli/commands/notify.ts
@@ -38,6 +38,7 @@ interface NotifyClearOptions {
   session?: string;
   target?: string;
   from?: string;
+  kind?: string;
 }
 
 export function registerNotifyCommands(program: Command): void {
@@ -184,6 +185,7 @@ export function registerNotifyCommands(program: Command): void {
     .option('--session <session>', 'Clear notifications for a target or source session')
     .option('--target <session>', 'Clear notifications for a target session')
     .option('--from <session>', 'Clear notifications from a source session')
+    .option('--kind <kind>', 'Clear notification kind: complete, needs-input, error, blocked, info')
     .action((opts: NotifyClearOptions) => {
       const globalOpts = program.opts() as OutputOpts;
       try {
@@ -191,6 +193,7 @@ export function registerNotifyCommands(program: Command): void {
           session: opts.session,
           targetSession: opts.target,
           sourceSession: opts.from,
+          kind: opts.kind ? parseKind(opts.kind) : undefined,
         });
         outputResult(
           {

--- a/packages/cli/src/smoke/notificationStateServiceSmoke.ts
+++ b/packages/cli/src/smoke/notificationStateServiceSmoke.ts
@@ -312,6 +312,13 @@ async function testWorkerClearScopeClearsSourceNotifications(): Promise<void> {
   try {
     await withProcessEnv(ctx, async () => {
       const store = new NotificationStore();
+      const needsInput = store.create({
+        kind: 'needs-input',
+        title: 'Worker needs input',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
       const completed = store.create({
         kind: 'complete',
         title: 'Worker completed',
@@ -328,9 +335,11 @@ async function testWorkerClearScopeClearsSourceNotifications(): Promise<void> {
 
         const workerScope = resolveSessionNotificationClearScope({ contextValue: 'taskWorkerItem' }, 'repo_worker');
         assert.deepEqual(workerScope.filters, { session: 'repo_worker' });
-        assert.equal(service.getBySession('repo_worker').length, 1);
-        assert.equal(service.clear(workerScope.filters).cleared, 1);
-        assert.equal(service.getLatestSourceAttention('repo_worker'), undefined);
+        assert.equal(service.getBySession('repo_worker').length, 2);
+        assert.equal(service.clear({ ...workerScope.filters, kind: 'complete' }).cleared, 1);
+        assert.equal(service.getById(completed.id), undefined);
+        assert.equal(service.getById(needsInput.id)?.id, needsInput.id);
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.id, needsInput.id);
         assert.equal(service.getLatestSourceCompletion('repo_worker'), undefined);
 
         const copilotScope = resolveSessionNotificationClearScope({ contextValue: 'copilotItem' }, 'repo_copilot');
@@ -606,6 +615,57 @@ async function testEventOnlyErrorProjectionEmitsChange(): Promise<void> {
   }
 }
 
+async function testKindScopedClearPreservesEventOnlyAttention(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-kind-clear-projection-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      new EventLog().append({
+        type: 'notify.created',
+        source: 'hook',
+        payload: {
+          notificationId: 'event-only-needs-input',
+          kind: 'needs-input',
+          title: 'Worker needs input',
+          targetSession: 'repo_copilot',
+          sourceSession: 'repo_worker',
+          actionType: 'open-session',
+          actionSession: 'repo_worker',
+        },
+      });
+      await sleep(10);
+
+      const storedComplete = new NotificationStore().create({
+        kind: 'complete',
+        title: 'Worker completed',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        action: { type: 'open-session', session: 'repo_worker' },
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        assert.equal(service.getLatestSourceAttention('repo_worker')?.id, storedComplete.id);
+        assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, storedComplete.id);
+
+        const cleared = service.clear({ session: 'repo_worker', kind: 'complete' });
+        assert.equal(cleared.cleared, 1);
+        assert.equal(service.getById(storedComplete.id), undefined);
+        assert.equal(
+          service.getLatestSourceAttention('repo_worker')?.id,
+          'event-only-needs-input',
+          'complete-only clear must preserve event-only needs-input attention',
+        );
+        assert.equal(service.getLatestSourceCompletion('repo_worker'), undefined);
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
 async function testStoredNotificationWinsOverDuplicateEventProjection(): Promise<void> {
   const ctx = setupContext('hydra-notification-state-duplicate-event-projection-');
   try {
@@ -832,6 +892,7 @@ async function main(): Promise<void> {
   await testEventOnlyCompletionProjectionEmitsChange();
   await testSourceAttentionProjectionUsesLatestStatus();
   await testEventOnlyErrorProjectionEmitsChange();
+  await testKindScopedClearPreservesEventOnlyAttention();
   await testStoredNotificationWinsOverDuplicateEventProjection();
   await testInitializeSignatureWindow();
   await testDuplicateAndMalformedEventTolerance();

--- a/packages/cli/src/smoke/notifyCliSmoke.ts
+++ b/packages/cli/src/smoke/notifyCliSmoke.ts
@@ -189,12 +189,61 @@ function main(): void {
     assert.equal(store.version, 1);
     assert.equal(store.notifications.length, 1);
 
+    const info = parseStdoutJson<{
+      status: string;
+      notification: {
+        id: string;
+        kind: string;
+        targetSession: string | null;
+        sourceSession: string | null;
+      };
+    }>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'repo_copilot',
+        '--from',
+        'repo_worker',
+        '--kind',
+        'info',
+        '--title',
+        'Informational note',
+        '--json',
+      ], ctx.env),
+      'hydra notify create info --json',
+    );
+    assert.equal(info.status, 'created');
+    assert.equal(info.notification.kind, 'info');
+
     const cleared = parseStdoutJson<{ status: string; cleared: number }>(
-      runCli(['notify', 'clear', '--session', 'repo_worker', '--json'], ctx.env),
-      'hydra notify clear --json',
+      runCli(['notify', 'clear', '--session', 'repo_worker', '--kind', 'complete', '--json'], ctx.env),
+      'hydra notify clear --kind complete --json',
     );
     assert.equal(cleared.status, 'ok');
     assert.equal(cleared.cleared, 1);
+
+    const remainingList = parseStdoutJson<{
+      notifications: Array<{ id: string; kind: string }>;
+      count: number;
+      unreadCount: number;
+      totalCount: number;
+    }>(
+      runCli(['notify', 'list', '--json'], ctx.env),
+      'hydra notify list remaining --json',
+    );
+    assert.equal(remainingList.count, 1);
+    assert.equal(remainingList.unreadCount, 1);
+    assert.equal(remainingList.totalCount, 1);
+    assert.equal(remainingList.notifications[0].id, info.notification.id);
+    assert.equal(remainingList.notifications[0].kind, 'info');
+
+    const clearedRemaining = parseStdoutJson<{ status: string; cleared: number }>(
+      runCli(['notify', 'clear', '--session', 'repo_worker', '--json'], ctx.env),
+      'hydra notify clear remaining --json',
+    );
+    assert.equal(clearedRemaining.status, 'ok');
+    assert.equal(clearedRemaining.cleared, 1);
 
     const emptyList = parseStdoutJson<{ notifications: unknown[]; count: number; unreadCount: number; totalCount: number }>(
       runCli(['notify', 'list', '--json'], ctx.env),
@@ -210,9 +259,11 @@ function main(): void {
       'notify.created',
       'worker.runtime.changed',
       'notify.read',
+      'notify.created',
+      'notify.cleared',
       'notify.cleared',
     ]);
-    assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4]);
+    assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4, 5, 6]);
     assert.equal(fs.readFileSync(eventsPath, 'utf-8').includes('Branch: feat/auth'), false);
 
     console.log('notifyCliSmoke: ok');

--- a/packages/core/src/core/notificationStateService.ts
+++ b/packages/core/src/core/notificationStateService.ts
@@ -12,9 +12,9 @@ import {
   NotificationStore,
   type HydraNotification,
   type NotificationKind,
+  type NotificationClearFilters,
   type NotificationMarkSessionReadResult,
   type NotificationClearResult,
-  type NotificationListFilters,
   type NotificationOpenResult,
   type NotificationReadResult,
 } from './notifications';
@@ -206,7 +206,7 @@ export class NotificationStateService implements Disposable {
   }
 
   clear(
-    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    filters: NotificationClearFilters = {},
     eventSource: HydraEventSource = 'extension',
   ): NotificationClearResult {
     const result = this.store.clear(filters, eventSource);
@@ -517,9 +517,13 @@ function notificationMatchesClearEvent(notification: HydraNotification, event: H
   const session = getStringPayload(payload, 'session');
   const targetSession = getStringPayload(payload, 'targetSession');
   const sourceSession = getStringPayload(payload, 'sourceSession');
+  const kind = getStringPayload(payload, 'kind');
 
   if (!session && !targetSession && !sourceSession) {
-    return true;
+    return !kind || notification.kind === kind;
+  }
+  if (kind && notification.kind !== kind) {
+    return false;
   }
   if (session && notification.targetSession !== session && notification.sourceSession !== session) {
     return false;

--- a/packages/core/src/core/notifications.ts
+++ b/packages/core/src/core/notifications.ts
@@ -72,6 +72,11 @@ export interface NotificationListResult {
   totalCount: number;
 }
 
+export type NotificationClearFilters = Pick<
+  NotificationListFilters,
+  'session' | 'targetSession' | 'sourceSession' | 'kind'
+>;
+
 export interface NotificationReadResult {
   notification: HydraNotification;
   markedRead: number;
@@ -225,7 +230,7 @@ export class NotificationStore {
   }
 
   clear(
-    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'> = {},
+    filters: NotificationClearFilters = {},
     eventSource: HydraEventSource = 'cli',
   ): NotificationClearResult {
     return this.withLock(() => {
@@ -367,7 +372,7 @@ export class NotificationStore {
 
   private emitClearEvent(
     cleared: number,
-    filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>,
+    filters: NotificationClearFilters,
     source: HydraEventSource,
   ): void {
     try {
@@ -380,6 +385,7 @@ export class NotificationStore {
           session: filters.session,
           targetSession: filters.targetSession,
           sourceSession: filters.sourceSession,
+          kind: filters.kind,
         },
       });
     } catch (error) {

--- a/packages/desktop/index.html
+++ b/packages/desktop/index.html
@@ -834,11 +834,13 @@
       }
       .hydra-row__line {
         display: flex;
-        align-items: baseline;
+        align-items: center;
         gap: 0.35rem;
         min-width: 0;
       }
       .hydra-row__name {
+        min-width: 0;
+        flex: 0 1 auto;
         font-size: 0.84rem;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -863,7 +865,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      /* Line 2: relative time · U:N · completed chip — a compact inline strip. */
+      /* Line 2: relative time · U:N — a compact inline strip. */
       .hydra-row__sub {
         display: flex;
         align-items: center;
@@ -892,6 +894,61 @@
       .hydra-row--selected .hydra-row__menu,
       .hydra-row__menu.hydra-menu--open {
         opacity: 1;
+      }
+      .hydra-notification-row {
+        width: calc(100% - 1.9rem);
+        margin: 0.05rem 0 0.12rem 1.9rem;
+        padding: 0.22rem 0.45rem;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--hy-muted);
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        min-width: 0;
+        cursor: pointer;
+        text-align: left;
+        font: inherit;
+      }
+      .hydra-notification-row:hover,
+      .hydra-notification-row:focus-visible {
+        background: var(--hy-tile);
+        color: var(--hy-text);
+      }
+      .hydra-notification-row:focus-visible {
+        outline: 2px solid var(--hy-accent);
+        outline-offset: -2px;
+      }
+      .hydra-notification-row--disabled {
+        cursor: default;
+        opacity: 0.65;
+      }
+      .hydra-notification-row__badge {
+        flex: none;
+        min-width: 1rem;
+        height: 1rem;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.64rem;
+        font-weight: 700;
+        color: var(--hy-ok);
+        border: 1px solid var(--hy-ok);
+      }
+      .hydra-notification-row__label {
+        min-width: 0;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 0.74rem;
+      }
+      .hydra-notification-row__time {
+        flex: none;
+        white-space: nowrap;
+        font-size: 0.68rem;
       }
 
       /* ── status dots (shared by tree + tabs) ──────────────────────────── */

--- a/packages/desktop/scripts/missionControlBoardSmoke.mjs
+++ b/packages/desktop/scripts/missionControlBoardSmoke.mjs
@@ -238,6 +238,33 @@ assert.equal(view.groups[0].tiles[0].unread, 1, 'surviving session keeps its unr
   assert.equal(v.groups[0].tiles[0].completed, false, 'the chip clears the moment the worker runs again');
 }
 
+{
+  const copilotCompleteNotif = {
+    loadedAt: '2026-01-01T00:00:00.000Z',
+    lastEventSeq: seq,
+    totalCount: 1,
+    unreadCount: 1,
+    notifications: [
+      {
+        id: 'done-copilot',
+        createdAt: '2026-01-01T00:05:00.000Z',
+        readAt: null,
+        kind: 'complete',
+        title: 'worker done',
+        body: '',
+        targetSession: 'copilot_captain',
+        sourceSession: 'repo-a_feat-one',
+        action: { type: 'open-session', session: 'repo-a_feat-one' },
+      },
+    ],
+  };
+  const m = applyNotificationSnapshot(createBoardModel(snapshot), copilotCompleteNotif);
+  const v = selectBoard(m);
+  const copilotTile = v.groups.find((group) => group.kind === 'copilots').tiles[0];
+  assert.equal(copilotTile.completionNotifications.length, 1, 'copilot exposes completion child rows');
+  assert.equal(copilotTile.completionNotifications[0].actionSession, 'repo-a_feat-one');
+}
+
 // ── 9. git-status counts fold into CODE-worker tiles only ──
 
 {

--- a/packages/desktop/src/renderer/Overview/OverviewTab.tsx
+++ b/packages/desktop/src/renderer/Overview/OverviewTab.tsx
@@ -23,6 +23,7 @@ export function OverviewTab(): JSX.Element {
     onOpen: (tile, view) => {
       tabs.openTab(tile.session, tile.kind);
       tabs.setView(tile.session, view);
+      actions.acknowledgeCompletion(tile);
     },
     onSend: actions.send,
     onRename: actions.rename,

--- a/packages/desktop/src/renderer/missionControl/boardModel.ts
+++ b/packages/desktop/src/renderer/missionControl/boardModel.ts
@@ -11,6 +11,7 @@
 import type {
   CopilotMode,
   HydraEvent,
+  HydraNotification,
   HydraSessionList,
   NotificationSnapshot,
   SessionListCopilot,
@@ -46,6 +47,8 @@ export interface BoardModel {
   readonly gitStatusBySession: Readonly<Record<string, number>>;
   /** Total unread across all notifications (authoritative from the snapshot). */
   readonly unreadTotal: number;
+  /** Complete notifications keyed by target session, used for copilot child rows. */
+  readonly completionNotificationsByTargetSession: Readonly<Record<string, readonly CompletionNotificationModel[]>>;
   /** ISO timestamp of the most recent event touching each session. */
   readonly lastEventBySession: Readonly<Record<string, string>>;
   /** Highest event `seq` applied — the live cursor. */
@@ -97,6 +100,7 @@ export function createBoardModel(snapshot: HydraSessionList): BoardModel {
     completedBySession: {},
     gitStatusBySession: {},
     unreadTotal: 0,
+    completionNotificationsByTargetSession: {},
     lastEventBySession: {},
     lastSeq: 0,
     resyncToken: 0,
@@ -119,6 +123,7 @@ export function applySnapshot(model: BoardModel, snapshot: HydraSessionList): Bo
     unreadBySession: pruneToSessions(model.unreadBySession, alive),
     completedBySession: pruneToSessions(model.completedBySession, alive),
     gitStatusBySession: pruneToSessions(model.gitStatusBySession, alive),
+    completionNotificationsByTargetSession: pruneToSessions(model.completionNotificationsByTargetSession, alive),
     lastEventBySession: pruneToSessions(model.lastEventBySession, alive),
   };
 }
@@ -186,6 +191,7 @@ export function applyNotificationSnapshot(model: BoardModel, snapshot: Notificat
   const unreadBySession: Record<string, number> = {};
   // Newest notification (read or unread) per session → drives the completed chip.
   const latestBySession = new Map<string, { at: number; kind: string }>();
+  const completionNotificationsByTargetSession: Record<string, CompletionNotificationModel[]> = {};
 
   for (const notification of snapshot.notifications) {
     // Count / classify a notification once per distinct session it references
@@ -208,6 +214,12 @@ export function applyNotificationSnapshot(model: BoardModel, snapshot: Notificat
         latestBySession.set(session, { at: Number.isFinite(at) ? at : 0, kind: notification.kind });
       }
     }
+    if (notification.kind === 'complete' && notification.targetSession) {
+      const targetSession = notification.targetSession;
+      const bucket = completionNotificationsByTargetSession[targetSession] ?? [];
+      bucket.push(toCompletionNotificationModel(notification));
+      completionNotificationsByTargetSession[targetSession] = bucket;
+    }
   }
 
   const completedBySession: Record<string, boolean> = {};
@@ -217,7 +229,13 @@ export function applyNotificationSnapshot(model: BoardModel, snapshot: Notificat
     }
   }
 
-  return { ...model, unreadBySession, completedBySession, unreadTotal: snapshot.unreadCount };
+  return {
+    ...model,
+    unreadBySession,
+    completedBySession,
+    completionNotificationsByTargetSession,
+    unreadTotal: snapshot.unreadCount,
+  };
 }
 
 /**
@@ -251,7 +269,7 @@ export interface WorkerTileModel {
   readonly runtime: WorkerRuntimeState;
   readonly runtimeReason: string | null;
   readonly unread: number;
-  /** Latest unread notification is a `complete` (and the worker isn't running). */
+  /** Latest stored notification is a `complete` (and the worker isn't running). */
   readonly completed: boolean;
   /**
    * `git status --porcelain` changed-file count for CODE workers, or `null`
@@ -273,8 +291,10 @@ export interface CopilotTileModel {
   readonly mode: CopilotMode;
   readonly lifecycle: TileLifecycle;
   readonly unread: number;
-  /** Latest unread notification targeting the copilot is a `complete`. */
+  /** Latest stored notification targeting the copilot is a `complete`. */
   readonly completed: boolean;
+  /** Complete notifications targeting this copilot, newest first. */
+  readonly completionNotifications: readonly CompletionNotificationModel[];
   /** Number of workers this copilot manages (`copilotSessionName` match). */
   readonly workerCount: number;
   /** Distinct repos among those workers (task workers contribute none). */
@@ -286,6 +306,15 @@ export interface CopilotTileModel {
 }
 
 export type TileModel = WorkerTileModel | CopilotTileModel;
+
+export interface CompletionNotificationModel {
+  readonly id: string;
+  readonly title: string;
+  readonly createdAt: string;
+  readonly targetSession: string;
+  readonly sourceSession: string | null;
+  readonly actionSession: string | null;
+}
 
 export type BoardGroupKind = 'repo' | 'tasks' | 'copilots';
 
@@ -459,12 +488,24 @@ function toCopilotTile(
     lifecycle: model.lifecycleOverrides[copilot.session] ?? deriveLifecycle(copilot.status),
     unread: model.unreadBySession[copilot.session] ?? 0,
     completed: model.completedBySession[copilot.session] ?? false,
+    completionNotifications: model.completionNotificationsByTargetSession[copilot.session] ?? [],
     workerCount: summary?.workerCount ?? 0,
     repoCount: summary?.repoCount ?? 0,
     lastEventAt: model.lastEventBySession[copilot.session] ?? null,
     attached: copilot.attached,
     workdir: copilot.workdir,
     raw: copilot,
+  };
+}
+
+function toCompletionNotificationModel(notification: HydraNotification): CompletionNotificationModel {
+  return {
+    id: notification.id,
+    title: notification.title,
+    createdAt: notification.createdAt,
+    targetSession: notification.targetSession ?? '',
+    sourceSession: notification.sourceSession,
+    actionSession: notification.action?.session ?? notification.sourceSession,
   };
 }
 

--- a/packages/desktop/src/renderer/missionControl/useMissionControlBoard.ts
+++ b/packages/desktop/src/renderer/missionControl/useMissionControlBoard.ts
@@ -99,6 +99,8 @@ export function useMissionControlBoard(client: HydraControlClient): MissionContr
 
   // A stable ref to the running refetch so `refresh()` and the debounce share it.
   const runResync = useRef<() => void>(() => {});
+  // Notification state is separate from session state; refresh both for direct mutations.
+  const runNotificationRefresh = useRef<() => void>(() => {});
   // A stable ref to the git-status poll so a resync can kick an immediate refresh.
   const runGitStatusPoll = useRef<() => void>(() => {});
 
@@ -150,6 +152,22 @@ export function useMissionControlBoard(client: HydraControlClient): MissionContr
     };
     runResync.current = resyncNow;
 
+    const refreshNotificationsNow = () => {
+      client
+        .listNotifications()
+        .then((result) => {
+          if (!disposed.current) {
+            setModel((prev) =>
+              prev ? applyNotificationSnapshot(prev, result as unknown as NotificationSnapshot) : prev,
+            );
+          }
+        })
+        .catch(() => {
+          /* non-fatal — the live stream still delivers updates */
+        });
+    };
+    runNotificationRefresh.current = refreshNotificationsNow;
+
     function scheduleResync(): void {
       if (resyncTimer.current !== null) {
         return;
@@ -172,18 +190,7 @@ export function useMissionControlBoard(client: HydraControlClient): MissionContr
           // notifications once so existing unread badges, attention, and the
           // completed chip populate on first paint (not just after the next
           // notification arrives).
-          client
-            .listNotifications()
-            .then((result) => {
-              if (!disposed.current) {
-                setModel((prev) =>
-                  prev ? applyNotificationSnapshot(prev, result as unknown as NotificationSnapshot) : prev,
-                );
-              }
-            })
-            .catch(() => {
-              /* non-fatal — the live stream still delivers updates */
-            });
+          refreshNotificationsNow();
         }
       })
       .catch((cause: unknown) => {
@@ -230,6 +237,7 @@ export function useMissionControlBoard(client: HydraControlClient): MissionContr
         clearTimeout(resyncTimer.current);
         resyncTimer.current = null;
       }
+      runNotificationRefresh.current = () => {};
     };
   }, [client]);
 
@@ -261,6 +269,7 @@ export function useMissionControlBoard(client: HydraControlClient): MissionContr
 
   const refresh = useCallback(() => {
     runResync.current();
+    runNotificationRefresh.current();
   }, []);
 
   const view = useMemo(() => (model ? selectBoard(model) : null), [model]);

--- a/packages/desktop/src/renderer/sessions/SessionsProvider.tsx
+++ b/packages/desktop/src/renderer/sessions/SessionsProvider.tsx
@@ -21,6 +21,10 @@ import { useMissionControlBoard, type MissionControlBoard } from '../missionCont
 import { CreateSessionModal, type CreateKind } from '../missionControl/CreateSessionModal';
 import { ConfirmDeleteModal, PromptModal } from '../missionControl/dialogs';
 import type { TileModel, WorkerTileModel } from '../missionControl/boardModel';
+import {
+  completionNotificationClearFiltersForTile,
+  completionNotificationClearFiltersForWorkerSession,
+} from './notificationClear';
 
 /** Every session mutation the UI can trigger, from any surface. */
 export interface SessionActions {
@@ -31,6 +35,8 @@ export interface SessionActions {
   send: (tile: TileModel) => void;
   rename: (tile: TileModel) => void;
   delete: (tile: TileModel) => void;
+  acknowledgeCompletion: (tile: TileModel) => void;
+  acknowledgeWorkerCompletion: (session: string) => void;
   start: (tile: TileModel) => void;
   stop: (tile: WorkerTileModel) => void;
 }
@@ -108,6 +114,13 @@ export function SessionsProvider({ children }: { children: ReactNode }): JSX.Ele
       send: (tile) => setDialog({ type: 'send', tile }),
       rename: (tile) => setDialog({ type: 'rename', tile }),
       delete: (tile) => setDialog({ type: 'delete', tile }),
+      acknowledgeCompletion: (tile) => {
+        if (tile.kind === 'worker' && tile.completed) {
+          void runDirect(() => client.clearNotifications(completionNotificationClearFiltersForTile(tile)));
+        }
+      },
+      acknowledgeWorkerCompletion: (session) =>
+        runDirect(() => client.clearNotifications(completionNotificationClearFiltersForWorkerSession(session))),
       start: (tile) => runDirect(() => client.startSession(tile.session, tile.kind)),
       stop: (tile) => runDirect(() => client.stopWorker(tile.session)),
     }),

--- a/packages/desktop/src/renderer/sessions/notificationClear.ts
+++ b/packages/desktop/src/renderer/sessions/notificationClear.ts
@@ -1,0 +1,16 @@
+import type { NotificationClearFilters } from '@hydra/protocol';
+
+export interface NotificationClearTile {
+  readonly kind: 'worker' | 'copilot';
+  readonly session: string;
+}
+
+export function completionNotificationClearFiltersForTile(tile: NotificationClearTile): NotificationClearFilters {
+  return tile.kind === 'worker'
+    ? completionNotificationClearFiltersForWorkerSession(tile.session)
+    : { targetSession: tile.session, kind: 'complete' };
+}
+
+export function completionNotificationClearFiltersForWorkerSession(session: string): NotificationClearFilters {
+  return { session, kind: 'complete' };
+}

--- a/packages/desktop/src/renderer/sidebar/RowMenu.tsx
+++ b/packages/desktop/src/renderer/sidebar/RowMenu.tsx
@@ -14,15 +14,17 @@ export function RowMenu({ tile }: { tile: TileModel }): JSX.Element {
 
   const items: MenuItem[] = [];
   const canOpenTerminal = tile.kind === 'worker' || tile.lifecycle !== 'stopped';
+  const openTile = (view: 'terminal' | 'diff') => {
+    tabs.openTab(tile.session, tile.kind);
+    tabs.setView(tile.session, view);
+    actions.acknowledgeCompletion(tile);
+  };
 
   if (canOpenTerminal) {
     items.push({
       key: 'terminal',
       label: 'Open Terminal',
-      onSelect: () => {
-        tabs.openTab(tile.session, tile.kind);
-        tabs.setView(tile.session, 'terminal');
-      },
+      onSelect: () => openTile('terminal'),
     });
   }
 
@@ -30,10 +32,7 @@ export function RowMenu({ tile }: { tile: TileModel }): JSX.Element {
     items.push({
       key: 'diff',
       label: 'Open Diff',
-      onSelect: () => {
-        tabs.openTab(tile.session, tile.kind);
-        tabs.setView(tile.session, 'diff');
-      },
+      onSelect: () => openTile('diff'),
     });
   }
 

--- a/packages/desktop/src/renderer/sidebar/Tree.tsx
+++ b/packages/desktop/src/renderer/sidebar/Tree.tsx
@@ -3,20 +3,52 @@
 // The grouping is taken straight from the board view the reducer already
 // produces — this file only reshapes it into the two top-level sections.
 
-import { useState, type ReactNode } from 'react';
+import { Fragment, useMemo, useState, type ReactNode } from 'react';
 
-import type { BoardGroup, BoardView } from '../missionControl/boardModel';
+import type {
+  BoardGroup,
+  BoardView,
+  CompletionNotificationModel,
+  WorkerTileModel,
+} from '../missionControl/boardModel';
+import { relativeTime } from '../missionControl/format';
+import { useSessions } from '../sessions/SessionsProvider';
+import { useTabs } from '../tabs/TabsProvider';
 import { TreeRow } from './TreeRow';
 
 export function Tree({ view }: { view: BoardView }): JSX.Element {
   const copilots = view.groups.find((group) => group.kind === 'copilots');
   const workerGroups = view.groups.filter((group) => group.kind === 'repo' || group.kind === 'tasks');
+  const workersBySession = useMemo(() => {
+    const workers = new Map<string, WorkerTileModel>();
+    for (const group of workerGroups) {
+      for (const tile of group.tiles) {
+        if (tile.kind === 'worker') {
+          workers.set(tile.session, tile);
+        }
+      }
+    }
+    return workers;
+  }, [workerGroups]);
 
   return (
     <div className="hydra-tree" role="tree">
       <TreeSection title="COPILOTS" count={view.copilotCount}>
         {copilots && copilots.tiles.length > 0 ? (
-          copilots.tiles.map((tile) => <TreeRow key={tile.session} tile={tile} />)
+          copilots.tiles.map((tile) => (
+            <Fragment key={tile.session}>
+              <TreeRow tile={tile} />
+              {tile.kind === 'copilot'
+                ? tile.completionNotifications.map((notification) => (
+                  <CompletionNotificationRow
+                    key={notification.id}
+                    notification={notification}
+                    workersBySession={workersBySession}
+                  />
+                ))
+                : null}
+            </Fragment>
+          ))
         ) : (
           <p className="hydra-tree__empty">No copilots</p>
         )}
@@ -30,6 +62,43 @@ export function Tree({ view }: { view: BoardView }): JSX.Element {
         )}
       </TreeSection>
     </div>
+  );
+}
+
+function CompletionNotificationRow({
+  notification,
+  workersBySession,
+}: {
+  notification: CompletionNotificationModel;
+  workersBySession: ReadonlyMap<string, WorkerTileModel>;
+}): JSX.Element {
+  const tabs = useTabs();
+  const { actions } = useSessions();
+  const workerSession = notification.actionSession ?? notification.sourceSession;
+  const worker = workerSession ? workersBySession.get(workerSession) : undefined;
+  const label = worker ? `${worker.name} #${worker.number}` : notification.title;
+  const canOpen = Boolean(worker);
+
+  const openWorker = () => {
+    if (!worker) {
+      return;
+    }
+    tabs.openTab(worker.session, 'worker');
+    actions.acknowledgeWorkerCompletion(worker.session);
+  };
+
+  return (
+    <button
+      type="button"
+      className={`hydra-notification-row${canOpen ? '' : ' hydra-notification-row--disabled'}`}
+      title={canOpen ? 'Open worker and clear completed notification' : notification.title}
+      disabled={!canOpen}
+      onClick={openWorker}
+    >
+      <span className="hydra-notification-row__badge">C</span>
+      <span className="hydra-notification-row__label">{label}</span>
+      <span className="hydra-notification-row__time">{relativeTime(notification.createdAt)}</span>
+    </button>
   );
 }
 

--- a/packages/desktop/src/renderer/sidebar/TreeRow.tsx
+++ b/packages/desktop/src/renderer/sidebar/TreeRow.tsx
@@ -1,10 +1,10 @@
 // One session row in the sidebar tree — a dense, two-line node that mirrors the
 // old VS Code extension tree (packages/extension tmuxSessionProvider.ts).
 //
-//   Copilot:  ● name [agent] [N workers · M repos]   [unread] ⋮
-//             35m ago  ✓ 已完成
-//   Worker:   ● branch #N [agent] running            [unread] ⋮
-//             35m ago  U:2  ✓ 已完成
+//   Copilot:  ● name [agent] [N workers · M repos] ✓ 已完成   [unread] ⋮
+//             35m ago
+//   Worker:   ● branch #N [agent] running ✓ 已完成             [unread] ⋮
+//             35m ago  U:2
 //
 // Clicking the row opens/focuses its tab when the session has an attachable
 // terminal; the ⋮ menu carries the per-row actions. The row is highlighted when
@@ -19,17 +19,26 @@ import {
   runtimeToken,
 } from '../missionControl/format';
 import { STATUS_LABELS, tileStatus } from '../status';
+import { useSessions } from '../sessions/SessionsProvider';
 import { useTabs } from '../tabs/TabsProvider';
 import { RowMenu } from './RowMenu';
 
 export function TreeRow({ tile }: { tile: TileModel }): JSX.Element {
   const tabs = useTabs();
+  const { actions } = useSessions();
   const status = tileStatus(tile);
   const selected = tabs.activeId === tile.session;
   const canOpenTerminal = tile.kind === 'worker' || tile.lifecycle !== 'stopped';
 
   const summary = tile.kind === 'copilot' ? copilotSummaryLabel(tile.workerCount, tile.repoCount) : null;
   const gitLabel = tile.kind === 'worker' ? gitChangeLabel(tile.changed) : null;
+  const openTerminal = () => {
+    if (!canOpenTerminal) {
+      return;
+    }
+    tabs.openTab(tile.session, tile.kind);
+    actions.acknowledgeCompletion(tile);
+  };
 
   return (
     <div
@@ -41,9 +50,7 @@ export function TreeRow({ tile }: { tile: TileModel }): JSX.Element {
       tabIndex={0}
       title={tile.session}
       onClick={() => {
-        if (canOpenTerminal) {
-          tabs.openTab(tile.session, tile.kind);
-        }
+        openTerminal();
       }}
       onKeyDown={(event) => {
         if (event.currentTarget !== event.target) {
@@ -51,9 +58,7 @@ export function TreeRow({ tile }: { tile: TileModel }): JSX.Element {
         }
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          if (canOpenTerminal) {
-            tabs.openTab(tile.session, tile.kind);
-          }
+          openTerminal();
         }
       }}
     >
@@ -68,17 +73,17 @@ export function TreeRow({ tile }: { tile: TileModel }): JSX.Element {
           ) : summary ? (
             <span className="hydra-row__summary">{summary}</span>
           ) : null}
+          {tile.completed ? (
+            <span className="hydra-chip hydra-chip--done" title="Task completed">
+              {COMPLETED_CHIP_LABEL}
+            </span>
+          ) : null}
         </div>
         <div className="hydra-row__sub">
           <span className="hydra-row__time">{relativeTime(tile.lastEventAt)}</span>
           {gitLabel ? (
             <span className="hydra-row__u" title="changed files (git status)">
               {gitLabel}
-            </span>
-          ) : null}
-          {tile.completed ? (
-            <span className="hydra-chip hydra-chip--done" title="Task completed">
-              {COMPLETED_CHIP_LABEL}
             </span>
           ) : null}
         </div>

--- a/packages/protocol/src/dto.ts
+++ b/packages/protocol/src/dto.ts
@@ -17,6 +17,7 @@ import type {
 import type { HydraEvent } from '@hydra/core/events';
 import type {
   HydraNotification,
+  NotificationClearFilters,
   NotificationListFilters,
   NotificationListResult,
   NotificationReadResult,
@@ -34,6 +35,7 @@ export type {
   WorkerRuntimeSignalOrigin,
   HydraEvent,
   HydraNotification,
+  NotificationClearFilters,
   NotificationListFilters,
   NotificationListResult,
   NotificationReadResult,
@@ -253,12 +255,6 @@ export interface EventSubscribeInput {
 
 // Reserved for future filters (e.g. by session); empty today.
 export type NotificationSubscribeInput = Record<string, never>;
-
-/** Filters accepted by `clearNotifications` (subset of the list filters). */
-export type NotificationClearFilters = Pick<
-  NotificationListFilters,
-  'session' | 'targetSession' | 'sourceSession'
->;
 
 // ── wire request payloads ──
 //


### PR DESCRIPTION
## Summary
- add `hydra notify clear --kind` and carry the kind filter through notification clear events and protocol types
- preserve non-completion attention when clearing only completion notifications
- show worker completion child rows under desktop copilots and clear completion notices when the worker is opened
- refresh desktop notification state after direct notification mutations

## Validation
- `npm run compile`
- `npm run lint`
- `npm run smoke:notify-cli`
- `npm run smoke:notification-state`
- `npm run smoke:mission-control`
- `npm run desktop:build`
- `git diff --check`