### PR TITLE
feat(desktop): add global attention inbox

### DIFF
--- a/packages/cli/src/smoke/workerRuntimeStateSmoke.ts
+++ b/packages/cli/src/smoke/workerRuntimeStateSmoke.ts
@@ -261,9 +261,9 @@ async function testNeedsInputWithoutNotificationTargetStillUpdatesRuntime(): Pro
       assert.ok(signal);
 
       const result = publishWorkerNeedsInputNotification(worker, signal, { eventSource: 'hook' });
-      assert.equal(result.created, false);
-      assert.equal(result.skipped, 'missing-target');
-      assert.equal(new NotificationStore().list().notifications.length, 0);
+      assert.equal(result.created, true);
+      assert.equal(result.notification.targetSession, null);
+      assert.equal(new NotificationStore().list().notifications.length, 1);
       assertRuntime(new WorkerRuntimeStateStore().get(worker.sessionName), 'needs-input', 'permission-request');
     });
   } finally {

--- a/packages/core/src/core/workerAttentionNotifications.ts
+++ b/packages/core/src/core/workerAttentionNotifications.ts
@@ -56,7 +56,7 @@ export interface PublishWorkerNeedsInputOptions {
 
 export type PublishWorkerAttentionNotificationResult =
   | (CreateNotificationResult & { skipped?: undefined })
-  | { created: false; notification?: undefined; skipped: 'missing-target' | 'store-failed' };
+  | { created: false; notification?: undefined; skipped: 'store-failed' };
 
 const ERROR_BODY_LIMIT = 600;
 const NEEDS_INPUT_BODY_LIMIT = 600;
@@ -65,16 +65,13 @@ export function publishWorkerAttentionNotification(
   input: PublishWorkerAttentionNotificationInput,
 ): PublishWorkerAttentionNotificationResult {
   const targetCopilotSession = input.targetCopilotSession?.trim();
-  if (!targetCopilotSession) {
-    return { created: false, skipped: 'missing-target' };
-  }
 
   try {
     return (input.store ?? new NotificationStore()).create({
       kind: input.kind,
       title: input.title,
       body: input.body,
-      targetSession: targetCopilotSession,
+      targetSession: targetCopilotSession || null,
       sourceSession: input.sourceWorkerSession,
       dedupeKey: input.dedupeKey,
       action: {

--- a/packages/core/src/smoke/workerAttentionNotificationSmoke.ts
+++ b/packages/core/src/smoke/workerAttentionNotificationSmoke.ts
@@ -156,17 +156,18 @@ async function testRuntimeErrorNotification(): Promise<void> {
   }
 }
 
-async function testMissingCopilotSkips(): Promise<void> {
+async function testMissingCopilotUsesGlobalInbox(): Promise<void> {
   const ctx = setupContext();
   try {
     await withProcessEnv(ctx, async () => {
-      const skipped = publishWorkerRuntimeErrorNotification(
+      const global = publishWorkerRuntimeErrorNotification(
         createWorker({ copilotSessionName: null }),
         new Error('Initial prompt delivery failed'),
       );
-      assert.equal(skipped.created, false);
-      assert.equal(skipped.skipped, 'missing-target');
-      assert.equal(new NotificationStore().list().notifications.length, 0);
+      assert.equal(global.created, true);
+      assert.equal(global.notification.targetSession, null);
+      assert.equal(global.notification.kind, 'error');
+      assert.equal(new NotificationStore().list().notifications.length, 1);
     });
   } finally {
     fs.rmSync(ctx.tmp, { recursive: true, force: true });
@@ -219,7 +220,7 @@ async function testPostCreateHelperPublishesAndRethrows(): Promise<void> {
 
 async function main(): Promise<void> {
   await testRuntimeErrorNotification();
-  await testMissingCopilotSkips();
+  await testMissingCopilotUsesGlobalInbox();
   await testStoreFailureDoesNotThrow();
   await testPostCreateHelperPublishesAndRethrows();
   console.log('workerAttentionNotificationSmoke: ok');

--- a/packages/desktop/index.html
+++ b/packages/desktop/index.html
@@ -1561,6 +1561,121 @@
         background: var(--hy-canvas);
         padding: 20px 26px 32px;
       }
+      .hydra-inbox {
+        max-width: 1180px;
+        margin: 0 auto 24px;
+        border: 1px solid var(--hy-border);
+        border-radius: 12px;
+        background: var(--hy-panel);
+        overflow: hidden;
+      }
+      .hydra-inbox__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 14px 16px 12px;
+        border-bottom: 1px solid var(--hy-border);
+      }
+      .hydra-inbox__head h2 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 680;
+      }
+      .hydra-inbox__head p {
+        margin: 3px 0 0;
+        color: var(--hy-muted);
+        font-size: 12px;
+      }
+      .hydra-inbox__count {
+        min-width: 24px;
+        padding: 2px 7px;
+        border-radius: 999px;
+        background: var(--hy-panel-strong);
+        color: var(--hy-muted);
+        text-align: center;
+        font-size: 12px;
+        font-weight: 650;
+      }
+      .hydra-inbox__empty {
+        padding: 18px 16px;
+        color: var(--hy-muted);
+        font-size: 12px;
+      }
+      .hydra-inbox__rows {
+        display: flex;
+        flex-direction: column;
+      }
+      .hydra-inbox-row {
+        display: grid;
+        grid-template-columns: 86px minmax(0, 1fr) auto;
+        gap: 12px;
+        align-items: start;
+        padding: 12px 16px;
+        background: var(--hy-canvas);
+        border-bottom: 1px solid var(--hy-border);
+      }
+      .hydra-inbox-row:last-child {
+        border-bottom: 0;
+      }
+      .hydra-inbox-row--unread {
+        box-shadow: inset 3px 0 0 var(--hy-accent);
+      }
+      .hydra-inbox-row__kind {
+        display: inline-flex;
+        justify-content: center;
+        padding: 3px 7px;
+        border: 1px solid currentColor;
+        border-radius: 999px;
+        color: var(--hy-muted);
+        font-size: 11px;
+        white-space: nowrap;
+      }
+      .hydra-inbox-row__kind--needs-input {
+        color: var(--hy-warn);
+      }
+      .hydra-inbox-row__kind--error {
+        color: var(--hy-danger);
+      }
+      .hydra-inbox-row__kind--complete {
+        color: var(--hy-ok);
+      }
+      .hydra-inbox-row__title {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        font-weight: 650;
+      }
+      .hydra-inbox-row__new {
+        color: var(--hy-accent);
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .hydra-inbox-row__content p {
+        max-width: 760px;
+        margin: 4px 0;
+        color: var(--hy-muted);
+        font-size: 12px;
+        white-space: pre-wrap;
+      }
+      .hydra-inbox-row__meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        color: var(--hy-faint);
+        font-size: 11px;
+      }
+      .hydra-inbox-row__actions {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+      }
+      .hydra-field__hint {
+        color: var(--hy-muted);
+        font-size: 11px;
+      }
       .hydra-board {
         max-width: 1180px;
         margin: 0 auto;
@@ -1862,6 +1977,15 @@
           transform: none;
           opacity: 1;
           justify-content: flex-start;
+          flex-wrap: wrap;
+        }
+        .hydra-inbox-row {
+          grid-template-columns: 1fr;
+        }
+        .hydra-inbox-row__kind {
+          justify-self: start;
+        }
+        .hydra-inbox-row__actions {
           flex-wrap: wrap;
         }
       }

--- a/packages/desktop/scripts/missionControlBoardSmoke.mjs
+++ b/packages/desktop/scripts/missionControlBoardSmoke.mjs
@@ -179,6 +179,9 @@ view = selectBoard(model);
 assert.equal(view.unreadTotal, 2, 'unread total taken from the notification snapshot');
 assert.equal(view.groups[0].tiles[0].unread, 1, 'unread counted per source session (read one ignored)');
 assert.equal(view.groups[1].tiles[0].unread, 1, 'unread counted per target session');
+assert.equal(view.inbox.length, 1, 'the inbox includes attention rows and excludes info notifications');
+assert.equal(view.inbox[0].kind, 'needs-input');
+assert.equal(view.inbox[0].targetSession, null, 'an untargeted occurrence remains visible in the global inbox');
 
 // ── 6. resync folds the fresh snapshot and clears stale overlays ──
 
@@ -273,6 +276,28 @@ assert.equal(view.groups[0].tiles[0].unread, 1, 'surviving session keeps its unr
   const v = selectBoard(m);
   assert.equal(v.groups[0].tiles[0].changed, 3, 'the code worker shows its changed-file count');
   assert.equal(v.groups[1].tiles[0].changed, null, 'a task worker never surfaces U:N, even if a count leaks in');
+}
+
+// ── 10. complete / needs-input / error all render as inbox rows ──
+
+{
+  const attention = {
+    loadedAt: '2026-01-01T00:00:00.000Z',
+    lastEventSeq: seq,
+    totalCount: 4,
+    unreadCount: 3,
+    notifications: [
+      { id: 'error', createdAt: '2026-01-01T00:03:00.000Z', readAt: null, kind: 'error', title: 'failed', body: 'boom', targetSession: null, sourceSession: 'repo-a_feat-one' },
+      { id: 'input', createdAt: '2026-01-01T00:02:00.000Z', readAt: null, kind: 'needs-input', title: 'question', body: 'pick one', targetSession: 'copilot_captain', sourceSession: 'repo-a_feat-one' },
+      { id: 'done', createdAt: '2026-01-01T00:01:00.000Z', readAt: '2026-01-01T00:04:00.000Z', kind: 'complete', title: 'done', body: '', targetSession: 'copilot_captain', sourceSession: 'repo-a_feat-one', action: { type: 'open-session', session: 'repo-a_feat-one' } },
+      { id: 'info', createdAt: '2026-01-01T00:00:00.000Z', readAt: null, kind: 'info', title: 'info', body: '', targetSession: null, sourceSession: null },
+    ],
+  };
+  const inbox = selectBoard(applyNotificationSnapshot(createBoardModel(snapshot), attention)).inbox;
+  assert.deepEqual(inbox.map(item => item.kind), ['error', 'needs-input', 'complete']);
+  assert.equal(inbox[0].read, false);
+  assert.equal(inbox[2].read, true);
+  assert.deepEqual(inbox[2].action, { type: 'open-session', session: 'repo-a_feat-one' });
 }
 
 // ── misc invariants ──

--- a/packages/desktop/src/renderer/Overview/OverviewTab.tsx
+++ b/packages/desktop/src/renderer/Overview/OverviewTab.tsx
@@ -4,7 +4,9 @@
 // so a tile's terminal/diff buttons open tabs instead of navigating a URL.
 
 import { MissionControlBoard } from '../missionControl/MissionControlBoard';
+import type { InboxNotificationModel, TileModel } from '../missionControl/boardModel';
 import type { TileActions } from '../missionControl/SessionTile';
+import { AttentionInbox } from '../notifications/AttentionInbox';
 import { useSessions } from '../sessions/SessionsProvider';
 import { useTabs } from '../tabs/TabsProvider';
 
@@ -31,9 +33,31 @@ export function OverviewTab(): JSX.Element {
     onStart: actions.start,
     onStop: actions.stop,
   };
+  const tiles = board.view.groups.flatMap(group => group.tiles);
+  const tileBySession = new Map(tiles.map(tile => [tile.session, tile]));
+  const notificationTile = (notification: InboxNotificationModel): TileModel | undefined => {
+    const session = notification.action?.session ?? notification.sourceSession;
+    return session ? tileBySession.get(session) : undefined;
+  };
 
   return (
     <div className="hydra-overview">
+      <AttentionInbox
+        notifications={board.view.inbox}
+        canOpen={(notification) => Boolean(notificationTile(notification))}
+        onOpen={(notification) => {
+          const tile = notificationTile(notification);
+          if (!tile) return;
+          actions.markNotificationRead(notification.id);
+          tabs.openTab(tile.session, tile.kind);
+          tabs.setView(
+            tile.session,
+            notification.action?.type === 'review-diff' && tile.kind === 'worker' ? 'diff' : 'terminal',
+          );
+        }}
+        onMarkRead={(notification) => actions.markNotificationRead(notification.id)}
+        onDismiss={(notification) => actions.dismissNotification(notification.id)}
+      />
       <MissionControlBoard
         view={board.view}
         connected={board.connected}

--- a/packages/desktop/src/renderer/missionControl/CreateSessionModal.tsx
+++ b/packages/desktop/src/renderer/missionControl/CreateSessionModal.tsx
@@ -13,6 +13,7 @@ export type CreateKind = 'worker' | 'copilot';
 
 interface CreateSessionModalProps {
   initialKind: CreateKind;
+  copilots: readonly { session: string; name: string; running: boolean }[];
   busy?: boolean;
   error?: string | null;
   onCreateWorker: (input: CreateWorkerInput) => void;
@@ -24,6 +25,7 @@ type WorkerType = 'code' | 'task';
 
 export function CreateSessionModal({
   initialKind,
+  copilots,
   busy = false,
   error,
   onCreateWorker,
@@ -42,6 +44,7 @@ export function CreateSessionModal({
   const [agent, setAgent] = useState('');
   const [base, setBase] = useState('');
   const [task, setTask] = useState('');
+  const [copilot, setCopilot] = useState(() => copilots.length === 1 ? copilots[0].session : '');
 
   // Copilot fields.
   const [copilotWorkdir, setCopilotWorkdir] = useState('');
@@ -72,6 +75,7 @@ export function CreateSessionModal({
         agent,
         base,
         task,
+        copilot,
       }));
       return;
     }
@@ -81,6 +85,7 @@ export function CreateSessionModal({
       name,
       agent,
       task,
+      copilot,
     }));
   };
 
@@ -131,6 +136,17 @@ export function CreateSessionModal({
             )}
 
             <Field label="Agent" value={agent} onChange={setAgent} placeholder="default agent" />
+            <SelectField
+              label="Parent copilot"
+              value={copilot}
+              onChange={setCopilot}
+              options={copilots.map(item => ({
+                value: item.session,
+                label: `${item.name}${item.running ? '' : ' (stopped)'}`,
+              }))}
+              emptyLabel="Global inbox (no parent)"
+              hint={copilots.length === 0 ? 'No copilots yet; attention will go to the global inbox.' : undefined}
+            />
             <Field label="Task" value={task} onChange={setTask} placeholder="optional first instruction" multiline />
           </>
         ) : (
@@ -245,6 +261,35 @@ function Field({
           onChange={(event) => onChange(event.target.value)}
         />
       )}
+    </label>
+  );
+}
+
+function SelectField({
+  label,
+  value,
+  onChange,
+  options,
+  emptyLabel,
+  hint,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: readonly { value: string; label: string }[];
+  emptyLabel: string;
+  hint?: string;
+}): JSX.Element {
+  return (
+    <label className="hydra-field">
+      <span className="hydra-field__label">{label}</span>
+      <select className="hydra-field__input" value={value} onChange={(event) => onChange(event.target.value)}>
+        <option value="">{emptyLabel}</option>
+        {options.map(option => (
+          <option key={option.value} value={option.value}>{option.label}</option>
+        ))}
+      </select>
+      {hint ? <span className="hydra-field__hint">{hint}</span> : null}
     </label>
   );
 }

--- a/packages/desktop/src/renderer/missionControl/boardModel.ts
+++ b/packages/desktop/src/renderer/missionControl/boardModel.ts
@@ -47,6 +47,8 @@ export interface BoardModel {
   readonly gitStatusBySession: Readonly<Record<string, number>>;
   /** Total unread across all notifications (authoritative from the snapshot). */
   readonly unreadTotal: number;
+  /** Active notification rows, including global occurrences with no parent target. */
+  readonly notifications: readonly HydraNotification[];
   /** Complete notifications keyed by target session, used for copilot child rows. */
   readonly completionNotificationsByTargetSession: Readonly<Record<string, readonly CompletionNotificationModel[]>>;
   /** ISO timestamp of the most recent event touching each session. */
@@ -100,6 +102,7 @@ export function createBoardModel(snapshot: HydraSessionList): BoardModel {
     completedBySession: {},
     gitStatusBySession: {},
     unreadTotal: 0,
+    notifications: [],
     completionNotificationsByTargetSession: {},
     lastEventBySession: {},
     lastSeq: 0,
@@ -124,6 +127,7 @@ export function applySnapshot(model: BoardModel, snapshot: HydraSessionList): Bo
     completedBySession: pruneToSessions(model.completedBySession, alive),
     gitStatusBySession: pruneToSessions(model.gitStatusBySession, alive),
     completionNotificationsByTargetSession: pruneToSessions(model.completionNotificationsByTargetSession, alive),
+    notifications: model.notifications,
     lastEventBySession: pruneToSessions(model.lastEventBySession, alive),
   };
 }
@@ -235,6 +239,11 @@ export function applyNotificationSnapshot(model: BoardModel, snapshot: Notificat
     completedBySession,
     completionNotificationsByTargetSession,
     unreadTotal: snapshot.unreadCount,
+    notifications: snapshot.notifications.map(notification => ({
+      ...notification,
+      action: notification.action ? { ...notification.action } : undefined,
+      context: notification.context ? { ...notification.context } : undefined,
+    })),
   };
 }
 
@@ -335,6 +344,19 @@ export interface BoardView {
   readonly copilotCount: number;
   readonly unreadTotal: number;
   readonly attentionTotal: number;
+  readonly inbox: readonly InboxNotificationModel[];
+}
+
+export interface InboxNotificationModel {
+  readonly id: string;
+  readonly kind: 'complete' | 'needs-input' | 'error';
+  readonly title: string;
+  readonly body: string;
+  readonly createdAt: string;
+  readonly read: boolean;
+  readonly targetSession: string | null;
+  readonly sourceSession: string | null;
+  readonly action: HydraNotification['action'] | null;
 }
 
 const LOCAL_TASKS_LABEL = 'Local Tasks';
@@ -385,6 +407,20 @@ export function selectBoard(model: BoardModel): BoardView {
     copilotCount: copilotTiles.length,
     unreadTotal: model.unreadTotal,
     attentionTotal: groups.reduce((sum, group) => sum + group.attentionCount, 0),
+    inbox: model.notifications
+      .filter(isInboxNotification)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .map(notification => ({
+        id: notification.id,
+        kind: notification.kind,
+        title: notification.title,
+        body: notification.body,
+        createdAt: notification.createdAt,
+        read: notification.readAt !== null,
+        targetSession: notification.targetSession,
+        sourceSession: notification.sourceSession,
+        action: notification.action ? { ...notification.action } : null,
+      })),
   };
 }
 
@@ -507,6 +543,14 @@ function toCompletionNotificationModel(notification: HydraNotification): Complet
     sourceSession: notification.sourceSession,
     actionSession: notification.action?.session ?? notification.sourceSession,
   };
+}
+
+function isInboxNotification(
+  notification: HydraNotification,
+): notification is HydraNotification & { kind: InboxNotificationModel['kind'] } {
+  return notification.kind === 'complete'
+    || notification.kind === 'needs-input'
+    || notification.kind === 'error';
 }
 
 function buildGroup(

--- a/packages/desktop/src/renderer/notifications/AttentionInbox.tsx
+++ b/packages/desktop/src/renderer/notifications/AttentionInbox.tsx
@@ -1,0 +1,94 @@
+import type { InboxNotificationModel } from '../missionControl/boardModel';
+import { relativeTime } from '../missionControl/format';
+
+export interface AttentionInboxProps {
+  notifications: readonly InboxNotificationModel[];
+  canOpen: (notification: InboxNotificationModel) => boolean;
+  onOpen: (notification: InboxNotificationModel) => void;
+  onMarkRead: (notification: InboxNotificationModel) => void;
+  onDismiss: (notification: InboxNotificationModel) => void;
+}
+
+export function AttentionInbox({
+  notifications,
+  canOpen,
+  onOpen,
+  onMarkRead,
+  onDismiss,
+}: AttentionInboxProps): JSX.Element {
+  return (
+    <section className="hydra-inbox" aria-labelledby="attention-inbox-title">
+      <header className="hydra-inbox__head">
+        <div>
+          <h2 id="attention-inbox-title">Attention Inbox</h2>
+          <p>Completion, input requests, and runtime errors across every worker.</p>
+        </div>
+        <span className="hydra-inbox__count">{notifications.length}</span>
+      </header>
+
+      {notifications.length === 0 ? (
+        <div className="hydra-inbox__empty">Nothing needs attention.</div>
+      ) : (
+        <div className="hydra-inbox__rows">
+          {notifications.map((notification) => (
+            <article
+              key={notification.id}
+              className={`hydra-inbox-row hydra-inbox-row--${notification.kind}${notification.read ? '' : ' hydra-inbox-row--unread'}`}
+            >
+              <span className={`hydra-inbox-row__kind hydra-inbox-row__kind--${notification.kind}`}>
+                {kindLabel(notification.kind)}
+              </span>
+              <div className="hydra-inbox-row__content">
+                <div className="hydra-inbox-row__title">
+                  {notification.title}
+                  {!notification.read ? <span className="hydra-inbox-row__new">new</span> : null}
+                </div>
+                {notification.body ? <p>{notification.body}</p> : null}
+                <div className="hydra-inbox-row__meta">
+                  <span>{notification.sourceSession ?? 'unknown worker'}</span>
+                  <span>→</span>
+                  <span>{notification.targetSession ?? 'Global inbox'}</span>
+                  <span>·</span>
+                  <span>{relativeTime(notification.createdAt)}</span>
+                </div>
+              </div>
+              <div className="hydra-inbox-row__actions">
+                <button
+                  type="button"
+                  className="hydra-btn hydra-btn--sm hydra-btn--primary"
+                  disabled={!canOpen(notification)}
+                  onClick={() => onOpen(notification)}
+                >
+                  Open
+                </button>
+                {!notification.read ? (
+                  <button type="button" className="hydra-btn hydra-btn--sm" onClick={() => onMarkRead(notification)}>
+                    Mark read
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="hydra-btn hydra-btn--sm"
+                  onClick={() => onDismiss(notification)}
+                >
+                  Dismiss
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function kindLabel(kind: InboxNotificationModel['kind']): string {
+  switch (kind) {
+    case 'complete':
+      return 'Complete';
+    case 'needs-input':
+      return 'Needs input';
+    case 'error':
+      return 'Error';
+  }
+}

--- a/packages/desktop/src/renderer/sessions/SessionsProvider.tsx
+++ b/packages/desktop/src/renderer/sessions/SessionsProvider.tsx
@@ -37,6 +37,8 @@ export interface SessionActions {
   delete: (tile: TileModel) => void;
   acknowledgeCompletion: (tile: TileModel) => void;
   acknowledgeWorkerCompletion: (session: string) => void;
+  markNotificationRead: (id: string) => void;
+  dismissNotification: (id: string) => void;
   start: (tile: TileModel) => void;
   stop: (tile: WorkerTileModel) => void;
 }
@@ -121,6 +123,8 @@ export function SessionsProvider({ children }: { children: ReactNode }): JSX.Ele
       },
       acknowledgeWorkerCompletion: (session) =>
         runDirect(() => client.clearNotifications(completionNotificationClearFiltersForWorkerSession(session))),
+      markNotificationRead: (id) => runDirect(() => client.markNotificationRead(id)),
+      dismissNotification: (id) => runDirect(() => client.dismissNotification(id)),
       start: (tile) => runDirect(() => client.startSession(tile.session, tile.kind)),
       stop: (tile) => runDirect(() => client.stopWorker(tile.session)),
     }),
@@ -147,6 +151,9 @@ export function SessionsProvider({ children }: { children: ReactNode }): JSX.Ele
       {dialog?.type === 'create' ? (
         <CreateSessionModal
           initialKind={dialog.kind}
+          copilots={(board.view?.groups ?? []).flatMap(group => group.tiles)
+            .filter((tile): tile is Extract<TileModel, { kind: 'copilot' }> => tile.kind === 'copilot')
+            .map(tile => ({ session: tile.session, name: tile.name, running: tile.lifecycle === 'running' }))}
           busy={busy}
           error={dialogError}
           onCreateWorker={(input: CreateWorkerInput) => runDialog(() => client.createWorker(input))}

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -21,6 +21,7 @@ import type {
   CreateWorkerResult,
   DeleteSessionOptions,
   DeleteSessionPayload,
+  DismissNotificationPayload,
   DiffSummary,
   EventSubscribeInput,
   FileSnapshot,
@@ -38,6 +39,7 @@ import type {
   NotificationListResult,
   NotificationReadResult,
   NotificationSnapshot,
+  NotificationStatusMutationResult,
   NotificationSubscribeInput,
   RenameSessionPayload,
   RestoreSessionPayload,
@@ -68,6 +70,7 @@ export interface HydraControlClient {
   // Attention inbox
   listNotifications(filters?: NotificationListFilters): Promise<NotificationListResult>;
   markNotificationRead(id: string): Promise<NotificationReadResult>;
+  dismissNotification(id: string): Promise<NotificationStatusMutationResult>;
   clearNotifications(filters?: NotificationClearFilters): Promise<NotificationClearResult>;
 
   // Diff review (path-constrained)
@@ -138,6 +141,10 @@ export function createHydraControlClient(
     markNotificationRead: (id) =>
       transport.request<MarkNotificationReadPayload, NotificationReadResult>(
         Op.markNotificationRead, { id }, auth),
+
+    dismissNotification: (id) =>
+      transport.request<DismissNotificationPayload, NotificationStatusMutationResult>(
+        Op.dismissNotification, { id }, auth),
 
     clearNotifications: (filters) =>
       transport.request<NotificationClearFilters, NotificationClearResult>(

--- a/packages/protocol/src/dto.ts
+++ b/packages/protocol/src/dto.ts
@@ -22,6 +22,7 @@ import type {
   NotificationListResult,
   NotificationReadResult,
   NotificationClearResult,
+  NotificationStatusMutationResult,
 } from '@hydra/core/notifications';
 import type { NotificationSnapshot } from '@hydra/core/notificationState';
 import type { DiffChange } from '@hydra/core/diff';
@@ -40,6 +41,7 @@ export type {
   NotificationListResult,
   NotificationReadResult,
   NotificationClearResult,
+  NotificationStatusMutationResult,
   NotificationSnapshot,
   DiffChange,
 };
@@ -306,6 +308,10 @@ export interface BroadcastPayload {
 }
 
 export interface MarkNotificationReadPayload {
+  id: string;
+}
+
+export interface DismissNotificationPayload {
   id: string;
 }
 

--- a/packages/protocol/src/ops.ts
+++ b/packages/protocol/src/ops.ts
@@ -22,6 +22,7 @@ export const Op = {
   broadcastToWorkers: 'worker.broadcast',
   listNotifications: 'notifications.list',
   markNotificationRead: 'notifications.markRead',
+  dismissNotification: 'notifications.dismiss',
   clearNotifications: 'notifications.clear',
   getDiff: 'diff.get',
   getFileSnapshot: 'diff.fileSnapshot',

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -24,6 +24,7 @@
 //  Op.broadcastToWorkers    WorkerLifecycleService.broadcastToWorkers            (worker send --all)
 //  Op.listNotifications     NotificationStore.list
 //  Op.markNotificationRead  NotificationStore.markRead
+//  Op.dismissNotification   NotificationStore.dismiss
 //  Op.clearNotifications    NotificationStore.clear
 //  Op.getDiff               DiffService.getDiff (workdir from SessionManager)
 //  Op.getFileSnapshot       DiffService.getFileSnapshot (path-constrained)
@@ -68,6 +69,7 @@ import {
   type CreateWorkerInput,
   type CreateWorkerResult,
   type DeleteSessionPayload,
+  type DismissNotificationPayload,
   type DiffSummary,
   type EventSubscribeInput,
   type FileSnapshot,
@@ -85,6 +87,7 @@ import {
   type NotificationListResult,
   type NotificationReadResult,
   type NotificationSnapshot,
+  type NotificationStatusMutationResult,
   type RenameSessionPayload,
   type RestoreSessionPayload,
   type SendMessagePayload,
@@ -208,6 +211,8 @@ export class HydraAppService implements HydraAppServiceApi {
         return this.listNotifications(payload as NotificationListFilters);
       case Op.markNotificationRead:
         return this.markNotificationRead(payload as MarkNotificationReadPayload);
+      case Op.dismissNotification:
+        return this.dismissNotification(payload as DismissNotificationPayload);
       case Op.clearNotifications:
         return this.clearNotifications(payload as NotificationClearFilters);
       case Op.getDiff:
@@ -496,6 +501,11 @@ export class HydraAppService implements HydraAppServiceApi {
   /** NotificationStore.markRead. */
   private async markNotificationRead(payload: MarkNotificationReadPayload): Promise<NotificationReadResult> {
     return this.notificationStore.markRead(payload.id, this.notificationEventSource);
+  }
+
+  /** NotificationStore.dismiss. Runtime remains unchanged. */
+  private async dismissNotification(payload: DismissNotificationPayload): Promise<NotificationStatusMutationResult> {
+    return this.notificationStore.dismiss(payload.id, this.notificationEventSource);
   }
 
   /** NotificationStore.clear. */

--- a/packages/sidecar/src/smoke/seamSmoke.ts
+++ b/packages/sidecar/src/smoke/seamSmoke.ts
@@ -69,8 +69,10 @@ async function main(): Promise<void> {
   try {
     // ── Build the seam: engine-free client over the in-process transport ──
     const backend = new FakeBackend();
+    const { SessionManager } = await import('@hydra/core/sessionManager');
     const { HydraAppService } = await import('../appService');
-    const appService = new HydraAppService({ backend });
+    const sessionManager = new SessionManager(backend);
+    const appService = new HydraAppService({ backend, sessionManager });
     const transport = transportFactory({ kind: 'in-process', appService });
     const client = createHydraControlClient(transport);
 
@@ -91,7 +93,120 @@ async function main(): Promise<void> {
       ),
       'desktop seam sends copilot onboarding prompt',
     );
+    const parentedWorker = await client.createWorker({
+      temp: true,
+      name: 'parented-worker',
+      agent: 'claude',
+      copilot: copilot.session,
+      task: 'report to the selected parent',
+    });
+    const parentedEntry = (await client.listSessions()).workers.find(worker => worker.session === parentedWorker.session);
+    assert.equal(parentedEntry?.copilotSessionName, copilot.session, 'desktop-selected parent is persisted on the worker');
+    await client.deleteSession(parentedWorker.session, 'worker', { deleteFiles: true });
     await client.deleteSession(copilot.session, 'copilot');
+
+    // ── Desktop-only global Inbox: no extension and no parent copilot ──
+    const completeWorkerResult = await client.createWorker({ temp: true, name: 'global-complete', agent: 'claude', task: 'complete this task' });
+    const inputWorkerResult = await client.createWorker({ temp: true, name: 'global-input', agent: 'claude', task: 'ask for input' });
+    const errorWorkerResult = await client.createWorker({ temp: true, name: 'global-error', agent: 'claude', task: 'fail this task' });
+    const attentionWorkers = await Promise.all([
+      sessionManager.getWorker(completeWorkerResult.session),
+      sessionManager.getWorker(inputWorkerResult.session),
+      sessionManager.getWorker(errorWorkerResult.session),
+    ]);
+    assert.ok(attentionWorkers.every(Boolean), 'sidecar lifecycle persisted all attention workers');
+    const [completeWorker, inputWorker, errorWorker] = attentionWorkers;
+    assert.ok(completeWorker && inputWorker && errorWorker);
+
+    const { CompletionCoordinator } = await import('@hydra/core/completionCoordinator');
+    const { CompletionJobStore } = await import('@hydra/core/completionJobStore');
+    const { EventLog } = await import('@hydra/core/events');
+    const { NotificationStore } = await import('@hydra/core/notifications');
+    const { getWorkerLifecycleEpoch } = await import('@hydra/core/workerIdentity');
+    const { WorkerRuntimeCoordinator } = await import('@hydra/core/workerRuntimeCoordinator');
+    const { WorkerRuntimeStateStore } = await import('@hydra/core/workerRuntimeState');
+    const { WorkerRuntimeStateStoreV2 } = await import('@hydra/core/workerRuntimeV2');
+    const { AgentHookEventCoordinator } = await import('@hydra/core/agentHookEventCoordinator');
+    const byId = new Map(attentionWorkers.map(worker => [worker!.workerId, worker!]));
+    const eventLog = new EventLog();
+    const runtimeStore = new WorkerRuntimeStateStoreV2();
+    const compatibilityStore = new WorkerRuntimeStateStore();
+    const notificationStore = new NotificationStore(
+      undefined, undefined, eventLog, compatibilityStore, Date.now, undefined, runtimeStore,
+    );
+    const runtimeCoordinator = new WorkerRuntimeCoordinator(
+      workerId => {
+        const worker = byId.get(workerId);
+        return worker ? {
+          workerId,
+          sessionName: worker.sessionName,
+          lifecycleEpoch: getWorkerLifecycleEpoch(worker),
+          agent: worker.agent,
+          workdir: worker.workdir,
+        } : undefined;
+      },
+      runtimeStore,
+      compatibilityStore,
+      eventLog,
+    );
+    const completion = new CompletionCoordinator({
+      resolveWorker: workerId => {
+        const worker = byId.get(workerId);
+        return worker ? { worker, lifecycleEpoch: getWorkerLifecycleEpoch(worker) } : undefined;
+      },
+      jobStore: new CompletionJobStore(),
+      runtimeStore,
+      runtimeCoordinator,
+      notificationStore,
+      eventSource: 'session-manager',
+    });
+    const completed = await completion.complete({
+      workerId: completeWorker.workerId,
+      lifecycleEpoch: getWorkerLifecycleEpoch(completeWorker),
+      origin: 'hook',
+    });
+    assert.equal(completed.outcome, 'completed', 'sidecar lifecycle completion reaches the global inbox');
+
+    const hookCoordinator = new AgentHookEventCoordinator({
+      resolveWorker: workerId => byId.get(workerId),
+      runtimeStore,
+      compatibilityStore,
+      notificationStore,
+      completionJobStore: new CompletionJobStore(),
+      eventLog,
+      runtimeCoordinator,
+      eventSource: 'session-manager',
+    });
+    const needsInput = hookCoordinator.process({
+      workerId: inputWorker.workerId,
+      lifecycleEpoch: getWorkerLifecycleEpoch(inputWorker),
+      agent: 'claude',
+      eventName: 'PermissionRequest',
+      payload: { tool_name: 'Bash', tool_use_id: 'sidecar-input', tool_input: { command: 'npm test' } },
+    });
+    assert.equal(needsInput.status, 'applied');
+    const runtimeError = hookCoordinator.process({
+      workerId: errorWorker.workerId,
+      lifecycleEpoch: getWorkerLifecycleEpoch(errorWorker),
+      agent: 'claude',
+      eventName: 'StopFailure',
+      payload: { error: 'server_error', error_details: 'service unavailable' },
+    });
+    assert.equal(runtimeError.status, 'applied');
+
+    const globalInbox = await client.listNotifications();
+    const globalAttention = globalInbox.notifications.filter(notification =>
+      [completeWorker.sessionName, inputWorker.sessionName, errorWorker.sessionName].includes(notification.sourceSession ?? ''),
+    );
+    assert.deepEqual(
+      globalAttention.map(notification => notification.kind).sort(),
+      ['complete', 'error', 'needs-input'],
+      'desktop-only operation produces all three attention kinds',
+    );
+    assert.ok(globalAttention.every(notification => notification.targetSession === null), 'all three use global fallback');
+    for (const worker of attentionWorkers) {
+      await client.deleteSession(worker!.sessionName, 'worker', { deleteFiles: true });
+    }
 
     // ── Mutation: create + delete a task worker ──
     const created = await client.createWorker({ temp: true, name: 'seam-temp', agent: 'claude' });
@@ -121,6 +236,8 @@ async function main(): Promise<void> {
     buildGitRepo(repoRoot);
     const diffWorker = await client.createWorker({ dir: repoRoot, name: 'repo', agent: 'claude' });
     const diffSession = diffWorker.session;
+    const diffWorkerId = (await client.listSessions()).workers.find(worker => worker.session === diffSession)?.number;
+    assert.equal(typeof diffWorkerId, 'number', 'diff worker has a stable worker id');
 
     const diff = await client.getDiff(diffSession);
     assert.equal(diff.session, diffSession, 'diff carries the session');
@@ -169,20 +286,30 @@ async function main(): Promise<void> {
     assert.deepEqual(broadcast.sessions, [diffSession], 'broadcast hits the running worker');
 
     // ── Notifications round-trip: seed via core, drive via the client ──
-    const { NotificationStore } = await import('@hydra/core/notifications');
     new NotificationStore().create({
       kind: 'needs-input',
       title: 'Needs input',
       sourceSession: diffSession,
       targetSession: diffSession,
+      context: { workerId: diffWorkerId },
     });
     const listed = await client.listNotifications({ session: diffSession });
     assert.equal(listed.count, 1, 'client lists the seeded notification');
     const notificationId = listed.notifications[0].id;
     const read = await client.markNotificationRead(notificationId);
     assert.equal(read.markedRead, 1, 'markNotificationRead flips unread → read');
+    const dismissed = await client.dismissNotification(notificationId);
+    assert.equal(dismissed.changed, true, 'dismissNotification removes one occurrence from the active inbox');
+    assert.equal(dismissed.status, 'dismissed');
+    new NotificationStore().create({
+      kind: 'complete',
+      title: 'Complete',
+      sourceSession: diffSession,
+      targetSession: null,
+      context: { workerId: diffWorkerId },
+    });
     const cleared = await client.clearNotifications({ session: diffSession });
-    assert.equal(cleared.cleared, 1, 'clearNotifications removes it');
+    assert.equal(cleared.cleared, 1, 'clearNotifications dismisses the remaining active occurrence');
 
     // ── subscribeEvents stream: the create mutation left a worker.created ──
     const events = await collectEvents(


### PR DESCRIPTION
## Summary

- add a parent copilot selector to Desktop worker creation, with a global-inbox option when no parent is selected
- preserve needs-input and error notifications as targetSession=null global occurrences instead of dropping them
- add a complete Desktop Attention Inbox for complete, needs-input, and error rows
- support Open, Mark read, and single-occurrence Dismiss actions through the shared protocol and sidecar service
- keep notification runtime semantics intact: dismiss changes attention history only
- validate Desktop-only operation through the sidecar lifecycle with complete, needs-input, and error global occurrences

## Validation

- npm run compile
- npm run lint
- npm run smoke:worker-attention-notification
- npm run smoke:worker-runtime-state
- npm run smoke:mission-control
- npm run smoke:seam
- npm run smoke:protocol-contract
- npm run smoke:protocol-compatibility
- npm run smoke:loopback
- npm run desktop:build
- npm run desktop:boot-check
- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test
- git diff --check

## Scope

PR10C only. Base is feat/worker-attention-control-plane; this does not target main. CLI and VS Code notification convergence remains PR10D, while EventHub and stream retention remain PR10E.