### PR TITLE
fix(desktop): disable electron-builder auto-publish

### DIFF
--- a/packages/desktop/scripts/dist-mac-release.mjs
+++ b/packages/desktop/scripts/dist-mac-release.mjs
@@ -282,7 +282,11 @@ async function buildDistributables() {
   console.log('hydra-desktop release: building DMG from notarized app');
   await rm(dmgPath, { force: true });
   await rm(`${dmgPath}.blockmap`, { force: true });
-  await run(builderPath, ['--mac', 'dmg', '--prepackaged', appOutDir], { env: releaseEnvironment() });
+  await run(
+    builderPath,
+    ['--mac', 'dmg', '--prepackaged', appOutDir, '--publish', 'never'],
+    { env: releaseEnvironment() },
+  );
 
   console.log('hydra-desktop release: building ZIP with Hydra.app at archive root');
   await rm(zipPath, { force: true });

--- a/packages/desktop/scripts/releaseConfigurationSmoke.mjs
+++ b/packages/desktop/scripts/releaseConfigurationSmoke.mjs
@@ -20,8 +20,14 @@ assert.match(updateConfig, /^repo: hydra$/m);
 assert.match(releaseScript, /APPLE_APP_SPECIFIC_PASSWORD/);
 assert.match(releaseScript, /latest-mac\.yml/);
 assert.match(releaseScript, /zipBlockmapPath/);
-assert.match(releaseScript, /'--prepackaged', appPath/);
-assert.match(releaseScript, /'--publish', 'never'/);
+assert.match(
+  releaseScript,
+  /\['--mac', 'dmg', '--prepackaged', appOutDir, '--publish', 'never'\]/,
+);
+assert.match(
+  releaseScript,
+  /\['--mac', 'zip', '--prepackaged', appPath, '--arm64', '--publish', 'never'\]/,
+);
 
 for (const requiredWorkflowFragment of [
   'build-desktop:',


### PR DESCRIPTION
## Summary

- prevent the DMG build from implicitly publishing when a Git tag is present
- keep GitHub Release creation behind the final combined release job
- lock both DMG and ZIP publish-never arguments in release smoke coverage

## Validation

- env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test
- npm run lint
- git diff --check