### PR TITLE
chore: release v0.3.2026071500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.2026071500] - 2026-07-15
+
+### Added
+- Introduce the Hydra Desktop beta with a terminal-first workspace, multi-session navigation, worker creation, attention inbox, diff review, and polished supporting flows
+- Add signed and Apple-notarized macOS distribution for Apple Silicon through verified DMG and ZIP artifacts
+- Add durable worker runtime v2 coordination, lifecycle identity, completion jobs, events, and notification occurrences shared across CLI, VS Code, and Desktop
+
+### Changed
+- Unify worker lifecycle and notification actions across Hydra surfaces and improve Desktop terminal responsiveness, sidebar density, and session creation
+- Govern monorepo version consistency, release packaging, and compatibility validation with fail-closed smoke coverage
+
+### Fixed
+- Harden archive concurrency, diff and tmux ownership safety, packaged-app PATH handling, terminal environment isolation, Unicode rendering, link opening, scrollback, and stale runtime cleanup
+
 ## [0.3.2026062800] - 2026-06-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-monorepo",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -6229,7 +6229,7 @@
     },
     "packages/cli": {
       "name": "@hydra/cli",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6241,7 +6241,7 @@
     },
     "packages/core": {
       "name": "@hydra/core",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.2",
@@ -6250,7 +6250,7 @@
     },
     "packages/desktop": {
       "name": "@hydra/desktop",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/protocol": "*",
@@ -6277,7 +6277,7 @@
     },
     "packages/extension": {
       "name": "hydra-code",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6297,7 +6297,7 @@
     },
     "packages/protocol": {
       "name": "@hydra/protocol",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*"
@@ -6305,7 +6305,7 @@
     },
     "packages/sidecar": {
       "name": "@hydra/sidecar",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6317,7 +6317,7 @@
     },
     "packages/transport-loopback": {
       "name": "@hydra/transport-loopback",
-      "version": "0.3.2026062800",
+      "version": "0.3.2026071500",
       "license": "MIT",
       "dependencies": {
         "@hydra/protocol": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra monorepo — @hydra/core engine, @hydra/cli, and the hydra-code VS Code extension",
   "license": "MIT",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/cli",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra CLI — the `hydra` command (depends on @hydra/core)",
   "license": "MIT",
   "private": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/core",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra headless engine — worker lifecycle, tmux/git, sessions, telemetry (vscode-free)",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/desktop",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra desktop — Electron shell (M1). Main forks the plain-Node sidecar, mints a per-launch bearer token, and hands { url, token } to a React renderer that talks to the sidecar over LoopbackHttpWsTransport.",
   "license": "MIT",
   "private": true,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/protocol",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra control-plane seam — HydraControlClient over a swappable HydraTransport (engine-free, transport-agnostic)",
   "license": "MIT",
   "private": true,

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/sidecar",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra sidecar — the server side of the seam. HydraAppService imports @hydra/core in-process (loopback HTTP/WS server lands in M1).",
   "license": "MIT",
   "private": true,

--- a/packages/transport-loopback/package.json
+++ b/packages/transport-loopback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/transport-loopback",
-  "version": "0.3.2026062800",
+  "version": "0.3.2026071500",
   "description": "Hydra loopback transport — LoopbackHttpWsTransport (renderer → sidecar over 127.0.0.1 HTTP/WS) + the shared loopback wire vocabulary. Engine-free: depends only on @hydra/protocol types and global fetch/WebSocket.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Release v0.3.2026071500

This release introduces the Hydra Desktop public beta, Apple Silicon Developer ID distribution, runtime and notification v2 foundations, and the desktop terminal-first experience.

Validation:
- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test
- npm run lint
- git diff --check