### PR TITLE
fix(desktop): keep row menus above sidebar items

### DIFF
--- a/packages/desktop/scripts/supportingFlowsSmoke.mjs
+++ b/packages/desktop/scripts/supportingFlowsSmoke.mjs
@@ -90,6 +90,13 @@ for (const name of ['tokens', 'base', 'shell', 'sidebar', 'workspace', 'context'
   assert.equal(fs.existsSync(path.join(renderer, 'styles', `${name}.css`)), true, `${name}.css exists`);
 }
 
+const sidebarCss = fs.readFileSync(path.join(renderer, 'styles', 'sidebar.css'), 'utf8');
+assert.match(
+  sidebarCss,
+  /\.hydra-row__menu\.hydra-menu--open\s*\{[^}]*z-index:\s*[1-9]\d*;/s,
+  'an open row menu raises its transformed stacking context above following tree rows',
+);
+
 const desktopPackage = JSON.parse(fs.readFileSync(path.join(desktop, 'package.json'), 'utf8'));
 assert.equal(typeof desktopPackage.dependencies['lucide-react'], 'string', 'coherent icon dependency declared');
 

--- a/packages/desktop/src/renderer/styles/sidebar.css
+++ b/packages/desktop/src/renderer/styles/sidebar.css
@@ -316,6 +316,10 @@
   transform: translateY(-50%);
 }
 
+.hydra-row__menu.hydra-menu--open {
+  z-index: 1;
+}
+
 .hydra-row:hover > .hydra-sdot,
 .hydra-row:focus-within > .hydra-sdot {
   opacity: 0;


### PR DESCRIPTION
## Summary

- raise the open row menu stacking context above later sidebar rows
- add a desktop supporting-flow regression assertion for the stacking contract

## Validation

- npm run compile
- npm run lint
- npm run desktop:build
- npm run smoke:desktop-supporting
- npm run desktop:boot-check
- git diff --check
- headed Chromium visual comparison using the bundled renderer CSS