### PR TITLE
feat(attention): converge VS Code and CLI notification actions

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -184,6 +184,8 @@ Current event types:
 | --- | --- | --- | --- |
 | `notify.created` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `notificationId`, `kind`, `title`, redacted `body`, `targetSession`, `sourceSession`, optional `actionType`, `actionSession`, `workerId`, `branch`, `workdir`, `agent`. Emitted only when a new notification is stored; dedupe hits do not emit a duplicate event. |
 | `notify.read` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Same notification reference fields as `notify.created`. Emitted only when the notification transitions from unread to read. |
+| `notify.resolved` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Notification reference fields plus `notificationStatus`, `resolvedAt`, and `reason`. Emitted only when an active occurrence transitions to resolved. |
+| `notify.dismissed` | `cli`, `extension`, `session-manager`, or `hook` | undefined | Notification reference fields plus `notificationStatus`, `dismissedAt`, and `reason`. Emitted only when an active occurrence transitions to dismissed. |
 | `notify.cleared` | `cli`, `extension`, `session-manager`, or `hook` | undefined | `cleared`, optional `session`, `targetSession`, `sourceSession`, `kind`. Emitted only when at least one notification is removed. |
 | `worker.created` | `session-manager` | `worker` | `workerId`, `source`, optional `branch`, `repo`, `managedWorkdir`. Emitted for fresh code/task worker creation. |
 | `worker.started` | `session-manager` | `worker` | Worker identity fields plus `resumed`; existing-branch paths also include `alreadyRunning`. Emitted when an existing worker session is started or reused. |
@@ -276,6 +278,35 @@ Returns:
 | `notification` | object | The notification after the read operation. |
 | `markedRead` | number | `1` if the command changed unread to read, otherwise `0`. |
 
+Reading changes only `readAt`; it does not resolve or dismiss the occurrence
+and does not change worker runtime.
+
+### `hydra notify resolve <id> --reason <text> --json`
+
+Resolves one active notification occurrence. This is primarily an automation
+and lifecycle command; normal agent transitions resolve attention themselves.
+
+| Field | Type | Contract |
+| --- | --- | --- |
+| `status` | string | `"ok"`. |
+| `notificationStatus` | string | The durable occurrence status after the operation. |
+| `changed` | boolean | Whether the occurrence changed from active to resolved. |
+| `notification` | object | The compatibility notification projection. |
+
+Resolving records the supplied reason and removes the occurrence from active
+inbox projections. The command does not mutate worker runtime directly.
+
+### `hydra notify dismiss <id> --json`
+
+Dismisses one notification occurrence without changing worker runtime.
+
+| Field | Type | Contract |
+| --- | --- | --- |
+| `status` | string | `"ok"`. |
+| `notificationStatus` | string | The durable occurrence status after the operation. |
+| `changed` | boolean | Whether the occurrence changed from active to dismissed. |
+| `notification` | object | The compatibility notification projection. |
+
 ### `hydra notify clear --json`
 
 Returns:
@@ -366,6 +397,8 @@ Notify commands:
 | `notify create` | Create a structured local notification. Supports `--session`, `--from`, `--kind`, `--title`, `--body`, `--dedupe-key`, `--action`, and context flags. |
 | `notify list` | List structured notifications. Supports `--session`, `--target`, `--from`, `--kind`, `--unread`, and `--limit`. |
 | `notify read <id>` | Mark one notification read. |
+| `notify resolve <id>` | Resolve one occurrence with a required lifecycle reason; does not directly mutate runtime. |
+| `notify dismiss <id>` | Dismiss one occurrence without changing runtime. |
 | `notify clear` | Clear all notifications, or a narrowed session/source/target/kind subset. |
 | `notify open <id>` | Mark one notification read and return its suggested action. |
 
@@ -406,6 +439,8 @@ the expected text without tmux, git, VS Code, or a populated `~/.hydra`.
 - `hydra notify create --help` -> `Usage: hydra notify create [options]`
 - `hydra notify list --help` -> `Usage: hydra notify list [options]`
 - `hydra notify read --help` -> `Usage: hydra notify read [options] <id>`
+- `hydra notify resolve --help` -> `Usage: hydra notify resolve [options] <id>`
+- `hydra notify dismiss --help` -> `Usage: hydra notify dismiss [options] <id>`
 - `hydra notify clear --help` -> `Usage: hydra notify clear [options]`
 - `hydra notify open --help` -> `Usage: hydra notify open [options] <id>`
 <!-- cli-contract-help-probes:end -->

--- a/packages/cli/src/cli/commands/notify.ts
+++ b/packages/cli/src/cli/commands/notify.ts
@@ -43,6 +43,10 @@ interface NotifyClearOptions {
   kind?: string;
 }
 
+interface NotifyResolveOptions {
+  reason: string;
+}
+
 export function registerNotifyCommands(program: Command): void {
   const notify = program
     .command('notify')
@@ -183,6 +187,59 @@ export function registerNotifyCommands(program: Command): void {
           globalOpts,
           () => {
             console.log(`Marked read: ${result.notification.id}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  notify
+    .command('resolve <id>')
+    .description('Resolve an active Hydra notification occurrence')
+    .requiredOption('--reason <text>', 'Lifecycle reason for resolving the notification')
+    .action((id: string, opts: NotifyResolveOptions) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const result = new NotificationStore().resolve(id, opts.reason, 'cli');
+        outputResult(
+          {
+            status: 'ok',
+            notificationStatus: result.status,
+            changed: result.changed,
+            notification: result.notification,
+          },
+          globalOpts,
+          () => {
+            console.log(result.changed
+              ? `Resolved notification: ${result.notification.id}`
+              : `Notification ${result.notification.id} is already ${result.status}`);
+          },
+        );
+      } catch (error) {
+        outputError(error, globalOpts);
+      }
+    });
+
+  notify
+    .command('dismiss <id>')
+    .description('Dismiss a Hydra notification without changing worker runtime')
+    .action((id: string) => {
+      const globalOpts = program.opts() as OutputOpts;
+      try {
+        const result = new NotificationStore().dismiss(id, 'cli');
+        outputResult(
+          {
+            status: 'ok',
+            notificationStatus: result.status,
+            changed: result.changed,
+            notification: result.notification,
+          },
+          globalOpts,
+          () => {
+            console.log(result.changed
+              ? `Dismissed notification: ${result.notification.id}`
+              : `Notification ${result.notification.id} is already ${result.status}`);
           },
         );
       } catch (error) {

--- a/packages/cli/src/smoke/cliContractSmoke.ts
+++ b/packages/cli/src/smoke/cliContractSmoke.ts
@@ -129,6 +129,8 @@ function assertHelpProbes(baseEnv: Record<string, string | undefined>): void {
     { args: ['notify', 'create', '--help'], expected: 'Usage: hydra notify create [options]' },
     { args: ['notify', 'list', '--help'], expected: 'Usage: hydra notify list [options]' },
     { args: ['notify', 'read', '--help'], expected: 'Usage: hydra notify read [options] <id>' },
+    { args: ['notify', 'resolve', '--help'], expected: 'Usage: hydra notify resolve [options] <id>' },
+    { args: ['notify', 'dismiss', '--help'], expected: 'Usage: hydra notify dismiss [options] <id>' },
     { args: ['notify', 'clear', '--help'], expected: 'Usage: hydra notify clear [options]' },
     { args: ['notify', 'open', '--help'], expected: 'Usage: hydra notify open [options] <id>' },
   ];

--- a/packages/cli/src/smoke/notificationStateServiceSmoke.ts
+++ b/packages/cli/src/smoke/notificationStateServiceSmoke.ts
@@ -10,7 +10,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { EXIT_OK } from '../cli/output';
-import { resolveSessionNotificationClearScope } from '@hydra/core/notificationScope';
+import { resolveSessionNotificationScope } from '@hydra/core/notificationScope';
 import { EventLog } from '@hydra/core/events';
 import { NotificationStateService } from '@hydra/core/notificationStateService';
 import {
@@ -333,7 +333,7 @@ async function testWorkerClearScopeClearsSourceNotifications(): Promise<void> {
         assert.equal(service.getLatestSourceAttention('repo_worker')?.id, completed.id);
         assert.equal(service.getLatestSourceCompletion('repo_worker')?.id, completed.id);
 
-        const workerScope = resolveSessionNotificationClearScope({ contextValue: 'taskWorkerItem' }, 'repo_worker');
+        const workerScope = resolveSessionNotificationScope({ contextValue: 'taskWorkerItem' }, 'repo_worker');
         assert.deepEqual(workerScope.filters, { session: 'repo_worker' });
         assert.equal(service.getBySession('repo_worker').length, 2);
         assert.equal(service.clear({ ...workerScope.filters, kind: 'complete' }).cleared, 1);
@@ -342,8 +342,76 @@ async function testWorkerClearScopeClearsSourceNotifications(): Promise<void> {
         assert.equal(service.getLatestSourceAttention('repo_worker')?.id, needsInput.id);
         assert.equal(service.getLatestSourceCompletion('repo_worker'), undefined);
 
-        const copilotScope = resolveSessionNotificationClearScope({ contextValue: 'copilotItem' }, 'repo_copilot');
+        const copilotScope = resolveSessionNotificationScope({ contextValue: 'copilotItem' }, 'repo_copilot');
         assert.deepEqual(copilotScope.filters, { targetSession: 'repo_copilot' });
+      } finally {
+        service.dispose();
+      }
+    });
+  } finally {
+    fs.rmSync(ctx.tmp, { recursive: true, force: true });
+  }
+}
+
+async function testWorkerAndCopilotScopesConvergeForReadResolveAndDismiss(): Promise<void> {
+  const ctx = setupContext('hydra-notification-state-scope-ops-');
+  try {
+    await withProcessEnv(ctx, async () => {
+      const store = new NotificationStore();
+      const workerOutbound = store.create({
+        kind: 'needs-input',
+        title: 'Worker needs input',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_worker',
+        context: { workerId: 7 },
+      }).notification;
+      const workerInbound = store.create({
+        kind: 'info',
+        title: 'Copilot instruction',
+        targetSession: 'repo_worker',
+        sourceSession: 'repo_copilot',
+      }).notification;
+      const otherWorker = store.create({
+        kind: 'error',
+        title: 'Other worker error',
+        targetSession: 'repo_copilot',
+        sourceSession: 'repo_other',
+        context: { workerId: 8 },
+      }).notification;
+
+      const service = createService();
+      try {
+        service.initialize();
+        const workerScope = resolveSessionNotificationScope({ contextValue: 'workerItem' }, 'repo_worker');
+        assert.deepEqual(workerScope.filters, { session: 'repo_worker' });
+        assert.deepEqual(
+          service.getBySession('repo_worker').map(notification => notification.id).sort(),
+          [workerOutbound.id, workerInbound.id].sort(),
+        );
+        assert.equal(service.markMatchingRead(workerScope.filters).markedRead, 2);
+        assert.notEqual(service.getById(workerOutbound.id)?.readAt, null);
+        assert.notEqual(service.getById(workerInbound.id)?.readAt, null);
+        assert.equal(service.getById(otherWorker.id)?.readAt, null, 'worker scope must not read a sibling worker');
+
+        const dismissed = service.dismiss(workerOutbound.id);
+        assert.equal(dismissed.changed, true);
+        assert.equal(dismissed.status, 'dismissed');
+        assert.equal(service.getById(workerOutbound.id), undefined);
+
+        const copilotScope = resolveSessionNotificationScope({ contextValue: 'copilotItem' }, 'repo_copilot');
+        assert.deepEqual(copilotScope.filters, { targetSession: 'repo_copilot' });
+        assert.equal(service.markMatchingRead(copilotScope.filters).markedRead, 1);
+        assert.notEqual(service.getById(otherWorker.id)?.readAt, null);
+
+        const resolved = service.resolve(otherWorker.id, 'worker recovered');
+        assert.equal(resolved.changed, true);
+        assert.equal(resolved.status, 'resolved');
+        assert.equal(service.getById(otherWorker.id), undefined);
+        assert.equal(service.getById(workerInbound.id)?.id, workerInbound.id);
+
+        const events = readEventLines(ctx);
+        assert.ok(events.some(event => event.type === 'notify.dismissed' && event.source === 'extension'));
+        assert.ok(events.some(event => event.type === 'notify.resolved' && event.source === 'extension'));
       } finally {
         service.dispose();
       }
@@ -919,6 +987,7 @@ async function main(): Promise<void> {
   await testInitialLoadAndIndexes();
   await testServiceOperationsReloadSynchronously();
   await testTargetSessionOperationsIgnoreSourceOnlyNotifications();
+  await testWorkerAndCopilotScopesConvergeForReadResolveAndDismiss();
   await testMonotonicCreationOrderingAcrossBurstAndClockRollback();
   await testWorkerClearScopeClearsSourceNotifications();
   await testWatcherUpdatesFromNotificationFileOnly();

--- a/packages/cli/src/smoke/notifyCliSmoke.ts
+++ b/packages/cli/src/smoke/notifyCliSmoke.ts
@@ -216,12 +216,68 @@ function main(): void {
     assert.equal(info.status, 'created');
     assert.equal(info.notification.kind, 'info');
 
-    const cleared = parseStdoutJson<{ status: string; cleared: number }>(
-      runCli(['notify', 'clear', '--session', 'repo_worker', '--kind', 'complete', '--json'], ctx.env),
-      'hydra notify clear --kind complete --json',
+    const dismissed = parseStdoutJson<{
+      status: string;
+      notificationStatus: string;
+      changed: boolean;
+      notification: { id: string };
+    }>(
+      runCli(['notify', 'dismiss', created.notification.id, '--json'], ctx.env),
+      'hydra notify dismiss --json',
     );
-    assert.equal(cleared.status, 'ok');
-    assert.equal(cleared.cleared, 1);
+    assert.equal(dismissed.status, 'ok');
+    assert.equal(dismissed.notificationStatus, 'dismissed');
+    assert.equal(dismissed.changed, true);
+    assert.equal(dismissed.notification.id, created.notification.id);
+
+    const dismissedAgain = parseStdoutJson<typeof dismissed>(
+      runCli(['notify', 'dismiss', created.notification.id, '--json'], ctx.env),
+      'hydra notify dismiss idempotent --json',
+    );
+    assert.equal(dismissedAgain.notificationStatus, 'dismissed');
+    assert.equal(dismissedAgain.changed, false);
+
+    const needsInput = parseStdoutJson<typeof created>(
+      runCli([
+        'notify',
+        'create',
+        '--session',
+        'repo_copilot',
+        '--from',
+        'repo_worker',
+        '--kind',
+        'needs-input',
+        '--title',
+        'Worker needs input',
+        '--dedupe-key',
+        'needs-input:repo_worker:def',
+        '--worker-id',
+        '7',
+        '--json',
+      ], ctx.env),
+      'hydra notify create needs-input --json',
+    );
+
+    const resolved = parseStdoutJson<{
+      status: string;
+      notificationStatus: string;
+      changed: boolean;
+      notification: { id: string };
+    }>(
+      runCli(['notify', 'resolve', needsInput.notification.id, '--reason', 'worker answered', '--json'], ctx.env),
+      'hydra notify resolve --json',
+    );
+    assert.equal(resolved.status, 'ok');
+    assert.equal(resolved.notificationStatus, 'resolved');
+    assert.equal(resolved.changed, true);
+    assert.equal(resolved.notification.id, needsInput.notification.id);
+
+    const resolvedAgain = parseStdoutJson<typeof resolved>(
+      runCli(['notify', 'resolve', needsInput.notification.id, '--reason', 'duplicate signal', '--json'], ctx.env),
+      'hydra notify resolve idempotent --json',
+    );
+    assert.equal(resolvedAgain.notificationStatus, 'resolved');
+    assert.equal(resolvedAgain.changed, false);
 
     const remainingList = parseStdoutJson<{
       notifications: Array<{ id: string; kind: string }>;
@@ -243,7 +299,7 @@ function main(): void {
       'hydra notify clear remaining --json',
     );
     assert.equal(clearedRemaining.status, 'ok');
-    assert.equal(clearedRemaining.cleared, 1);
+    assert.equal(clearedRemaining.cleared, 2, 'clear also evicts matching resolved history');
 
     const emptyList = parseStdoutJson<{ notifications: unknown[]; count: number; unreadCount: number; totalCount: number }>(
       runCli(['notify', 'list', '--json'], ctx.env),
@@ -260,10 +316,12 @@ function main(): void {
       'worker.runtime.changed',
       'notify.read',
       'notify.created',
-      'notify.cleared',
+      'notify.dismissed',
+      'notify.created',
+      'notify.resolved',
       'notify.cleared',
     ]);
-    assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4, 5, 6]);
+    assert.deepEqual(events.map(event => event.seq), [1, 2, 3, 4, 5, 6, 7, 8]);
     assert.equal(fs.readFileSync(eventsPath, 'utf-8').includes('Branch: feat/auth'), false);
 
     console.log('notifyCliSmoke: ok');

--- a/packages/core/src/core/notificationScope.ts
+++ b/packages/core/src/core/notificationScope.ts
@@ -4,10 +4,13 @@ export interface SessionNotificationScopeItem {
   contextValue?: string;
 }
 
-export interface SessionNotificationClearScope {
+export interface SessionNotificationScope {
   filters: Pick<NotificationListFilters, 'session' | 'targetSession' | 'sourceSession'>;
   lookup: 'session' | 'targetSession';
 }
+
+/** @deprecated Use SessionNotificationScope for all notification operations. */
+export type SessionNotificationClearScope = SessionNotificationScope;
 
 const WORKER_CONTEXT_VALUES = new Set([
   'workerItem',
@@ -16,10 +19,10 @@ const WORKER_CONTEXT_VALUES = new Set([
   'inactiveTaskWorkerItem',
 ]);
 
-export function resolveSessionNotificationClearScope(
+export function resolveSessionNotificationScope(
   item: SessionNotificationScopeItem | undefined,
   sessionName: string,
-): SessionNotificationClearScope {
+): SessionNotificationScope {
   if (item?.contextValue && WORKER_CONTEXT_VALUES.has(item.contextValue)) {
     return {
       filters: { session: sessionName },
@@ -32,3 +35,6 @@ export function resolveSessionNotificationClearScope(
     lookup: 'targetSession',
   };
 }
+
+/** @deprecated Use resolveSessionNotificationScope for all notification operations. */
+export const resolveSessionNotificationClearScope = resolveSessionNotificationScope;

--- a/packages/core/src/core/notificationStateService.ts
+++ b/packages/core/src/core/notificationStateService.ts
@@ -12,10 +12,12 @@ import {
   type HydraNotification,
   type NotificationKind,
   type NotificationClearFilters,
+  type NotificationReadFilters,
   type NotificationMarkSessionReadResult,
   type NotificationClearResult,
   type NotificationOpenResult,
   type NotificationReadResult,
+  type NotificationStatusMutationResult,
 } from './notifications';
 import {
   buildNotificationState,
@@ -183,25 +185,20 @@ export class NotificationStateService implements Disposable {
   }
 
   markSessionRead(sessionName: string, eventSource: HydraEventSource = 'extension'): NotificationMarkSessionReadResult {
-    const result = this.store.markSessionRead(sessionName, eventSource);
-    this.reloadNow({ emit: true, reason: 'mark-session-read' });
+    return this.markMatchingRead({ session: sessionName }, eventSource);
+  }
+
+  markMatchingRead(
+    filters: NotificationReadFilters,
+    eventSource: HydraEventSource = 'extension',
+  ): NotificationMarkSessionReadResult {
+    const result = this.store.markMatchingRead(filters, eventSource);
+    this.reloadNow({ emit: true, reason: 'mark-matching-read' });
     return result;
   }
 
   markTargetSessionRead(sessionName: string, eventSource: HydraEventSource = 'extension'): NotificationMarkSessionReadResult {
-    const unread = this.store.list({ targetSession: sessionName, unread: true }).notifications;
-    const notifications: HydraNotification[] = [];
-    for (const notification of unread) {
-      const result = this.store.markRead(notification.id, eventSource);
-      if (result.markedRead > 0) {
-        notifications.push(result.notification);
-      }
-    }
-    this.reloadNow({ emit: true, reason: 'mark-target-session-read' });
-    return {
-      notifications,
-      markedRead: notifications.length,
-    };
+    return this.markMatchingRead({ targetSession: sessionName }, eventSource);
   }
 
   clear(
@@ -216,6 +213,22 @@ export class NotificationStateService implements Disposable {
   open(id: string, eventSource: HydraEventSource = 'extension'): NotificationOpenResult {
     const result = this.store.open(id, eventSource);
     this.reloadNow({ emit: true, reason: 'open' });
+    return result;
+  }
+
+  resolve(
+    id: string,
+    reason: string,
+    eventSource: HydraEventSource = 'extension',
+  ): NotificationStatusMutationResult {
+    const result = this.store.resolve(id, reason, eventSource);
+    this.reloadNow({ emit: true, reason: 'resolve' });
+    return result;
+  }
+
+  dismiss(id: string, eventSource: HydraEventSource = 'extension'): NotificationStatusMutationResult {
+    const result = this.store.dismiss(id, eventSource);
+    this.reloadNow({ emit: true, reason: 'dismiss' });
     return result;
   }
 

--- a/packages/core/src/core/notifications.ts
+++ b/packages/core/src/core/notifications.ts
@@ -88,6 +88,8 @@ export type NotificationClearFilters = Pick<
   'session' | 'targetSession' | 'sourceSession' | 'kind'
 >;
 
+export type NotificationReadFilters = NotificationClearFilters;
+
 export interface NotificationReadResult {
   notification: HydraNotification;
   markedRead: number;
@@ -284,12 +286,19 @@ export class NotificationStore {
   }
 
   markSessionRead(sessionName: string, eventSource: HydraEventSource = 'cli'): NotificationMarkSessionReadResult {
+    return this.markMatchingRead({ session: sessionName }, eventSource);
+  }
+
+  markMatchingRead(
+    filters: NotificationReadFilters,
+    eventSource: HydraEventSource = 'cli',
+  ): NotificationMarkSessionReadResult {
     return this.withLock(() => {
       const store = this.readStore();
       this.reconcileCompatibility(store);
       const readAt = new Date(this.now()).toISOString();
       const updatedById = new Map<string, HydraNotification>();
-      const updatedOccurrences = this.v2Store.markMatchingRead({ session: sessionName }, readAt);
+      const updatedOccurrences = this.v2Store.markMatchingRead(filters, readAt);
       for (const occurrence of updatedOccurrences) {
         const existing = store.notifications.find(notification => notification.id === occurrence.id);
         updatedById.set(occurrence.id, toLegacyNotification(occurrence, existing));
@@ -298,7 +307,7 @@ export class NotificationStore {
       store.notifications = store.notifications.map(notification => {
         if (
           notification.readAt !== null ||
-          (notification.targetSession !== sessionName && notification.sourceSession !== sessionName)
+          !matchesFilters(notification, filters)
         ) {
           return notification;
         }
@@ -370,7 +379,9 @@ export class NotificationStore {
     reason: string,
     eventSource: HydraEventSource = 'session-manager',
   ): NotificationStatusMutationResult {
-    return this.changeStatus(id, 'resolved', reason, eventSource);
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) throw new Error('Notification resolve reason is required');
+    return this.changeStatus(id, 'resolved', truncate(normalizedReason, MAX_TITLE_LENGTH), eventSource);
   }
 
   dismiss(

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -182,6 +182,10 @@
         "title": "Hydra: Mark Notifications Read"
       },
       {
+        "command": "hydra.dismissSessionNotification",
+        "title": "Hydra: Dismiss Notification"
+      },
+      {
         "command": "hydra.clearSessionNotifications",
         "title": "Hydra: Clear Notifications"
       },
@@ -351,9 +355,14 @@
           "group": "5_notifications@1"
         },
         {
+          "command": "hydra.dismissSessionNotification",
+          "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem' || viewItem == 'notificationDetailItem')",
+          "group": "5_notifications@2"
+        },
+        {
           "command": "hydra.clearSessionNotifications",
           "when": "(view == hydraCopilots || view == hydraWorkers) && (viewItem == 'workerItem' || viewItem == 'inactiveWorkerItem' || viewItem == 'taskWorkerItem' || viewItem == 'inactiveTaskWorkerItem' || viewItem == 'copilotItem')",
-          "group": "5_notifications@2"
+          "group": "5_notifications@3"
         },
         {
           "command": "tmux.copyPath",
@@ -385,6 +394,10 @@
     "onCommand:tmux.pasteImage",
     "onCommand:tmux.createWorktreeFromBranch",
     "onCommand:hydra.openPR",
+    "onCommand:hydra.openSessionNotification",
+    "onCommand:hydra.markSessionNotificationsRead",
+    "onCommand:hydra.dismissSessionNotification",
+    "onCommand:hydra.clearSessionNotifications",
     "onCommand:hydra.createCopilot",
     "onCommand:hydra.startPlanCopilot",
     "onCommand:hydra.startCopilotClaude",

--- a/packages/extension/src/commands/notificationTreeCommands.ts
+++ b/packages/extension/src/commands/notificationTreeCommands.ts
@@ -2,13 +2,17 @@ import * as vscode from 'vscode';
 import { NotificationStateService } from '@hydra/core/notificationStateService';
 import { buildSessionNotificationSummary } from '@hydra/core/sessionNotificationSummary';
 import { TmuxItem } from '../providers/tmuxSessionProvider';
-import { resolveSessionNotificationClearScope } from '@hydra/core/notificationScope';
+import {
+  resolveSessionNotificationScope,
+  type SessionNotificationScope,
+} from '@hydra/core/notificationScope';
 import { resolveSessionName } from './treeItemResolver';
 import { openHydraSessionByName, reviewHydraSessionByName } from './openHydraSession';
 
 export interface NotificationTreeCommands {
   openSessionNotification(item?: TmuxItem): Promise<void>;
   markSessionNotificationsRead(item?: TmuxItem): Promise<void>;
+  dismissSessionNotification(item?: TmuxItem): Promise<void>;
   clearSessionNotifications(item?: TmuxItem): Promise<void>;
 }
 
@@ -17,6 +21,16 @@ function getNotificationId(item?: TmuxItem): string | undefined {
   return typeof candidate?.notificationId === 'string' && candidate.notificationId
     ? candidate.notificationId
     : undefined;
+}
+
+function getNotificationsForScope(
+  notificationState: NotificationStateService,
+  scope: SessionNotificationScope,
+  sessionName: string,
+) {
+  return scope.lookup === 'session'
+    ? notificationState.getBySession(sessionName)
+    : notificationState.getByTargetSession(sessionName);
 }
 
 export function createNotificationTreeCommands(
@@ -31,10 +45,14 @@ export function createNotificationTreeCommands(
           return;
         }
 
+        const scope = resolveSessionNotificationScope(item, sessionName);
         const notificationId = getNotificationId(item);
         let targetNotificationId = notificationId;
         if (!targetNotificationId) {
-          const summary = buildSessionNotificationSummary(sessionName, notificationState.getByTargetSession(sessionName));
+          const summary = buildSessionNotificationSummary(
+            sessionName,
+            getNotificationsForScope(notificationState, scope, sessionName),
+          );
           if (!summary) {
             vscode.window.showInformationMessage(`No unread notifications for ${sessionName}`);
             return;
@@ -69,7 +87,8 @@ export function createNotificationTreeCommands(
           return;
         }
 
-        const result = notificationState.markTargetSessionRead(sessionName, 'extension');
+        const scope = resolveSessionNotificationScope(item, sessionName);
+        const result = notificationState.markMatchingRead(scope.filters, 'extension');
         vscode.window.showInformationMessage(
           result.markedRead === 0
             ? `No unread notifications for ${sessionName}`
@@ -77,6 +96,35 @@ export function createNotificationTreeCommands(
         );
       } catch (error) {
         vscode.window.showErrorMessage(`Failed to mark notifications read: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+
+    async dismissSessionNotification(item?: TmuxItem): Promise<void> {
+      try {
+        const sessionName = resolveSessionName(item);
+        if (!sessionName) {
+          vscode.window.showErrorMessage('No session selected');
+          return;
+        }
+
+        const scope = resolveSessionNotificationScope(item, sessionName);
+        const notificationId = getNotificationId(item) ?? buildSessionNotificationSummary(
+          sessionName,
+          getNotificationsForScope(notificationState, scope, sessionName),
+        )?.attention.id;
+        if (!notificationId) {
+          vscode.window.showInformationMessage(`No active notifications for ${sessionName}`);
+          return;
+        }
+
+        const result = notificationState.dismiss(notificationId, 'extension');
+        vscode.window.showInformationMessage(
+          result.changed
+            ? `Dismissed notification: ${result.notification.title}`
+            : `Notification already ${result.status}: ${result.notification.title}`,
+        );
+      } catch (error) {
+        vscode.window.showErrorMessage(`Failed to dismiss notification: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
 
@@ -88,7 +136,7 @@ export function createNotificationTreeCommands(
           return;
         }
 
-        const clearScope = resolveSessionNotificationClearScope(item, sessionName);
+        const clearScope = resolveSessionNotificationScope(item, sessionName);
         const count = clearScope.lookup === 'session'
           ? notificationState.getBySession(sessionName).length
           : notificationState.getByTargetSession(sessionName).length;

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -168,6 +168,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('tmux.newWindow', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], newWindow, ...args)),
     vscode.commands.registerCommand('hydra.openSessionNotification', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.openSessionNotification, ...args)),
     vscode.commands.registerCommand('hydra.markSessionNotificationsRead', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.markSessionNotificationsRead, ...args)),
+    vscode.commands.registerCommand('hydra.dismissSessionNotification', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.dismissSessionNotification, ...args)),
     vscode.commands.registerCommand('hydra.clearSessionNotifications', async (...args: unknown[]) => runWithHydraItem(['worker', 'copilot'], notificationCommands.clearSessionNotifications, ...args)),
     vscode.commands.registerCommand('tmux.terminalPaste', terminalSmartPaste),
     vscode.commands.registerCommand('tmux.pasteImage', pasteImageForce),


### PR DESCRIPTION
## Summary

- use one worker-versus-copilot notification scope for VS Code open, read, dismiss, and clear actions
- add idempotent CLI notify resolve and notify dismiss commands with explicit runtime-neutral semantics
- expose shared read, resolve, and dismiss operations through NotificationStateService
- cover worker source/target scope, copilot target-only scope, event sources, and CLI contract behavior

## Scope decisions

Worker create, start, send, stop, delete, rename, and restore already converge through WorkerLifecycleService from PR7; this PR preserves that shared path instead of duplicating lifecycle orchestration. Resolve remains primarily lifecycle-owned and the direct CLI command does not mutate runtime. VS Code exposes read and dismiss, while clear remains a distinct tombstone operation.

Implements PR10D from docs/worker-attention-control-plane-plan.md, especially frozen decisions 8, 9, and 13 plus sections 7.2 and 11 Wave 4.

## Validation

- npm run compile
- npm run lint
- npm run smoke:notification-v2
- npm run smoke:notification-state
- npm run smoke:notify-cli
- npm run smoke:worker-runtime-state
- npm run smoke:session-notification-summary
- npm run smoke:cli-contract
- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test
- git diff --check