### PR TITLE
chore: release v0.3.2026071501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.2026071501] - 2026-07-15
+
+### Added
+- Add automated signed and Apple-notarized macOS Desktop releases with in-app update prompts
+
+### Fixed
+- Prevent older extension activations from replacing a newer Hydra CLI installation
+- Clarify Desktop worker activity and completion status, and correct task and context icons
+- Normalize the macOS app icon size and transparency across system surfaces
+
 ## [0.3.2026071500] - 2026-07-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-monorepo",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -6317,7 +6317,7 @@
     },
     "packages/cli": {
       "name": "@hydra/cli",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6329,7 +6329,7 @@
     },
     "packages/core": {
       "name": "@hydra/core",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.7.2",
@@ -6338,7 +6338,7 @@
     },
     "packages/desktop": {
       "name": "@hydra/desktop",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/protocol": "*",
@@ -6366,7 +6366,7 @@
     },
     "packages/extension": {
       "name": "hydra-code",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6386,7 +6386,7 @@
     },
     "packages/protocol": {
       "name": "@hydra/protocol",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*"
@@ -6394,7 +6394,7 @@
     },
     "packages/sidecar": {
       "name": "@hydra/sidecar",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6406,7 +6406,7 @@
     },
     "packages/transport-loopback": {
       "name": "@hydra/transport-loopback",
-      "version": "0.3.2026071500",
+      "version": "0.3.2026071501",
       "license": "MIT",
       "dependencies": {
         "@hydra/protocol": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra monorepo — @hydra/core engine, @hydra/cli, and the hydra-code VS Code extension",
   "license": "MIT",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/cli",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra CLI — the `hydra` command (depends on @hydra/core)",
   "license": "MIT",
   "private": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/core",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra headless engine — worker lifecycle, tmux/git, sessions, telemetry (vscode-free)",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/desktop",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra desktop — Electron shell (M1). Main forks the plain-Node sidecar, mints a per-launch bearer token, and hands { url, token } to a React renderer that talks to the sidecar over LoopbackHttpWsTransport.",
   "license": "MIT",
   "private": true,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/protocol",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra control-plane seam — HydraControlClient over a swappable HydraTransport (engine-free, transport-agnostic)",
   "license": "MIT",
   "private": true,

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/sidecar",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra sidecar — the server side of the seam. HydraAppService imports @hydra/core in-process (loopback HTTP/WS server lands in M1).",
   "license": "MIT",
   "private": true,

--- a/packages/transport-loopback/package.json
+++ b/packages/transport-loopback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/transport-loopback",
-  "version": "0.3.2026071500",
+  "version": "0.3.2026071501",
   "description": "Hydra loopback transport — LoopbackHttpWsTransport (renderer → sidecar over 127.0.0.1 HTTP/WS) + the shared loopback wire vocabulary. Engine-free: depends only on @hydra/protocol types and global fetch/WebSocket.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Release v0.3.2026071501.

Validation:
- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test
- npm run lint
- npm run desktop:boot-check
- git diff --check