### PR TITLE
Improve desktop diff review fidelity

### DIFF
--- a/packages/desktop/src/renderer/diff/DiffStyles.tsx
+++ b/packages/desktop/src/renderer/diff/DiffStyles.tsx
@@ -133,6 +133,7 @@ const DIFF_CSS = `
 .hydra-diff__filehead {
   position: sticky;
   top: 0;
+  z-index: 2;
   display: flex;
   align-items: baseline;
   gap: 0.5rem;
@@ -144,35 +145,76 @@ const DIFF_CSS = `
 }
 .hydra-diff__stat-add { color: #2ea043; font-weight: 600; }
 .hydra-diff__stat-del { color: #cf222e; font-weight: 600; }
+.hydra-diff__side-note {
+  padding: 0.35rem 0.6rem;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.2);
+  background: rgba(80, 140, 255, 0.08);
+  color: rgba(128, 128, 128, 0.95);
+  font-size: 0.75rem;
+}
 .hydra-diff__code {
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
   font-size: 0.8rem;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   border-collapse: collapse;
-  table-layout: fixed;
+  line-height: 1.55;
 }
 .hydra-diff__code td {
   padding: 0 0.5rem;
   vertical-align: top;
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
+}
+.hydra-diff__code--split .hydra-diff__cell {
+  min-width: 28rem;
 }
 .hydra-diff__ln {
   width: 3rem;
+  min-width: 3rem;
   text-align: right;
   color: rgba(128, 128, 128, 0.8);
   user-select: none;
   background: rgba(128, 128, 128, 0.06);
   white-space: nowrap;
 }
-.hydra-diff__row--add td { background: rgba(46, 160, 67, 0.16); }
-.hydra-diff__row--del td { background: rgba(207, 34, 46, 0.16); }
-.hydra-diff__cell--empty { background: rgba(128, 128, 128, 0.05); }
+.hydra-diff__ln--right {
+  border-left: 1px solid rgba(128, 128, 128, 0.25);
+}
+.hydra-diff__row--add > td { background: rgba(46, 160, 67, 0.16); }
+.hydra-diff__row--del > td { background: rgba(207, 34, 46, 0.16); }
+.hydra-diff__cell--add {
+  background: rgba(46, 160, 67, 0.16);
+  box-shadow: inset 3px 0 #2ea043;
+}
+.hydra-diff__cell--del {
+  background: rgba(207, 34, 46, 0.16);
+  box-shadow: inset 3px 0 #cf222e;
+}
+.hydra-diff__cell--empty { background: rgba(128, 128, 128, 0.08); }
 .hydra-diff__sign {
   width: 1rem;
   text-align: center;
   color: rgba(128, 128, 128, 0.9);
   user-select: none;
+}
+.hydra-diff__gap td {
+  padding: 0;
+  border-top: 1px solid rgba(128, 128, 128, 0.16);
+  border-bottom: 1px solid rgba(128, 128, 128, 0.16);
+}
+.hydra-diff__gap-button {
+  width: 100%;
+  padding: 0.2rem 0.6rem;
+  border: 0;
+  background: rgba(80, 140, 255, 0.07);
+  color: rgba(128, 128, 128, 0.95);
+  font: inherit;
+  font-size: 0.72rem;
+  text-align: left;
+  cursor: pointer;
+}
+.hydra-diff__gap-button:hover {
+  background: rgba(80, 140, 255, 0.14);
 }
 .hydra-diff__ship {
   border: 1px solid rgba(128, 128, 128, 0.25);

--- a/packages/desktop/src/renderer/diff/FileDiffView.tsx
+++ b/packages/desktop/src/renderer/diff/FileDiffView.tsx
@@ -2,23 +2,50 @@
 // file, either inline (single column, +/- signs) or side-by-side (two columns).
 // All the diffing already happened in diffModel / useFileDiff — this is layout.
 
-import { toSideBySide, type ChangedFileView, type DiffRow, type LineDiff } from './diffModel';
+import { useState } from 'react';
+
+import {
+  collapseUnchangedRows,
+  toSideBySide,
+  type ChangedFileView,
+  type DiffRow,
+  type LineDiff,
+} from './diffModel';
 import type { FileDiffState } from './useDiff';
 
 export type DiffViewMode = 'inline' | 'split';
 
 const SIGN: Record<DiffRow['type'], string> = { context: ' ', add: '+', del: '-' };
 
-function InlineDiff({ diff }: { diff: LineDiff }): JSX.Element {
+function UnchangedGap({ count, onExpand }: { count: number; onExpand: () => void }): JSX.Element {
   return (
-    <table className="hydra-diff__code">
+    <tr className="hydra-diff__gap">
+      <td colSpan={4}>
+        <button type="button" className="hydra-diff__gap-button" onClick={onExpand}>
+          {count} unchanged line{count === 1 ? '' : 's'} — show
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function InlineDiff({ diff }: { diff: LineDiff }): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const items = expanded
+    ? diff.rows.map((row) => ({ kind: 'row' as const, row }))
+    : collapseUnchangedRows(diff.rows, (row) => row.type === 'context');
+
+  return (
+    <table className="hydra-diff__code hydra-diff__code--inline" aria-label="Inline file diff">
       <tbody>
-        {diff.rows.map((row, index) => (
-          <tr key={index} className={`hydra-diff__row--${row.type}`}>
-            <td className="hydra-diff__ln">{row.baseLine ?? ''}</td>
-            <td className="hydra-diff__ln">{row.currentLine ?? ''}</td>
-            <td className="hydra-diff__sign">{SIGN[row.type]}</td>
-            <td>{row.text}</td>
+        {items.map((item, index) => item.kind === 'gap' ? (
+          <UnchangedGap key={`gap-${index}`} count={item.count} onExpand={() => setExpanded(true)} />
+        ) : (
+          <tr key={`row-${index}`} className={`hydra-diff__row--${item.row.type}`}>
+            <td className="hydra-diff__ln">{item.row.baseLine ?? ''}</td>
+            <td className="hydra-diff__ln">{item.row.currentLine ?? ''}</td>
+            <td className="hydra-diff__sign">{SIGN[item.row.type]}</td>
+            <td className="hydra-diff__cell">{item.row.text}</td>
           </tr>
         ))}
       </tbody>
@@ -27,19 +54,35 @@ function InlineDiff({ diff }: { diff: LineDiff }): JSX.Element {
 }
 
 function SplitDiff({ diff }: { diff: LineDiff }): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
   const rows = toSideBySide(diff.rows);
+  const items = expanded
+    ? rows.map((row) => ({ kind: 'row' as const, row }))
+    : collapseUnchangedRows(
+        rows,
+        (row) => row.left.type === 'context' && row.right.type === 'context',
+      );
+
   return (
-    <table className="hydra-diff__code">
+    <table className="hydra-diff__code hydra-diff__code--split" aria-label="Side-by-side file diff">
       <tbody>
-        {rows.map((row, index) => (
+        {items.map((item, index) => item.kind === 'gap' ? (
+          <UnchangedGap key={`gap-${index}`} count={item.count} onExpand={() => setExpanded(true)} />
+        ) : (
           <tr key={index}>
-            <td className="hydra-diff__ln">{row.left.lineNumber ?? ''}</td>
-            <td className={row.left.type === 'empty' ? 'hydra-diff__cell--empty' : `hydra-diff__row--${row.left.type}`}>
-              {row.left.text}
+            <td className="hydra-diff__ln">{item.row.left.lineNumber ?? ''}</td>
+            <td
+              className={`hydra-diff__cell hydra-diff__cell--${item.row.left.type}`}
+              aria-label={item.row.left.type === 'empty' ? 'No base content' : undefined}
+            >
+              {item.row.left.text}
             </td>
-            <td className="hydra-diff__ln">{row.right.lineNumber ?? ''}</td>
-            <td className={row.right.type === 'empty' ? 'hydra-diff__cell--empty' : `hydra-diff__row--${row.right.type}`}>
-              {row.right.text}
+            <td className="hydra-diff__ln hydra-diff__ln--right">{item.row.right.lineNumber ?? ''}</td>
+            <td
+              className={`hydra-diff__cell hydra-diff__cell--${item.row.right.type}`}
+              aria-label={item.row.right.type === 'empty' ? 'No current content' : undefined}
+            >
+              {item.row.right.text}
             </td>
           </tr>
         ))}
@@ -68,17 +111,27 @@ export function FileDiffView({ file, state, mode }: FileDiffViewProps): JSX.Elem
     body = <p className="hydra-diff__hint">Could not load {file.path}: {error}</p>;
   } else if (!lineDiff || lineDiff.truncated) {
     body = <p className="hydra-diff__hint">{file.path} is too large to diff inline.</p>;
-  } else if (lineDiff.rows.length === 0) {
+  } else if (lineDiff.added === 0 && lineDiff.removed === 0) {
     body = (
       <p className="hydra-diff__hint">
-        No line changes{file.kind === 'renamed' ? ' — renamed only.' : '.'}
+        {file.kind === 'added'
+          ? 'New empty file.'
+          : file.kind === 'deleted'
+            ? 'Deleted empty file.'
+            : `No line changes${file.kind === 'renamed' ? ' — renamed only.' : ' — metadata only.'}`}
       </p>
     );
   } else if (mode === 'split') {
-    body = <SplitDiff diff={lineDiff} />;
+    body = <SplitDiff key={file.path} diff={lineDiff} />;
   } else {
-    body = <InlineDiff diff={lineDiff} />;
+    body = <InlineDiff key={file.path} diff={lineDiff} />;
   }
+
+  const sideNotice = file.kind === 'added'
+    ? 'New file — the base side is empty.'
+    : file.kind === 'deleted'
+      ? 'Deleted file — the current side is empty.'
+      : null;
 
   return (
     <div className="hydra-diff__pane">
@@ -95,6 +148,9 @@ export function FileDiffView({ file, state, mode }: FileDiffViewProps): JSX.Elem
           </span>
         ) : null}
       </div>
+      {sideNotice && mode === 'split' ? (
+        <div className="hydra-diff__side-note">{sideNotice}</div>
+      ) : null}
       {body}
     </div>
   );

--- a/packages/desktop/src/renderer/diff/diffModel.ts
+++ b/packages/desktop/src/renderer/diff/diffModel.ts
@@ -273,6 +273,75 @@ export function toSideBySide(rows: DiffRow[]): SideBySideRow[] {
   return paired;
 }
 
+// ── unchanged-context compaction ────────────────────────────────────────────
+
+export type DiffDisplayItem<T> =
+  | { kind: 'row'; row: T }
+  | { kind: 'gap'; count: number };
+
+/**
+ * Keep a small amount of context around every changed row and replace longer
+ * unchanged runs with a single expandable gap. This mirrors the way editor
+ * diff views keep reviews focused without throwing the surrounding file away.
+ */
+export function collapseUnchangedRows<T>(
+  rows: T[],
+  isUnchanged: (row: T) => boolean,
+  contextLines = 3,
+  minimumGap = 4,
+): DiffDisplayItem<T>[] {
+  const changedIndexes = rows
+    .map((row, index) => (isUnchanged(row) ? -1 : index))
+    .filter((index) => index >= 0);
+
+  if (changedIndexes.length === 0) {
+    return rows.map((row) => ({ kind: 'row', row }));
+  }
+
+  const visible = new Array<boolean>(rows.length).fill(false);
+  for (const index of changedIndexes) {
+    const start = Math.max(0, index - contextLines);
+    const end = Math.min(rows.length - 1, index + contextLines);
+    for (let cursor = start; cursor <= end; cursor++) {
+      visible[cursor] = true;
+    }
+  }
+
+  // A one- or two-line placeholder is noisier than the context it replaces.
+  for (let start = 0; start < rows.length;) {
+    if (visible[start]) {
+      start++;
+      continue;
+    }
+    let end = start + 1;
+    while (end < rows.length && !visible[end]) {
+      end++;
+    }
+    if (end - start < minimumGap) {
+      for (let cursor = start; cursor < end; cursor++) {
+        visible[cursor] = true;
+      }
+    }
+    start = end;
+  }
+
+  const result: DiffDisplayItem<T>[] = [];
+  for (let index = 0; index < rows.length;) {
+    if (visible[index]) {
+      result.push({ kind: 'row', row: rows[index] });
+      index++;
+      continue;
+    }
+    let end = index + 1;
+    while (end < rows.length && !visible[end]) {
+      end++;
+    }
+    result.push({ kind: 'gap', count: end - index });
+    index = end;
+  }
+  return result;
+}
+
 // ── ship handoff (push & PR) ─────────────────────────────────────────────────
 
 export interface ShipCommand {

--- a/packages/desktop/src/smoke/diffModelSmoke.ts
+++ b/packages/desktop/src/smoke/diffModelSmoke.ts
@@ -26,6 +26,7 @@ import {
   basePathFor,
   buildShipCommands,
   classifyStatus,
+  collapseUnchangedRows,
   computeLineDiff,
   currentPathFor,
   splitLines,
@@ -143,6 +144,28 @@ async function main(): Promise<void> {
     assert.equal(split[1].right.type, 'add');
     assert.equal(split[3].left.type, 'empty', 'the extra trailing add pads the base column');
     assert.equal(split[3].right.text, 'line4');
+
+    // ── unchanged-context compaction ──
+    const longContext = computeLineDiff(
+      `${Array.from({ length: 10 }, (_, index) => `before-${index + 1}`).join('\n')}\nold\n${Array.from({ length: 10 }, (_, index) => `after-${index + 1}`).join('\n')}\n`,
+      `${Array.from({ length: 10 }, (_, index) => `before-${index + 1}`).join('\n')}\nnew\n${Array.from({ length: 10 }, (_, index) => `after-${index + 1}`).join('\n')}\n`,
+    );
+    const compact = collapseUnchangedRows(
+      longContext.rows,
+      (row) => row.type === 'context',
+      2,
+      3,
+    );
+    assert.equal(compact[0].kind, 'gap', 'leading context is collapsed');
+    assert.equal(compact[0].kind === 'gap' ? compact[0].count : 0, 8);
+    const lastCompactItem = compact.at(-1);
+    assert.equal(lastCompactItem?.kind, 'gap', 'trailing context is collapsed');
+    assert.equal(lastCompactItem?.kind === 'gap' ? lastCompactItem.count : 0, 8);
+    assert.equal(
+      compact.filter((item) => item.kind === 'row').length,
+      6,
+      'two context lines remain on either side of the paired change',
+    );
 
     // ── ship handoff commands ──
     const commands = buildShipCommands({ branch: summary.branch, workdir: summary.workdir });


### PR DESCRIPTION
## Summary
- restore add/delete highlighting in the split diff view
- collapse long unchanged regions with an accessible expand control
- clarify missing base/current sides for added and deleted files
- improve no-change states and add smoke coverage for context compaction

## Why
The desktop split renderer attached change classes directly to cells while its CSS only matched descendant cells, so additions and deletions appeared unstyled. New files also showed a blank base pane without explaining why, and long unchanged regions made reviews harder to scan.

## Validation
- npm run compile
- npm run lint
- npm run desktop:build
- npm run smoke:desktop-diff
- local rendered interaction check for split highlighting and unchanged-line expansion