### PR TITLE
fix(desktop): clarify worker completion status

### DIFF
--- a/packages/desktop/scripts/desktopControlStateSmoke.mjs
+++ b/packages/desktop/scripts/desktopControlStateSmoke.mjs
@@ -14,6 +14,7 @@ const bundled = await build({
   stdin: {
     contents: `
       export * from './controlState/index.ts';
+      export * from './status.ts';
     `,
     resolveDir: renderer,
     sourcefile: 'desktop-control-state-smoke-entry.ts',
@@ -38,6 +39,7 @@ const {
   applyNotificationOccurrenceSnapshot,
   applyRuntimeSnapshot,
   applySessionsSnapshot,
+  controlRowStatus,
   selectCopilotContext,
   selectDesktopControlView,
   selectSessionHeader,
@@ -205,6 +207,8 @@ assert.equal(view.workerGroups[0].label, 'repo-a');
 assert.equal(view.copilots[0].workerCount, 2);
 assert.equal(view.copilots[0].repoCount, 1);
 assert.equal(view.workers[0].runtimeState, 'running');
+assert.equal(controlRowStatus(view.workers[0]), 'running');
+assert.equal(controlRowStatus(view.workers[1]), 'idle');
 
 const divergentSessions = {
   ...sessions,
@@ -278,9 +282,20 @@ assert.equal(selectDesktopControlView(model).workers[0].runtimeState, 'needs-inp
 model = applyRuntimeSnapshot(model, {
   ...runtimeList,
   lastEventSeq: 20,
-  runtimes: [runtime(1, { revision: 4, state: 'idle', observedAt: '2026-07-11T01:00:20.000Z' }), runtime(2)],
+  runtimes: [
+    runtime(1, {
+      revision: 4,
+      state: 'idle',
+      reason: 'complete',
+      observedAt: '2026-07-11T01:00:20.000Z',
+    }),
+    runtime(2),
+  ],
 });
-assert.equal(selectDesktopControlView(model).workers[0].runtimeState, 'idle');
+const completedWorker = selectDesktopControlView(model).workers[0];
+assert.equal(completedWorker.runtimeState, 'idle');
+assert.equal(completedWorker.runtimeReason, 'complete');
+assert.equal(controlRowStatus(completedWorker), 'idle', 'completion is not shown before its unread notification arrives');
 assert.equal(model.lastEventSeq, 16, 'runtime refresh cursor does not advance the applied event cursor');
 model = applyRuntimeSnapshot(model, {
   ...runtimeList,
@@ -322,6 +337,8 @@ assert.equal(result.sessionRefreshRequired, true, 'event at the notification cur
 model = result.model;
 view = selectDesktopControlView(model);
 assert.deepEqual(view.attention.map(row => row.occurrence.kind), ['error', 'needs-input', 'complete']);
+assert.equal(view.workers[0].completed, true);
+assert.equal(controlRowStatus(view.workers[0]), 'completed');
 assert.equal(view.unreadTotal, 3);
 assert.equal(view.workers[0].unreadCount, 2, 'worker counts join by stable workerId');
 assert.equal(view.copilots[0].activeAttentionCount, 3, 'copilot aggregates its managed Workers');
@@ -333,10 +350,29 @@ assert.deepEqual(
 assert.equal(selectWorkerContext(model, 1).occurrences.length, 2);
 assert.equal(selectSessionHeader(model, 'repo-a_feat-one').activeAttentionCount, 2);
 
+model = applyNotificationOccurrenceSnapshot(model, {
+  version: 2,
+  loadedAt: '2026-07-11T02:04:30.000Z',
+  lastEventSeq: 23,
+  occurrences: [
+    { ...complete, readAt: '2026-07-11T02:04:30.000Z' },
+    needsInput,
+    error,
+  ],
+  count: 3,
+  totalCount: 3,
+  activeCount: 3,
+  unreadCount: 2,
+});
+view = selectDesktopControlView(model);
+assert.equal(view.workers[0].completed, false);
+assert.equal(controlRowStatus(view.workers[0]), 'idle', 'opening the Worker clears its green completion dot');
+assert.deepEqual(view.attention.map(row => row.occurrence.kind), ['error', 'needs-input']);
+
 const newerEmpty = {
   version: 2,
   loadedAt: '2026-07-11T02:05:00.000Z',
-  lastEventSeq: 23,
+  lastEventSeq: 24,
   occurrences: [],
   count: 0,
   totalCount: 0,
@@ -347,7 +383,7 @@ model = applyNotificationOccurrenceSnapshot(model, newerEmpty);
 assert.equal(selectDesktopControlView(model).attention.length, 0, 'new snapshot removes stale occurrences');
 model = applyNotificationOccurrenceSnapshot(model, {
   ...newerEmpty,
-  lastEventSeq: 22,
+  lastEventSeq: 23,
   occurrences: [error],
   count: 1,
   totalCount: 1,

--- a/packages/desktop/src/renderer/status.ts
+++ b/packages/desktop/src/renderer/status.ts
@@ -2,12 +2,13 @@
 // looks the same wherever it appears. A session's status folds its lifecycle
 // (running / stopped) and — for workers — its live runtime projection into a
 // single glanceable token:
-//   running, idle, stopped, needs-input, error, or unknown.
+//   running, completed, idle, stopped, needs-input, error, or unknown.
 
 import type { SessionControlRow } from './controlState/selectors';
 
 export type SessionStatus =
   | 'running'
+  | 'completed'
   | 'idle'
   | 'stopped'
   | 'needs-input'
@@ -16,6 +17,7 @@ export type SessionStatus =
 
 export const STATUS_LABELS: Record<SessionStatus, string> = {
   running: 'Running',
+  completed: 'Completed',
   idle: 'Idle',
   stopped: 'Stopped',
   'needs-input': 'Needs input',
@@ -31,15 +33,20 @@ export function controlRowStatus(row: SessionControlRow): SessionStatus {
   if (row.kind === 'copilot') {
     return 'running';
   }
+  if (row.runtimeState === 'needs-input') {
+    return 'needs-input';
+  }
+  if (row.runtimeState === 'error') {
+    return 'error';
+  }
+  if (row.completed) {
+    return 'completed';
+  }
   switch (row.runtimeState) {
     case 'running':
       return 'running';
     case 'idle':
       return 'idle';
-    case 'needs-input':
-      return 'needs-input';
-    case 'error':
-      return 'error';
     default:
       return 'unknown';
   }

--- a/packages/desktop/src/renderer/styles/base.css
+++ b/packages/desktop/src/renderer/styles/base.css
@@ -921,7 +921,12 @@ body.hydra-resizing {
   display: inline-block;
   position: relative;
 }
-.hydra-sdot--running { background: var(--hy-run-running); }
+.hydra-sdot--running {
+  background: transparent;
+  border: 1.5px solid color-mix(in srgb, var(--hy-run-idle) 32%, transparent);
+  border-top-color: var(--hy-run-idle);
+}
+.hydra-sdot--completed { background: var(--hy-ok); }
 .hydra-sdot--idle {
   background: transparent;
   border: 1.5px solid var(--hy-run-idle);
@@ -935,32 +940,18 @@ body.hydra-resizing {
 .hydra-sdot--unknown { background: var(--hy-run-unknown); }
 
 /* ── live activity motion ─────────────────────────────────────────────
-   Only genuinely-active states move: running (a worker actively churning,
-   or a live copilot) breathes + emits a soft radar ping; needs-input pulses
-   an amber halo because it's waiting on you. idle/stopped/error stay still
-   so the board doesn't shimmer. Honours the OS reduced-motion setting.
-   The same dot class is used in the sidebar and the tab strip. */
-@keyframes hy-breathe {
-  0%, 100% { transform: scale(1); opacity: 1; }
-  50% { transform: scale(1.22); opacity: 0.65; }
-}
-@keyframes hy-ping {
-  0% { box-shadow: 0 0 0 0 var(--hy-run-running); opacity: 0.45; }
-  100% { box-shadow: 0 0 0 5px var(--hy-run-running); opacity: 0; }
+   Running uses a familiar progress spinner. Completed/idle/stopped/error
+   stay still so the board only moves while work is actually in progress.
+   Honours the OS reduced-motion setting. */
+@keyframes hy-spin {
+  to { transform: rotate(360deg); }
 }
 @keyframes hy-attention {
   0%, 100% { box-shadow: 0 0 0 2px rgba(185, 118, 27, 0.28); }
   50% { box-shadow: 0 0 0 5px rgba(185, 118, 27, 0.0); }
 }
 @media (prefers-reduced-motion: no-preference) {
-  .hydra-sdot--running { animation: hy-breathe 1.6s ease-in-out infinite; }
-  .hydra-sdot--running::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    animation: hy-ping 1.8s ease-out infinite;
-  }
+  .hydra-sdot--running { animation: hy-spin 720ms linear infinite; }
   .hydra-sdot--needs-input { animation: hy-attention 1.1s ease-in-out infinite; }
 }
 
@@ -1426,13 +1417,9 @@ body.hydra-resizing .hydra-resizer::after {
   width: 9px;
   height: 9px;
 }
-.hydra-sdot--running,
 .hydra-sdot--needs-input {
   animation: none;
   box-shadow: none;
-}
-.hydra-sdot--running::after {
-  display: none;
 }
 .hydra-sdot--idle {
   border-width: 1.4px;

--- a/packages/desktop/src/renderer/styles/sidebar.css
+++ b/packages/desktop/src/renderer/styles/sidebar.css
@@ -289,6 +289,12 @@
   margin-right: 2px;
 }
 
+.hydra-row > .hydra-sdot--running {
+  width: 10px;
+  height: 10px;
+  margin-right: 0;
+}
+
 .hydra-tree__disclosure {
   min-height: 25px;
   margin: 0 3px;

--- a/packages/desktop/src/renderer/tabs/TabsProvider.tsx
+++ b/packages/desktop/src/renderer/tabs/TabsProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 
 import { useSessions } from '../sessions/SessionsProvider';
+import { selectTabSession } from './tabSelectors';
 import {
   chooseInitialSession,
   INITIAL_TABS_STATE,
@@ -50,7 +51,7 @@ export interface TabsApi extends TabsState {
 const TabsContext = createContext<TabsApi | null>(null);
 
 export function TabsProvider({ children }: { children: ReactNode }): JSX.Element {
-  const { control } = useSessions();
+  const { control, actions } = useSessions();
   const [state, dispatch] = useReducer(tabsReducer, INITIAL_TABS_STATE);
   const bootstrapped = useRef(false);
 
@@ -92,6 +93,17 @@ export function TabsProvider({ children }: { children: ReactNode }): JSX.Element
       // Local preferences are best effort.
     }
   }, [activeTab]);
+
+  useEffect(() => {
+    if (!activeTab || activeTab.sessionKind !== 'worker') return;
+    const row = selectTabSession(control.view, activeTab);
+    if (!row || row.kind !== 'worker' || !row.completed) return;
+    for (const occurrence of row.occurrences) {
+      if (occurrence.kind === 'complete' && occurrence.readAt === null) {
+        actions.markNotificationRead(occurrence.id);
+      }
+    }
+  }, [activeTab, control.view, actions]);
 
   const openTab = useCallback((
     session: string,


### PR DESCRIPTION
## Summary

- show active workers with a visible rotating progress ring
- show unread completions with a green solid dot
- acknowledge completion when the worker terminal becomes active so the dot returns to idle
- preserve needs-input and error status priority

## Testing

- npm run compile
- npm run desktop:build
- npm run smoke:desktop-control-state
- npm run smoke:desktop-context
- npm run smoke:desktop-supporting
- npm run lint
- git diff --check