### PR TITLE
test(e2e): retry temporary directory cleanup

### DIFF
--- a/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
+++ b/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
@@ -330,13 +330,22 @@ async function main(): Promise<void> {
     console.log('copilotEnvE2eSmoke: ok');
   } finally {
     runTmux(['kill-server']);
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+    cleanupTempRoot();
   }
+}
+
+function cleanupTempRoot(): void {
+  fs.rmSync(tempRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 10,
+    retryDelay: 100,
+  });
 }
 
 void main().catch((error: unknown) => {
   try { runTmux(['kill-server']); } catch { /* best-effort */ }
-  fs.rmSync(tempRoot, { recursive: true, force: true });
+  cleanupTempRoot();
   console.error(error instanceof Error ? error.stack || error.message : String(error));
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary

- retry recursive temporary-root removal when macOS reports transient ENOTEMPTY
- use the same cleanup helper on success and failure paths
- keep all E2E behavior and assertions unchanged

## Evidence

The Wave 3 integration run reached copilotEnvE2eSmoke cleanup and failed while removing the temporary HOME with ENOTEMPTY. The same identity tree had already passed two full PR-branch runs, and a focused rerun passed, confirming a cleanup race rather than a product assertion failure.

## Validation

- npm run compile
- npm run lint
- npm run smoke:copilot-env-e2e three consecutive times
- git diff --check

This targets the integration branch only; main remains unchanged.