### PR TITLE
test(e2e): tolerate delayed compatibility delivery

### DIFF
--- a/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
+++ b/packages/cli/src/smoke/copilotEnvE2eSmoke.ts
@@ -307,7 +307,7 @@ async function main(): Promise<void> {
     await pollUntil(() => {
       const currentLog = fs.readFileSync(fakeAgentLog, 'utf-8');
       return currentLog.includes(`INPUT cwd=${repoRoot} hydra_copilot_session=${COPILOT_B} line=Worker #`);
-    }, 10_000, 'completion notification delivered to copilot B');
+    }, 30_000, 'completion notification delivered to copilot B');
 
     const finalLog = fs.readFileSync(fakeAgentLog, 'utf-8');
     assert.equal(


### PR DESCRIPTION
## Summary
- increase the Copilot compatibility-delivery smoke assertion window from 10s to 30s
- keep durable completion-job and notification behavior unchanged
- eliminate the observed timing flake after the Worker Attention Control Plane promotion

## Validation
- focused smoke passed 3 consecutive runs
- npm run lint
- git diff --check
- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test

## Scope
Test-only, one-line timeout adjustment.