### PR TITLE
test(e2e): tolerate delayed compatibility delivery

### DIFF
--- a/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
+++ b/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
@@ -307,7 +307,7 @@ async function main(): Promise<void> {
     await pollUntil(() => {
       const currentLog = fs.readFileSync(fakeAgentLog, 'utf-8');
       return currentLog.includes(`INPUT cwd=${repoRoot} hydra_copilot_session=${COPILOT_B} line=Worker #`);
-    }, 10_000, 'completion notification delivered to copilot B');
+    }, 30_000, 'completion notification delivered to copilot B');
 
     const finalLog = fs.readFileSync(fakeAgentLog, 'utf-8');
     assert.equal(


### PR DESCRIPTION
## Summary

Increase the compatibility-delivery assertion window from 10s to 30s in `copilotEnvE2eSmoke`.

The durable completion job and notification occurrence were already persisted correctly; only the best-effort tmux delivery to the fake copilot occasionally exceeded 10 seconds under load.

## Validation

- focused smoke passed 3 consecutive runs
- `npm run lint`
- `git diff --check`
- `env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test`