### PR TITLE
fix: harden diff and tmux ownership safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "smoke:worker-needs-input": "node packages/cli/out/smoke/workerNeedsInputSmoke.js",
     "smoke:worker-runtime-state": "node packages/cli/out/smoke/workerRuntimeStateSmoke.js",
     "smoke:worker-attention-characterization": "node packages/core/out/smoke/workerAttentionCharacterizationSmoke.js",
+    "smoke:control-plane-safety": "node packages/core/out/smoke/controlPlaneSafetySmoke.js",
     "smoke:notification-state": "node packages/cli/out/smoke/notificationStateServiceSmoke.js",
     "smoke:session-notification-summary": "node packages/core/out/smoke/sessionNotificationSummarySmoke.js",
     "smoke:agent-registry": "node packages/core/out/smoke/agentRegistrySmoke.js",

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -25,6 +25,7 @@ const execFile = promisify(execFileCallback);
 
 // Match the extension's ceiling so large worktrees behave identically.
 const MAX_GIT_OUTPUT = 50 * 1024 * 1024;
+export const MAX_FILE_SNAPSHOT_BYTES = 2 * 1024 * 1024;
 
 // The base-ref candidate chain, in priority order, after the branch-configured
 // `branch.<name>.vscode-merge-base`. Identical to `reviewChanges.ts` so the
@@ -65,6 +66,15 @@ export interface FileSnapshotResult {
   exists: boolean;
 }
 
+export interface BoundedSnapshotReader {
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: null,
+  ): Promise<{ bytesRead: number }>;
+}
+
 interface ExecFileFailure extends Error {
   code?: string | number;
 }
@@ -99,7 +109,7 @@ export class DiffService {
     const normalizedRelPath = path.relative(path.resolve(workdir), safeAbsolutePath);
 
     if (side === 'current') {
-      const content = await tryReadFile(safeAbsolutePath);
+      const content = await readCurrentSnapshot(path.resolve(workdir), safeAbsolutePath, relPath);
       return {
         path: normalizedRelPath,
         side,
@@ -112,13 +122,44 @@ export class DiffService {
     const baseCommit = await this.getMergeBase(workdir, baseRef);
     // `git show <commit>:<path>` needs a repo-relative, forward-slash path.
     const gitPath = normalizedRelPath.split(path.sep).join('/');
-    const shown = await this.tryGit(['show', `${baseCommit}:${gitPath}`], workdir);
+    const treeEntry = await this.tryGit(['ls-tree', '-z', baseCommit, '--', gitPath], workdir);
+    if (!treeEntry.ok || !treeEntry.output) {
+      return {
+        path: normalizedRelPath,
+        side,
+        ref: baseCommit,
+        content: '',
+        exists: false,
+      };
+    }
+    const mode = treeEntry.output.slice(0, treeEntry.output.indexOf(' '));
+    if (mode !== '100644' && mode !== '100755') {
+      throw new Error(`File snapshot is not a regular file: ${relPath}`);
+    }
+    const object = `${baseCommit}:${gitPath}`;
+    const type = await this.tryGit(['cat-file', '-t', object], workdir);
+    if (!type.ok) {
+      return {
+        path: normalizedRelPath,
+        side,
+        ref: baseCommit,
+        content: '',
+        exists: false,
+      };
+    }
+    if (type.output.trim() !== 'blob') {
+      throw new Error(`File snapshot is not a regular file: ${relPath}`);
+    }
+    const size = Number.parseInt((await this.git(['cat-file', '-s', object], workdir)).trim(), 10);
+    assertSnapshotSize(size, relPath);
+    const shown = await this.gitBuffer(['show', object], workdir, MAX_FILE_SNAPSHOT_BYTES + 1);
+    assertTextSnapshot(shown, relPath);
     return {
       path: normalizedRelPath,
       side,
       ref: baseCommit,
-      content: shown.output,
-      exists: shown.ok,
+      content: shown.toString('utf8'),
+      exists: true,
     };
   }
 
@@ -210,6 +251,22 @@ export class DiffService {
     }
   }
 
+  private async gitBuffer(args: string[], cwd: string, maxBuffer: number): Promise<Buffer> {
+    const binary = await this.getGitBinary();
+    try {
+      const { stdout } = await execFile(binary, args, { cwd, maxBuffer, encoding: 'buffer' });
+      return stdout;
+    } catch (error) {
+      const failure = error as ExecFileFailure;
+      if (failure.code !== 'ENOENT') {
+        throw error;
+      }
+      this.gitBinary = undefined;
+      const { stdout } = await execFile(await this.getGitBinary(), args, { cwd, maxBuffer, encoding: 'buffer' });
+      return stdout;
+    }
+  }
+
   /** Run git, swallowing failures into an empty string (best-effort probes). */
   private async tryGitOutput(args: string[], cwd: string): Promise<string> {
     return (await this.tryGit(args, cwd)).output;
@@ -282,10 +339,95 @@ function parseNameStatus(output: string): DiffChange[] {
   return changes;
 }
 
-async function tryReadFile(filePath: string): Promise<string | undefined> {
+async function readCurrentSnapshot(
+  resolvedWorkdir: string,
+  filePath: string,
+  relPath: string,
+): Promise<string | undefined> {
   try {
-    return await fs.readFile(filePath, 'utf8');
-  } catch {
-    return undefined;
+    const realWorkdir = await fs.realpath(resolvedWorkdir);
+    const realFile = await fs.realpath(filePath);
+    assertPathInside(realWorkdir, realFile, relPath);
+    const targetStats = await fs.stat(realFile);
+    if (!targetStats.isFile()) {
+      throw new Error(`File snapshot is not a regular file: ${relPath}`);
+    }
+    assertSnapshotSize(targetStats.size, relPath);
+
+    const handle = await fs.open(filePath, 'r');
+    try {
+      const openedStats = await handle.stat();
+      if (!openedStats.isFile()) {
+        throw new Error(`File snapshot is not a regular file: ${relPath}`);
+      }
+      if (openedStats.dev !== targetStats.dev || openedStats.ino !== targetStats.ino) {
+        throw new Error(`File snapshot target changed during validation: ${relPath}`);
+      }
+      assertSnapshotSize(openedStats.size, relPath);
+      const content = await readBoundedSnapshotBytes(handle, relPath);
+      assertTextSnapshot(content, relPath);
+      return content.toString('utf8');
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return undefined;
+    }
+    throw error;
   }
+}
+
+export async function readBoundedSnapshotBytes(
+  reader: BoundedSnapshotReader,
+  relPath: string,
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(MAX_FILE_SNAPSHOT_BYTES + 1);
+  let offset = 0;
+
+  while (offset < buffer.length) {
+    const { bytesRead } = await reader.read(buffer, offset, buffer.length - offset, null);
+    if (!Number.isSafeInteger(bytesRead) || bytesRead < 0 || bytesRead > buffer.length - offset) {
+      throw new Error(`Invalid file snapshot read result: ${relPath}`);
+    }
+    if (bytesRead === 0) {
+      break;
+    }
+    offset += bytesRead;
+  }
+
+  assertSnapshotSize(offset, relPath);
+  return buffer.subarray(0, offset);
+}
+
+function assertPathInside(realWorkdir: string, realFile: string, relPath: string): void {
+  const relative = path.relative(realWorkdir, realFile);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`File snapshot path escapes the session workdir: ${relPath}`);
+  }
+}
+
+function assertSnapshotSize(size: number, relPath: string): void {
+  if (!Number.isSafeInteger(size) || size < 0 || size > MAX_FILE_SNAPSHOT_BYTES) {
+    throw new Error(`File snapshot exceeds ${MAX_FILE_SNAPSHOT_BYTES} bytes: ${relPath}`);
+  }
+}
+
+function assertTextSnapshot(content: Buffer, relPath: string): void {
+  if (content.includes(0)) {
+    throw new Error(`Binary file snapshots are not supported: ${relPath}`);
+  }
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(content);
+  } catch {
+    throw new Error(`Binary file snapshots are not supported: ${relPath}`);
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  const code = error && typeof error === 'object' && 'code' in error
+    ? (error as { code?: unknown }).code
+    : undefined;
+  return Boolean(error && typeof error === 'object' && 'code' in error
+    && (code === 'ENOENT' || code === 'ENOTDIR'));
 }

--- a/packages/core/src/core/sessionManager.ts
+++ b/packages/core/src/core/sessionManager.ts
@@ -742,11 +742,11 @@ export class SessionManager {
       notifyCopilot: shouldNotifyCopilot,
     });
 
+    const peekState = this.readSessionState();
+    const workerId = peekState.workers[prepared.sessionName]?.workerId ??
+      prepared.preservedWorkerInfo?.workerId ??
+      peekState.nextWorkerId;
     if ((shouldNotifyCopilot || shouldInstallClaudeNeedsInputHooks) && prepared.copilotSessionName) {
-      const peekState = this.readSessionState();
-      const workerId = peekState.workers[prepared.sessionName]?.workerId ??
-        prepared.preservedWorkerInfo?.workerId ??
-        peekState.nextWorkerId;
       this.injectCompletionHook(prepared.workdir, prepared.agentType, {
         copilotSessionName: prepared.copilotSessionName,
         sessionName: prepared.sessionName,
@@ -766,6 +766,7 @@ export class SessionManager {
     await this.backend.createSession(prepared.sessionName, prepared.workdir);
     await this.backend.setSessionWorkdir(prepared.sessionName, prepared.workdir);
     await this.backend.setSessionRole(prepared.sessionName, 'worker');
+    await this.backend.setSessionWorkerId?.(prepared.sessionName, workerId);
     await this.backend.setSessionAgent(prepared.sessionName, prepared.agentType);
 
     const isResume = !!prepared.resumeSessionId;
@@ -834,6 +835,7 @@ export class SessionManager {
       state.updatedAt = now;
       return nextWorker;
     });
+    await this.backend.setSessionWorkerId?.(prepared.sessionName, workerInfo.workerId);
     logger.info('session.launchWorker', 'Worker session persisted', {
       source: workerInfo.source,
       sessionName: workerInfo.sessionName,
@@ -882,11 +884,14 @@ export class SessionManager {
     logger.info('session.delete', 'Deleting worker session', { ...context, phase: 'start' });
 
     try {
+      const ownership = await this.assertHydraSessionOwnership(sessionName, 'worker');
       if (worker && isDirectoryWorker(worker) && opts.deleteFiles && !worker.managedWorkdir) {
         throw new Error(`Worker "${sessionName}" uses a user-provided directory. --delete-files is only supported for Hydra-managed task workers.`);
       }
 
-      await this.killSessionOrConfirmAbsent(sessionName);
+      if (ownership.live) {
+        await this.killSessionOrConfirmAbsent(sessionName);
+      }
       logger.info('session.delete', 'Worker multiplexer session removed or absent', {
         ...context,
         phase: 'killSession',
@@ -1052,8 +1057,11 @@ export class SessionManager {
   }
 
   async stopWorker(sessionName: string): Promise<void> {
+    const ownership = await this.assertHydraSessionOwnership(sessionName, 'worker');
     try {
-      await this.backend.killSession(sessionName);
+      if (ownership.live) {
+        await this.backend.killSession(sessionName);
+      }
     } catch { /* Already dead */ }
 
     await this.updateSessionState((state) => {
@@ -1092,6 +1100,7 @@ export class SessionManager {
     await this.backend.createSession(sessionName, existingWorker.workdir);
     await this.backend.setSessionWorkdir(sessionName, existingWorker.workdir);
     await this.backend.setSessionRole(sessionName, 'worker');
+    await this.backend.setSessionWorkerId?.(sessionName, existingWorker.workerId);
     await this.backend.setSessionAgent(sessionName, agent);
 
     // Resume from stored session ID if available; otherwise fresh start
@@ -1178,6 +1187,8 @@ export class SessionManager {
         launchStartedAt,
       );
     }
+
+    await this.backend.setSessionWorkerId?.(sessionName, workerInfo.workerId);
 
     this.emitWorkerEvent('worker.started', workerInfo, { resumed: canResume });
     this.updateWorkerRuntimeState(workerInfo, 'running', 'worker-started');
@@ -1584,8 +1595,11 @@ export class SessionManager {
     logger.info('session.delete', 'Deleting copilot session', { ...context, phase: 'start' });
 
     try {
+      const ownership = await this.assertHydraSessionOwnership(sessionName, 'copilot');
       try {
-        await this.backend.killSession(sessionName);
+        if (ownership.live) {
+          await this.backend.killSession(sessionName);
+        }
       } catch { /* Already dead */ }
       logger.info('session.delete', 'Copilot multiplexer session removed or absent', {
         ...context,
@@ -1977,6 +1991,43 @@ export class SessionManager {
 
       throw error;
     }
+  }
+
+  async assertHydraSessionOwnership(
+    sessionName: string,
+    expectedKind?: 'worker' | 'copilot',
+  ): Promise<{ kind: 'worker' | 'copilot'; live: boolean }> {
+    const state = this.readSessionState();
+    const worker = state.workers[sessionName];
+    const copilot = state.copilots[sessionName];
+    const kind = worker ? 'worker' : copilot ? 'copilot' : undefined;
+    const session = worker ?? copilot;
+
+    if (!kind || !session || (expectedKind && kind !== expectedKind)) {
+      throw new Error(`Refusing to control unknown Hydra ${expectedKind ?? 'session'} "${sessionName}"`);
+    }
+
+    const live = await this.backend.hasSession(sessionName);
+    if (!live) {
+      return { kind, live: false };
+    }
+
+    const [role, tmuxWorkdir, tmuxWorkerId] = await Promise.all([
+      this.backend.getSessionRole(sessionName),
+      this.backend.getSessionWorkdir(sessionName),
+      kind === 'worker' ? this.backend.getSessionWorkerId?.(sessionName) : Promise.resolve(undefined),
+    ]);
+    const expectedWorkdir = toCanonicalPath(session.workdir);
+    const actualWorkdir = tmuxWorkdir ? toCanonicalPath(tmuxWorkdir) : undefined;
+
+    if (role !== kind || !expectedWorkdir || actualWorkdir !== expectedWorkdir) {
+      throw new Error(`Refusing to control foreign tmux session "${sessionName}": Hydra metadata does not match session state`);
+    }
+    if (worker && tmuxWorkerId !== undefined && tmuxWorkerId !== worker.workerId) {
+      throw new Error(`Refusing to control foreign tmux session "${sessionName}": worker identity does not match session state`);
+    }
+
+    return { kind, live: true };
   }
 
   private archiveEntry(
@@ -3598,6 +3649,7 @@ export class SessionManager {
         state.updatedAt = now;
         return nextWorker;
       });
+      await this.backend.setSessionWorkerId?.(sessionName, workerInfo.workerId);
 
       this.emitWorkerEvent('worker.started', workerInfo, {
         resumed: true,
@@ -3624,10 +3676,12 @@ export class SessionManager {
       await this.backend.createSession(sessionName, worktreePath);
       await this.backend.setSessionWorkdir(sessionName, worktreePath);
       await this.backend.setSessionRole(sessionName, 'worker');
+      const existingWorker = this.readSessionState().workers[sessionName] || savedWorker;
+      const workerId = existingWorker?.workerId ?? this.readSessionState().nextWorkerId;
+      await this.backend.setSessionWorkerId?.(sessionName, workerId);
       await this.backend.setSessionAgent(sessionName, agentType);
 
       const now = new Date().toISOString();
-      const existingWorker = this.readSessionState().workers[sessionName] || savedWorker;
       const storedSessionId = existingWorker?.sessionId;
       const requestedResumeSessionFile = resumeSessionFile ?? existingWorker?.agentSessionFile ?? null;
       const resolvedResumeSessionFile = storedSessionId
@@ -3722,6 +3776,7 @@ export class SessionManager {
         state.updatedAt = now;
         return nextWorker;
       });
+      await this.backend.setSessionWorkerId?.(sessionName, workerInfo.workerId);
 
       this.emitWorkerEvent('worker.started', workerInfo, {
         resumed: canResume,

--- a/packages/core/src/core/tmux.ts
+++ b/packages/core/src/core/tmux.ts
@@ -328,6 +328,35 @@ export class TmuxBackendCore implements MultiplexerBackendCore {
     await exec(`${tmuxCommand} set-option -t ${shellQuote(sessionName)} @hydra-role ${shellQuote(role)}`);
   }
 
+  async getSessionWorkerId(sessionName: string): Promise<number | undefined> {
+    try {
+      const tmuxCommand = getTmuxCommand();
+      const output = await exec(`${tmuxCommand} show-options -t ${shellQuote(sessionName)} -qv @hydra-worker-id`);
+      const value = output.trim();
+      if (!value) {
+        return undefined;
+      }
+      if (!/^[1-9]\d*$/.test(value)) {
+        throw new Error(`Malformed @hydra-worker-id on tmux session "${sessionName}": ${value}`);
+      }
+      const workerId = Number(value);
+      if (!Number.isSafeInteger(workerId)) {
+        throw new Error(`Malformed @hydra-worker-id on tmux session "${sessionName}": ${value}`);
+      }
+      return workerId;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Malformed @hydra-worker-id')) {
+        throw error;
+      }
+      return undefined;
+    }
+  }
+
+  async setSessionWorkerId(sessionName: string, workerId: number): Promise<void> {
+    const tmuxCommand = getTmuxCommand();
+    await exec(`${tmuxCommand} set-option -t ${shellQuote(sessionName)} @hydra-worker-id ${shellQuote(String(workerId))}`);
+  }
+
   async getSessionAgent(sessionName: string): Promise<string | undefined> {
     try {
       const tmuxCommand = getTmuxCommand();

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -35,6 +35,8 @@ export interface MultiplexerBackendCore {
   setSessionWorkdir(sessionName: string, workdir: string): Promise<void>;
   getSessionRole(sessionName: string): Promise<HydraRole | undefined>;
   setSessionRole(sessionName: string, role: HydraRole): Promise<void>;
+  getSessionWorkerId?(sessionName: string): Promise<number | undefined>;
+  setSessionWorkerId?(sessionName: string, workerId: number): Promise<void>;
   getSessionAgent(sessionName: string): Promise<string | undefined>;
   setSessionAgent(sessionName: string, agent: string): Promise<void>;
   sendKeys(sessionName: string, keys: string): Promise<void>;

--- a/packages/core/src/smoke/controlPlaneSafetySmoke.ts
+++ b/packages/core/src/smoke/controlPlaneSafetySmoke.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  DiffService,
+  MAX_FILE_SNAPSHOT_BYTES,
+  readBoundedSnapshotBytes,
+  type BoundedSnapshotReader,
+} from '../core/diff';
+import { SessionManager, type WorkerInfo } from '../core/sessionManager';
+import type {
+  HydraRole,
+  MultiplexerBackendCore,
+  MultiplexerSession,
+  SessionStatusInfo,
+} from '../core/types';
+
+class OwnershipBackend implements MultiplexerBackendCore {
+  readonly type = 'tmux' as const;
+  readonly displayName = 'ownership-smoke';
+  readonly installHint = 'none';
+  readonly sessions = new Set<string>();
+  readonly workdirs = new Map<string, string>();
+  readonly roles = new Map<string, HydraRole>();
+  readonly workerIds = new Map<string, number>();
+  readonly workerIdErrors = new Map<string, Error>();
+  readonly workerIdWrites: Array<{ sessionName: string; workerId: number }> = [];
+  readonly killed: string[] = [];
+  onWorkerIdWrite?: (sessionName: string, workerId: number, writeIndex: number) => void;
+
+  async isInstalled(): Promise<boolean> { return true; }
+  async listSessions(): Promise<MultiplexerSession[]> { return []; }
+  async createSession(sessionName: string, workdir: string): Promise<void> { this.sessions.add(sessionName); this.workdirs.set(sessionName, workdir); }
+  async killSession(sessionName: string): Promise<void> { this.killed.push(sessionName); this.sessions.delete(sessionName); }
+  async renameSession(): Promise<void> {}
+  async hasSession(sessionName: string): Promise<boolean> { return this.sessions.has(sessionName); }
+  async getSessionWorkdir(sessionName: string): Promise<string | undefined> { return this.workdirs.get(sessionName); }
+  async setSessionWorkdir(sessionName: string, workdir: string): Promise<void> { this.workdirs.set(sessionName, workdir); }
+  async getSessionRole(sessionName: string): Promise<HydraRole | undefined> { return this.roles.get(sessionName); }
+  async setSessionRole(sessionName: string, role: HydraRole): Promise<void> { this.roles.set(sessionName, role); }
+  async getSessionWorkerId(sessionName: string): Promise<number | undefined> {
+    const error = this.workerIdErrors.get(sessionName);
+    if (error) throw error;
+    return this.workerIds.get(sessionName);
+  }
+  async setSessionWorkerId(sessionName: string, workerId: number): Promise<void> {
+    this.workerIds.set(sessionName, workerId);
+    this.workerIdWrites.push({ sessionName, workerId });
+    this.onWorkerIdWrite?.(sessionName, workerId, this.workerIdWrites.length);
+  }
+  async getSessionAgent(): Promise<string | undefined> { return undefined; }
+  async setSessionAgent(): Promise<void> {}
+  async sendKeys(): Promise<void> {}
+  async capturePane(): Promise<string> { return 'Session: 11111111-1111-4111-8111-111111111111\n⏵'; }
+  async sendMessage(): Promise<void> {}
+  async getSessionInfo(): Promise<SessionStatusInfo> { return { attached: false, lastActive: 0 }; }
+  async getSessionPaneCount(): Promise<number> { return 1; }
+  async getSessionPanePids(): Promise<string[]> { return []; }
+  async splitPane(): Promise<void> {}
+  async newWindow(): Promise<void> {}
+  buildSessionName(repoName: string, slug: string): string { return `${repoName}_${slug}`; }
+  sanitizeSessionName(name: string): string { return name; }
+}
+
+function worker(sessionName: string, workdir: string): WorkerInfo {
+  const now = new Date().toISOString();
+  return {
+    source: 'directory', sessionName, displayName: sessionName, workerId: 7,
+    repo: null, repoRoot: null, branch: null, slug: sessionName, status: 'running',
+    attached: false, agent: 'codex', workdir, managedWorkdir: false,
+    tmuxSession: sessionName, createdAt: now, lastSeenAt: now, sessionId: null,
+    copilotSessionName: null,
+  };
+}
+
+async function expectReject(label: string, action: () => Promise<unknown>, pattern: RegExp): Promise<void> {
+  await assert.rejects(action, pattern, label);
+}
+
+class ChunkReader implements BoundedSnapshotReader {
+  private offset = 0;
+
+  constructor(
+    private readonly content: Buffer,
+    private readonly chunkSize: number,
+  ) {}
+
+  async read(buffer: Buffer, offset: number, length: number): Promise<{ bytesRead: number }> {
+    const bytesRead = Math.min(length, this.chunkSize, this.content.length - this.offset);
+    if (bytesRead <= 0) return { bytesRead: 0 };
+    this.content.copy(buffer, offset, this.offset, this.offset + bytesRead);
+    this.offset += bytesRead;
+    return { bytesRead };
+  }
+}
+
+async function main(): Promise<void> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hydra-control-plane-safety-'));
+  const previousHome = process.env.HYDRA_HOME;
+  const previousConfig = process.env.HYDRA_CONFIG_PATH;
+  try {
+    const workdir = path.join(root, 'workdir');
+    const hydraHome = path.join(root, 'hydra');
+    fs.mkdirSync(workdir, { recursive: true });
+    fs.mkdirSync(hydraHome, { recursive: true });
+    process.env.HYDRA_HOME = hydraHome;
+    delete process.env.HYDRA_CONFIG_PATH;
+
+    const service = new DiffService();
+    fs.writeFileSync(path.join(workdir, 'regular.txt'), 'safe text\n');
+    assert.equal((await service.getFileSnapshot(workdir, 'regular.txt')).content, 'safe text\n');
+
+    fs.writeFileSync(path.join(workdir, 'binary.dat'), Buffer.from([0x41, 0x00, 0x42]));
+    await expectReject('binary current snapshot', () => service.getFileSnapshot(workdir, 'binary.dat'), /Binary file snapshots/);
+
+    fs.writeFileSync(path.join(workdir, 'large.txt'), Buffer.alloc(MAX_FILE_SNAPSHOT_BYTES + 1, 0x61));
+    await expectReject('oversized current snapshot', () => service.getFileSnapshot(workdir, 'large.txt'), /exceeds/);
+
+    const boundedContent = Buffer.alloc(MAX_FILE_SNAPSHOT_BYTES, 0x61);
+    const boundedRead = await readBoundedSnapshotBytes(new ChunkReader(boundedContent, 8191), 'bounded.txt');
+    assert.equal(boundedRead.length, MAX_FILE_SNAPSHOT_BYTES, 'bounded reader accepts the exact byte ceiling');
+    assert.equal(boundedRead.compare(boundedContent), 0, 'bounded reader preserves partial-read content');
+    await expectReject(
+      'bounded reader overflow',
+      () => readBoundedSnapshotBytes(
+        new ChunkReader(Buffer.alloc(MAX_FILE_SNAPSHOT_BYTES + 1, 0x61), 4093),
+        'grown.txt',
+      ),
+      /exceeds/,
+    );
+
+    const repo = path.join(root, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+    execFileSync('git', ['-c', 'init.defaultBranch=main', 'init', '-q'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'safety@hydra.test'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Safety Smoke'], { cwd: repo });
+    fs.writeFileSync(path.join(repo, 'base-binary.dat'), Buffer.from([0x41, 0x00, 0x42]));
+    fs.writeFileSync(path.join(repo, 'base-large.txt'), Buffer.alloc(MAX_FILE_SNAPSHOT_BYTES + 1, 0x61));
+    fs.symlinkSync('base-binary.dat', path.join(repo, 'base-link.dat'));
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: repo });
+    execFileSync('git', ['checkout', '-q', '-b', 'feature'], { cwd: repo });
+    fs.rmSync(path.join(repo, 'base-binary.dat'));
+    fs.rmSync(path.join(repo, 'base-large.txt'));
+    fs.rmSync(path.join(repo, 'base-link.dat'));
+    await expectReject('binary base snapshot', () => service.getFileSnapshot(repo, 'base-binary.dat', 'base'), /Binary file snapshots/);
+    await expectReject('oversized base snapshot', () => service.getFileSnapshot(repo, 'base-large.txt', 'base'), /exceeds/);
+    await expectReject('symlink base snapshot', () => service.getFileSnapshot(repo, 'base-link.dat', 'base'), /not a regular file/);
+
+    const outside = path.join(root, 'outside.txt');
+    fs.writeFileSync(outside, 'secret');
+    try {
+      fs.symlinkSync(outside, path.join(workdir, 'escape.txt'));
+      await expectReject('symlink escape', () => service.getFileSnapshot(workdir, 'escape.txt'), /escapes/);
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined;
+      if (code !== 'EPERM' && code !== 'EACCES') throw error;
+    }
+
+    const raceBackend = new OwnershipBackend();
+    const raceManager = new SessionManager(raceBackend);
+    const raceStatePath = path.join(hydraHome, 'sessions.json');
+    fs.writeFileSync(raceStatePath, JSON.stringify({
+      copilots: {}, workers: {}, nextWorkerId: 1, updatedAt: new Date().toISOString(),
+    }), 'utf8');
+    raceBackend.onWorkerIdWrite = (_sessionName, _workerId, writeIndex) => {
+      if (writeIndex !== 1) return;
+      const state = JSON.parse(fs.readFileSync(raceStatePath, 'utf8')) as { nextWorkerId: number };
+      state.nextWorkerId = 9;
+      fs.writeFileSync(raceStatePath, JSON.stringify(state), 'utf8');
+    };
+    const raced = await raceManager.createDirectoryWorker({
+      workdir: path.join(root, 'race-worker'),
+      name: 'race-worker',
+      agentType: 'codex',
+      agentCommand: 'codex',
+      notifyCopilot: false,
+    });
+    await raced.postCreatePromise;
+    assert.equal(raced.workerInfo.workerId, 9, 'persisted allocation observes the advanced nextWorkerId');
+    assert.deepEqual(
+      raceBackend.workerIdWrites.map(write => write.workerId),
+      [1, 9],
+      'tmux worker metadata is corrected from authoritative persisted WorkerInfo',
+    );
+
+    const sessionName = 'hydra-owned';
+    fs.writeFileSync(path.join(hydraHome, 'sessions.json'), JSON.stringify({
+      copilots: {}, workers: { [sessionName]: worker(sessionName, workdir) }, nextWorkerId: 8,
+      updatedAt: new Date().toISOString(),
+    }), 'utf8');
+    const backend = new OwnershipBackend();
+    const manager = new SessionManager(backend);
+
+    await assert.doesNotReject(() => manager.assertHydraSessionOwnership(sessionName, 'worker'), 'missing known session is safe');
+
+    backend.sessions.add(sessionName);
+    backend.workdirs.set(sessionName, workdir);
+    backend.roles.set(sessionName, 'worker');
+    await assert.doesNotReject(() => manager.assertHydraSessionOwnership(sessionName, 'worker'), 'legacy metadata remains supported');
+
+    backend.workerIds.set(sessionName, 7);
+    await manager.stopWorker(sessionName);
+    assert.deepEqual(backend.killed, [sessionName], 'known Hydra session is stopped');
+
+    backend.sessions.add('ordinary-user-tmux');
+    await expectReject('unknown session stop', () => manager.stopWorker('ordinary-user-tmux'), /unknown Hydra worker/);
+    await expectReject('unknown session delete', () => manager.deleteWorker('ordinary-user-tmux'), /unknown Hydra worker/);
+    assert.deepEqual(backend.killed, [sessionName], 'foreign session is never killed');
+
+    backend.sessions.add(sessionName);
+    backend.workdirs.set(sessionName, path.join(root, 'foreign'));
+    await expectReject('foreign metadata stop', () => manager.stopWorker(sessionName), /foreign tmux session/);
+    await expectReject('foreign metadata delete', () => manager.deleteWorker(sessionName), /foreign tmux session/);
+    assert.deepEqual(backend.killed, [sessionName], 'mismatched session is never killed');
+
+    backend.workdirs.set(sessionName, workdir);
+    backend.workerIds.set(sessionName, 8);
+    await expectReject('wrong worker ID', () => manager.assertHydraSessionOwnership(sessionName, 'worker'), /worker identity/);
+
+    backend.workerIds.delete(sessionName);
+    backend.workerIdErrors.set(sessionName, new Error('Malformed @hydra-worker-id on tmux session "hydra-owned": nope'));
+    await expectReject('malformed worker ID', () => manager.assertHydraSessionOwnership(sessionName, 'worker'), /Malformed @hydra-worker-id/);
+
+    const coreExec = await import('../core/exec') as unknown as { exec: (...args: unknown[]) => Promise<string> };
+    const originalExec = coreExec.exec;
+    coreExec.exec = async () => 'nope';
+    try {
+      const { TmuxBackendCore } = await import('../core/tmux');
+      await expectReject(
+        'tmux malformed worker ID parser',
+        () => new TmuxBackendCore().getSessionWorkerId(sessionName),
+        /Malformed @hydra-worker-id/,
+      );
+    } finally {
+      coreExec.exec = originalExec;
+    }
+
+    console.log('controlPlaneSafetySmoke: ok');
+  } finally {
+    if (previousHome === undefined) delete process.env.HYDRA_HOME;
+    else process.env.HYDRA_HOME = previousHome;
+    if (previousConfig === undefined) delete process.env.HYDRA_CONFIG_PATH;
+    else process.env.HYDRA_CONFIG_PATH = previousConfig;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/workerAttentionCharacterizationSmoke.ts
+++ b/packages/core/src/smoke/workerAttentionCharacterizationSmoke.ts
@@ -70,8 +70,8 @@ const EXPECTATIONS: Record<ScenarioId, ExpectedState> = {
   'event-only-notification-clear': 'known-failure',
   'codex-turn-aborted-resolution': 'known-failure',
   'completion-pending-overwrite': 'known-failure',
-  'diff-symlink-escape': 'known-failure',
-  'foreign-tmux-stop': 'known-failure',
+  'diff-symlink-escape': 'fixed',
+  'foreign-tmux-stop': 'fixed',
   'archive-concurrent-update': 'known-failure',
 };
 

--- a/packages/core/src/smoke/workerDeleteFailClosedSmoke.ts
+++ b/packages/core/src/smoke/workerDeleteFailClosedSmoke.ts
@@ -40,13 +40,15 @@ class DeleteWorkerBackend implements MultiplexerBackendCore {
   readonly installHint = 'not needed';
 
   private readonly sessions = new Set<string>();
+  private readonly workers = new Map<string, WorkerRecord>();
 
   killError: Error | null = null;
   hasSessionError: Error | null = null;
 
-  constructor(sessionNames: string[] = []) {
-    for (const sessionName of sessionNames) {
-      this.sessions.add(sessionName);
+  constructor(workers: WorkerRecord[] = []) {
+    for (const worker of workers) {
+      this.sessions.add(worker.sessionName);
+      this.workers.set(worker.sessionName, worker);
     }
   }
 
@@ -80,20 +82,24 @@ class DeleteWorkerBackend implements MultiplexerBackendCore {
     return this.sessions.has(sessionName);
   }
 
-  async getSessionWorkdir(): Promise<string | undefined> {
-    this.unexpected();
+  async getSessionWorkdir(sessionName: string): Promise<string | undefined> {
+    return this.workers.get(sessionName)?.workdir;
   }
 
   async setSessionWorkdir(): Promise<void> {
     this.unexpected();
   }
 
-  async getSessionRole(): Promise<HydraRole | undefined> {
-    this.unexpected();
+  async getSessionRole(sessionName: string): Promise<HydraRole | undefined> {
+    return this.workers.has(sessionName) ? 'worker' : undefined;
   }
 
   async setSessionRole(): Promise<void> {
     this.unexpected();
+  }
+
+  async getSessionWorkerId(sessionName: string): Promise<number | undefined> {
+    return this.workers.get(sessionName)?.workerId;
   }
 
   async getSessionAgent(): Promise<string | undefined> {
@@ -268,7 +274,7 @@ async function main(): Promise<void> {
     writeWorkerState(sessionsFile, worker);
     writeJson(archiveFile, { entries: [] });
 
-    const backend = new DeleteWorkerBackend([worker.sessionName]);
+    const backend = new DeleteWorkerBackend([worker]);
     backend.killError = makeExecError('kill-session failed', 'permission denied');
 
     let removeWorktreeCalls = 0;
@@ -357,7 +363,7 @@ async function main(): Promise<void> {
     writeWorkerRuntimeState(runtimeStateFile, worker);
     writeJson(archiveFile, { entries: [] });
 
-    const backend = new DeleteWorkerBackend([worker.sessionName]);
+    const backend = new DeleteWorkerBackend([worker]);
 
     let removeWorktreeCalls = 0;
     const branchDeleteCommands: string[] = [];

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -30,7 +30,8 @@
 //  Op.getGitStatus          SessionManager.sync + git status --porcelain        (sidebar U:N)
 //  Topic.events             EventLog.read (poll — EventBus push is M2)           (events.ts)
 //  Topic.notifications      NotificationStateService.onDidChange
-//  openTerminal             node-pty ⇄ tmux attach (M3 — not yet implemented)
+//  openTerminal             reserved in-process terminal seam; loopback attach
+//                             is handled by TerminalBridge after ownership auth
 
 import * as os from 'node:os';
 
@@ -135,7 +136,7 @@ export class HydraAppService implements HydraAppServiceApi {
     this.notificationEventSource = options.notificationEventSource ?? 'session-manager';
   }
 
-  // ── transport surface (the 3-method waist, server side) ──
+  // ── transport waist (3 methods) + sidecar-internal terminal authorization ──
 
   // `auth` is part of the HydraAppService contract but ignored in-process; it is
   // omitted here (optional params may be dropped by an implementer) and wired in
@@ -156,11 +157,15 @@ export class HydraAppService implements HydraAppServiceApi {
   }
 
   openTerminal(input: TerminalAttachInput): TerminalChannel {
-    // M3 delivers the node-pty ⇄ tmux attach bridge. The shape is fixed in
-    // @hydra/protocol so UI + transports are written against it today.
+    // Loopback terminal attach is implemented by TerminalBridge. The in-process
+    // transport keeps the frozen terminal method but has no PTY bridge.
     throw new Error(
       `attachTerminal (node-pty ⇄ tmux bridge) is implemented in milestone M3; requested session "${input.session}"`,
     );
+  }
+
+  async authorizeTerminal(input: TerminalAttachInput): Promise<void> {
+    await this.sessionManager.assertHydraSessionOwnership(input.session);
   }
 
   // ── request dispatch ──

--- a/packages/sidecar/src/loopbackServer.ts
+++ b/packages/sidecar/src/loopbackServer.ts
@@ -23,7 +23,11 @@ import { timingSafeEqual } from 'node:crypto';
 
 import { WebSocketServer, type WebSocket as WsWebSocket } from 'ws';
 
-import type { AuthContext, HydraAppService as HydraAppServiceApi } from '@hydra/protocol';
+import type {
+  AuthContext,
+  HydraAppService as HydraAppServiceApi,
+  TerminalAttachInput,
+} from '@hydra/protocol';
 import {
   BEARER_PREFIX,
   LOOPBACK_ROUTES,
@@ -67,6 +71,10 @@ export interface LoopbackServer {
   close(): Promise<void>;
 }
 
+interface TerminalAuthorizingAppService extends HydraAppServiceApi {
+  authorizeTerminal(input: TerminalAttachInput): Promise<void>;
+}
+
 /** Denial verdict from the auth/origin gate, or `null` when the request passes. */
 interface Denial {
   status: number;
@@ -78,7 +86,7 @@ interface Denial {
  * with the chosen `{ url, port, close() }`.
  */
 export function createLoopbackServer(
-  appService: HydraAppServiceApi,
+  appService: TerminalAuthorizingAppService,
   options: LoopbackServerOptions,
 ): Promise<LoopbackServer> {
   const token = options.token;
@@ -97,7 +105,9 @@ export function createLoopbackServer(
   const wss = new WebSocketServer({ noServer: true });
   // One bridge per server owns the interactive-owner registry (one owner per
   // worker); each `/v1/terminal` socket is handed to `bridge.handle`.
-  const terminalBridge = new TerminalBridge();
+  const terminalBridge = new TerminalBridge(async (session) => {
+    await appService.authorizeTerminal({ session });
+  });
 
   server.on('upgrade', (req, socket, head) => {
     const url = parseUrl(req);
@@ -115,7 +125,7 @@ export function createLoopbackServer(
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
       if (url.pathname === LOOPBACK_ROUTES.terminal) {
-        terminalBridge.handle(ws, url);
+        void terminalBridge.handle(ws, url);
       } else {
         void handleStream(ws, url);
       }

--- a/packages/sidecar/src/smoke/fakeBackend.ts
+++ b/packages/sidecar/src/smoke/fakeBackend.ts
@@ -17,6 +17,7 @@ export class FakeBackend implements MultiplexerBackendCore {
   readonly sessions = new Set<string>();
   readonly workdirs = new Map<string, string>();
   readonly roles = new Map<string, HydraRole>();
+  readonly workerIds = new Map<string, number>();
   readonly agents = new Map<string, string>();
   readonly messages: Array<{ sessionName: string; message: string }> = [];
   readonly killed: string[] = [];
@@ -51,6 +52,8 @@ export class FakeBackend implements MultiplexerBackendCore {
     if (workdir) this.workdirs.set(newName, workdir);
     const role = this.roles.get(oldName);
     if (role) this.roles.set(newName, role);
+    const workerId = this.workerIds.get(oldName);
+    if (workerId) this.workerIds.set(newName, workerId);
     const agent = this.agents.get(oldName);
     if (agent) this.agents.set(newName, agent);
   }
@@ -73,6 +76,14 @@ export class FakeBackend implements MultiplexerBackendCore {
 
   async setSessionRole(sessionName: string, role: HydraRole): Promise<void> {
     this.roles.set(sessionName, role);
+  }
+
+  async getSessionWorkerId(sessionName: string): Promise<number | undefined> {
+    return this.workerIds.get(sessionName);
+  }
+
+  async setSessionWorkerId(sessionName: string, workerId: number): Promise<void> {
+    this.workerIds.set(sessionName, workerId);
   }
 
   async getSessionAgent(sessionName: string): Promise<string | undefined> {

--- a/packages/sidecar/src/smoke/terminalSmoke.ts
+++ b/packages/sidecar/src/smoke/terminalSmoke.ts
@@ -206,11 +206,57 @@ async function main(): Promise<void> {
   const { createLoopbackServer } = await import('../loopbackServer');
 
   const token = `tm-${Math.random().toString(16).slice(2)}-${Math.random().toString(16).slice(2)}`;
-  const appService = new HydraAppService({ backend: new FakeBackend() });
+  const backend = new FakeBackend();
+  backend.sessions.add(SESSION);
+  backend.workdirs.set(SESSION, tempHome);
+  backend.roles.set(SESSION, 'worker');
+  backend.workerIds.set(SESSION, 1);
+  fs.mkdirSync(process.env.HYDRA_HOME!, { recursive: true });
+  fs.writeFileSync(path.join(process.env.HYDRA_HOME!, 'sessions.json'), JSON.stringify({
+    copilots: {},
+    workers: {
+      [SESSION]: {
+        source: 'directory',
+        sessionName: SESSION,
+        displayName: SESSION,
+        workerId: 1,
+        repo: null,
+        repoRoot: null,
+        branch: null,
+        slug: SESSION,
+        status: 'running',
+        attached: false,
+        agent: 'codex',
+        workdir: tempHome,
+        managedWorkdir: false,
+        tmuxSession: SESSION,
+        createdAt: new Date().toISOString(),
+        lastSeenAt: new Date().toISOString(),
+        sessionId: null,
+        copilotSessionName: null,
+      },
+    },
+    nextWorkerId: 2,
+    updatedAt: new Date().toISOString(),
+  }), 'utf8');
+  const appService = new HydraAppService({ backend });
   const server = await createLoopbackServer(appService, { token });
   const client = createHydraControlClient(new LoopbackHttpWsTransport({ url: server.url, token }));
 
   try {
+    console.log('0. Foreign session attach rejected');
+    const foreign = new Term(client, 'ordinary-user-tmux');
+    const foreignError = await foreign.waitFor(/Refusing to control unknown Hydra session/, 5000);
+    check('foreign tmux session is rejected before attach', foreignError !== null);
+    foreign.close();
+
+    backend.workerIds.set(SESSION, 2);
+    const mismatched = new Term(client, SESSION);
+    const mismatchError = await mismatched.waitFor(/worker identity does not match session state/, 5000);
+    check('mismatched Hydra worker identity is rejected before attach', mismatchError !== null);
+    mismatched.close();
+    backend.workerIds.set(SESSION, 1);
+
     // ── 1. bidirectional I/O (interactive attach) ──
     console.log('1. Bidirectional I/O');
     const t1 = new Term(client, SESSION, { mode: 'interactive', cols: 100, rows: 40 });

--- a/packages/sidecar/src/terminalBridge.ts
+++ b/packages/sidecar/src/terminalBridge.ts
@@ -56,10 +56,19 @@ export class TerminalBridge {
   /** session → its current interactive owner socket (one owner per worker). */
   private readonly owners = new Map<string, WsWebSocket>();
 
-  handle(ws: WsWebSocket, url: URL): void {
+  constructor(private readonly authorizeSession: (session: string) => Promise<void>) {}
+
+  async handle(ws: WsWebSocket, url: URL): Promise<void> {
     const session = url.searchParams.get(WIRE_PARAMS.session);
     if (!session) {
       sendControl(ws, { t: 'error', message: 'terminal: session is required' });
+      ws.close();
+      return;
+    }
+    try {
+      await this.authorizeSession(session);
+    } catch (error) {
+      sendControl(ws, { t: 'error', message: errorMessage(error) });
       ws.close();
       return;
     }
@@ -68,9 +77,9 @@ export class TerminalBridge {
     const cols = clampInt(url.searchParams.get(WIRE_PARAMS.cols), 80, MIN_COLS, MAX_COLS);
     const rows = clampInt(url.searchParams.get(WIRE_PARAMS.rows), 24, MIN_ROWS, MAX_ROWS);
 
-    // Session-existence check before any attach (FINAL §Security). We ask tmux
-    // directly (not SessionManager) so the bridge stays decoupled from the
-    // engine and works against any tmux session the user can attach.
+    // Ownership authorization has already matched this live tmux session to
+    // Hydra state and metadata. Confirm it still exists immediately before the
+    // attach so a concurrent stop fails cleanly instead of spawning a dead PTY.
     if (!sessionExists(session)) {
       sendControl(ws, { t: 'error', message: `tmux session "${session}" not found` });
       ws.close();


### PR DESCRIPTION
## Scope

Implements Wave 1 PR2 from `docs/worker-attention-control-plane-plan.md`:

- reject current/base snapshots that escape the trusted workdir, are non-regular, binary/invalid UTF-8, or exceed the 2 MiB actual-read ceiling;
- validate live tmux ownership before worker stop/delete, copilot delete, and sidecar terminal attach;
- stamp `@hydra-worker-id` on worker sessions and resynchronize it from the authoritative persisted `WorkerInfo.workerId`;
- retain role/workdir fallback for legacy Hydra sessions without worker-ID metadata;
- keep the protocol request/stream/openTerminal waist unchanged.

## Frozen decisions / acceptance

- Runtime and notification authority are unchanged by this PR.
- A normal user tmux session cannot be stopped, deleted, or attached through Hydra control-plane operations.
- Symlink escape, binary content, invalid UTF-8, oversized files, and read-growth races are rejected.
- Only `diff-symlink-escape` and `foreign-tmux-stop` move from known-failure to fixed.

## Compatibility

No stored schema or wire-operation change. `@hydra-worker-id` is additive; legacy sessions remain valid when existing Hydra role/workdir metadata matches. The sidecar terminal authorizer is internal and does not add a protocol operation.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:control-plane-safety`
- `npm run smoke:desktop-diff`
- `npm run smoke:worker-delete`
- `npm run smoke:worker-attention-characterization`
- `npm run smoke:terminal`
- `git diff --check origin/feat/worker-attention-control-plane..HEAD`
- `env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test`

All passed independently after the worker implementation and review corrections.