### PR TITLE
fix: surface Codex command approvals as needs input

### DIFF
--- a/docs/worker-attention-control-plane-plan.md
+++ b/docs/worker-attention-control-plane-plan.md
@@ -330,15 +330,21 @@ The incremental parser must understand at least:
 - `task_started` -> `running`;
 - `request_user_input` event -> `needs-input`;
 - `response_item` function call named `request_user_input` -> `needs-input`;
+- `response_item` escalated `custom_tool_call` for `exec` / `exec_command`
+  -> approval-flavored `needs-input`;
 - matching `function_call_output` -> resolve needs-input and return to
+  `running`;
+- matching `custom_tool_call_output` -> resolve command approval and return to
   `running`;
 - `task_complete` / `turn_complete` -> complete and `idle`;
 - `turn_aborted` -> resolve pending needs-input and move to `idle` with an
   aborted reason.
 
-Parser cursor state includes transcript identity, byte offset, and last native
-sequence/call identifier. It must not rescan the last fixed-size transcript
-window on every poll.
+Parser cursor state includes parser version, transcript identity, byte offset,
+and last native sequence/call identifier. A parser upgrade may perform one
+bounded recovery scan that restores only the latest unresolved attention; it
+must not replay historical completion. It must not rescan the last fixed-size
+transcript window on every poll.
 
 ### 9.2 Claude
 

--- a/packages/cli/src/smoke/workerNeedsInputSmoke.ts
+++ b/packages/cli/src/smoke/workerNeedsInputSmoke.ts
@@ -189,6 +189,77 @@ async function testClassifier(): Promise<void> {
   ].join('\n')), 'Codex response_item request_user_input');
   assert.match(codexFunctionCall.body, /Approve plan/);
 
+  const codexApprovalCall = JSON.stringify({
+    type: 'response_item',
+    payload: {
+      type: 'custom_tool_call',
+      status: 'completed',
+      call_id: 'call-approval',
+      name: 'exec',
+      input: [
+        'const result = await tools.exec_command({',
+        '  cmd: "printf approved > /tmp/approval.txt",',
+        '  sandbox_permissions: "require_escalated",',
+        '  justification: "Allow writing the requested file outside the worker?",',
+        '});',
+        'text(result);',
+      ].join('\n'),
+    },
+  });
+  const codexApproval = assertSignal(classifyCodexNeedsInputTranscriptText([
+    '{"type":"turn_context","payload":{"turn_id":"turn-approval"}}',
+    codexApprovalCall,
+  ].join('\n')), 'Codex exec approval request');
+  assert.equal(codexApproval.reason, 'approval-required');
+  assert.equal(codexApproval.title, 'Codex needs approval');
+  assert.match(codexApproval.body, /outside the worker/);
+  assert.equal(
+    classifyCodexRuntimeTranscriptText(codexApprovalCall)?.reason,
+    'approval-required',
+  );
+
+  const codexDefaultSandboxCall = JSON.stringify({
+    type: 'response_item',
+    payload: {
+      type: 'custom_tool_call',
+      call_id: 'call-default-sandbox',
+      name: 'exec',
+      input: [
+        'const result = await tools.exec_command({',
+        '  cmd: "pwd",',
+        '  sandbox_permissions: "use_default",',
+        '});',
+      ].join('\n'),
+    },
+  });
+  assert.equal(
+    classifyCodexNeedsInputTranscriptText(codexDefaultSandboxCall),
+    undefined,
+    'Codex exec calls without escalation must not become needs-input',
+  );
+
+  const resolvedApprovalTranscript = [
+    '{"type":"turn_context","payload":{"turn_id":"turn-approval"}}',
+    codexApprovalCall,
+    JSON.stringify({
+      type: 'response_item',
+      payload: {
+        type: 'custom_tool_call_output',
+        call_id: 'call-approval',
+        output: [{ type: 'input_text', text: 'Script completed' }],
+      },
+    }),
+  ].join('\n');
+  assert.equal(
+    classifyCodexNeedsInputTranscriptText(resolvedApprovalTranscript),
+    undefined,
+    'matching Codex custom_tool_call_output must resolve command approval',
+  );
+  assert.equal(
+    classifyCodexRuntimeTranscriptText(resolvedApprovalTranscript)?.reason,
+    'input-resolved',
+  );
+
   assert.equal(classifyCodexNeedsInputTranscriptText([
     '{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-3"}}',
     '{"type":"event_msg","payload":{"type":"request_user_input","call_id":"call-3","turn_id":"turn-3","questions":[{"question":"Pick?"}]}}',

--- a/packages/core/src/core/codexTranscriptCursorStore.ts
+++ b/packages/core/src/core/codexTranscriptCursorStore.ts
@@ -174,6 +174,9 @@ function validateTranscriptIdentity(value: unknown, label: string): asserts valu
 
 function validateParserState(value: unknown, label: string): asserts value is CodexTranscriptParserState {
   if (!isRecord(value)) throw new Error(`${label} parserState has invalid shape`);
+  if (value.parserVersion !== undefined) {
+    validateNonNegativeSafeInteger(value.parserVersion, `${label} parserVersion`);
+  }
   validateOptionalString(value.currentTurnId, `${label} currentTurnId`);
   validateOptionalString(value.pendingCallId, `${label} pendingCallId`);
   validateOptionalString(value.lastCallId, `${label} lastCallId`);

--- a/packages/core/src/core/codexTranscriptParser.ts
+++ b/packages/core/src/core/codexTranscriptParser.ts
@@ -7,17 +7,23 @@ export type CodexTranscriptEventKind =
   | 'turn-complete'
   | 'turn-aborted';
 
+export type CodexTranscriptNeedsInputReason =
+  | 'request-user-input'
+  | 'approval-required';
+
 export interface CodexTranscriptEvent {
   kind: CodexTranscriptEventKind;
   nativeId: string;
   turnId?: string;
   callId?: string;
   question?: string;
+  needsInputReason?: CodexTranscriptNeedsInputReason;
   observedAt?: string;
   sourceSequence?: number;
 }
 
 export interface CodexTranscriptParserState {
+  parserVersion?: number;
   currentTurnId?: string;
   pendingCallId?: string;
   lastCallId?: string;
@@ -30,16 +36,20 @@ export interface CodexTranscriptParseResult {
 }
 
 const MAX_NATIVE_ID_LENGTH = 500;
+export const CODEX_TRANSCRIPT_PARSER_VERSION = 2;
 
 export function createCodexTranscriptParserState(): CodexTranscriptParserState {
-  return {};
+  return { parserVersion: CODEX_TRANSCRIPT_PARSER_VERSION };
 }
 
 export function parseCodexTranscriptLines(
   lines: readonly string[],
   initialState: CodexTranscriptParserState = createCodexTranscriptParserState(),
 ): CodexTranscriptParseResult {
-  const state: CodexTranscriptParserState = { ...initialState };
+  const state: CodexTranscriptParserState = {
+    ...initialState,
+    parserVersion: CODEX_TRANSCRIPT_PARSER_VERSION,
+  };
   const events: CodexTranscriptEvent[] = [];
 
   for (const line of lines) {
@@ -82,13 +92,33 @@ export function parseCodexTranscriptLines(
           turnId: state.currentTurnId,
           callId: resolvedCallId,
           question,
+          needsInputReason: 'request-user-input',
           observedAt,
           sourceSequence,
         });
         continue;
       }
 
-      if (payloadType === 'function_call_output'
+      const approvalRequest = parseCodexExecApprovalRequest(payload);
+      if (approvalRequest) {
+        const resolvedCallId = callId
+          ?? `approval:${hashText(`${state.currentTurnId ?? 'turn'}:${approvalRequest.question}`)}`;
+        state.pendingCallId = resolvedCallId;
+        state.lastCallId = resolvedCallId;
+        events.push({
+          kind: 'needs-input',
+          nativeId: resolvedCallId,
+          turnId: state.currentTurnId,
+          callId: resolvedCallId,
+          question: approvalRequest.question,
+          needsInputReason: 'approval-required',
+          observedAt,
+          sourceSequence,
+        });
+        continue;
+      }
+
+      if ((payloadType === 'function_call_output' || payloadType === 'custom_tool_call_output')
         && callId
         && callId === state.pendingCallId) {
         events.push({
@@ -135,6 +165,7 @@ export function parseCodexTranscriptLines(
           turnId,
           callId,
           question,
+          needsInputReason: 'request-user-input',
           observedAt,
           sourceSequence,
         });
@@ -216,6 +247,47 @@ function firstQuestionText(payload: Record<string, unknown> | undefined): string
   }
   const direct = getString(payload, ['question', 'prompt', 'message', 'header']);
   return direct ? normalizeSingleLine(direct) : undefined;
+}
+
+function parseCodexExecApprovalRequest(
+  payload: Record<string, unknown>,
+): { question: string } | undefined {
+  if (getString(payload, ['type']) !== 'custom_tool_call') return undefined;
+  const toolName = getString(payload, ['name']);
+  if (toolName !== 'exec' && toolName !== 'exec_command') return undefined;
+
+  const inputObject = parseArgumentsObject(payload.input);
+  if (inputObject) {
+    const sandboxPermissions = getString(inputObject, ['sandbox_permissions', 'sandboxPermissions']);
+    if (sandboxPermissions !== 'require_escalated') return undefined;
+    return {
+      question: getString(inputObject, ['justification'])
+        ?? 'Codex is waiting for command approval.',
+    };
+  }
+
+  if (typeof payload.input !== 'string') return undefined;
+  const source = payload.input;
+  if (toolName === 'exec' && !/\btools\.exec_command\s*\(/.test(source)) return undefined;
+  if (!/["']?sandbox_permissions["']?\s*:\s*["']require_escalated["']/.test(source)) return undefined;
+  return {
+    question: extractDoubleQuotedProperty(source, 'justification')
+      ?? 'Codex is waiting for command approval.',
+  };
+}
+
+function extractDoubleQuotedProperty(source: string, property: string): string | undefined {
+  const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(
+    `["']?${escapedProperty}["']?\\s*:\\s*("(?:\\\\.|[^"\\\\])*")`,
+  ));
+  if (!match) return undefined;
+  try {
+    const value = JSON.parse(match[1]);
+    return typeof value === 'string' && value.trim() ? normalizeSingleLine(value) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function parseArgumentsObject(value: unknown): Record<string, unknown> | undefined {

--- a/packages/core/src/core/workerAttentionSupervisor.ts
+++ b/packages/core/src/core/workerAttentionSupervisor.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import {
+  CODEX_TRANSCRIPT_PARSER_VERSION,
   createCodexTranscriptParserState,
   parseCodexTranscriptLines,
   type CodexTranscriptEvent,
@@ -251,7 +252,18 @@ export class WorkerAttentionSupervisor implements Disposable {
       return 0;
     }
     const sameStoredTranscript = stored && sameTranscript(stored.transcript, transcript);
+    const parserUpgradeCursor = stored
+      && sameStoredTranscript
+      && stored.parserState.parserVersion !== CODEX_TRANSCRIPT_PARSER_VERSION
+      ? createCursor(
+        worker.workerId,
+        lifecycleEpoch,
+        transcript,
+        this.timestamp(),
+      )
+      : undefined;
     const epochResetCursor = stored
+      && !parserUpgradeCursor
       && stored.lifecycleEpoch !== lifecycleEpoch
       && sameStoredTranscript
       && stored.byteOffset <= stat.size
@@ -264,21 +276,25 @@ export class WorkerAttentionSupervisor implements Disposable {
       )
       : undefined;
     if (epochResetCursor) this.cursorStore.set(epochResetCursor);
-    const cursor = epochResetCursor
+    const cursor = parserUpgradeCursor
+      ?? epochResetCursor
       ?? (stored
         && stored.lifecycleEpoch === lifecycleEpoch
         && sameStoredTranscript
         && stored.byteOffset <= stat.size
         ? stored
         : createCursor(worker.workerId, lifecycleEpoch, transcript, this.timestamp()));
-    if (cursor.byteOffset === stat.size) return 0;
+    if (cursor.byteOffset === stat.size) {
+      if (parserUpgradeCursor) this.cursorStore.set(parserUpgradeCursor);
+      return 0;
+    }
 
     const delta = readFileRange(transcriptPath, cursor.byteOffset, stat.size);
     if (delta.length === 0) return 0;
     const pending = Buffer.from(cursor.pendingBytesBase64, 'base64');
     const split = splitJsonLines(Buffer.concat([pending, delta]));
     const parsed = parseCodexTranscriptLines(split.lines, cursor.parserState);
-    const events = stored
+    const events = stored && !parserUpgradeCursor
       ? parsed.events
       : this.selectInitialRecoveryEvents(worker, parsed.events, parsed.state.pendingCallId);
     let activeLease = lease;
@@ -343,12 +359,13 @@ export class WorkerAttentionSupervisor implements Disposable {
     const lifecycleEpoch = getWorkerLifecycleEpoch(worker);
     const runId = this.ensureActiveRun(worker, event);
     const signalId = this.signalId(worker, event);
+    const reason = event.needsInputReason ?? 'request-user-input';
     const occurrenceId = `codex-occurrence:${hashText(`${lifecycleEpoch}:${event.callId ?? event.nativeId}`)}`;
     const result = this.applyRuntime(
       worker,
       event,
       'needs-input',
-      'request-user-input',
+      reason,
       runId,
       occurrenceId,
     );
@@ -362,9 +379,13 @@ export class WorkerAttentionSupervisor implements Disposable {
 
     this.notificationStore.create({
       kind: 'needs-input',
-      title: `Worker #${worker.workerId} needs input`,
+      title: reason === 'approval-required'
+        ? `Worker #${worker.workerId} needs approval`
+        : `Worker #${worker.workerId} needs input`,
       body: truncateText(
-        redactText(event.question ?? 'Codex is waiting for input.'),
+        redactText(event.question ?? (reason === 'approval-required'
+          ? 'Codex is waiting for command approval.'
+          : 'Codex is waiting for input.')),
         MAX_NOTIFICATION_BODY,
       ),
       targetSession: worker.copilotSessionName,

--- a/packages/core/src/core/workerNeedsInputClassifier.ts
+++ b/packages/core/src/core/workerNeedsInputClassifier.ts
@@ -8,7 +8,8 @@ export type WorkerNeedsInputReason =
   | 'permission-request'
   | 'ask-user-question'
   | 'exit-plan'
-  | 'request-user-input';
+  | 'request-user-input'
+  | 'approval-required';
 
 export interface WorkerNeedsInputSignal {
   source: WorkerNeedsInputSignalSource;
@@ -21,6 +22,7 @@ export interface WorkerNeedsInputSignal {
 export type CodexRuntimeSignalReason =
   | 'task-started'
   | 'request-user-input'
+  | 'approval-required'
   | 'input-resolved'
   | 'turn-complete'
   | 'turn-aborted';
@@ -155,13 +157,18 @@ export function classifyAgentHookEvent(
 }
 
 export function classifyCodexNeedsInputTranscriptText(text: string): WorkerNeedsInputSignal | undefined {
-  let candidate: { callId: string; question?: string } | undefined;
+  let candidate: {
+    callId: string;
+    question?: string;
+    reason: Extract<WorkerNeedsInputReason, 'request-user-input' | 'approval-required'>;
+  } | undefined;
   const parsed = parseCodexTranscriptLines(text.split(/\r?\n/));
   for (const event of parsed.events) {
     if (event.kind === 'needs-input') {
       candidate = {
         callId: event.callId ?? event.nativeId,
         question: event.question,
+        reason: event.needsInputReason ?? 'request-user-input',
       };
     } else if (event.kind === 'input-resolved'
       || event.kind === 'turn-complete'
@@ -170,11 +177,13 @@ export function classifyCodexNeedsInputTranscriptText(text: string): WorkerNeeds
     }
   }
   if (!candidate || parsed.state.pendingCallId !== candidate.callId) return undefined;
-  const question = candidate.question ?? 'Codex is waiting for input.';
+  const question = candidate.question ?? (candidate.reason === 'approval-required'
+    ? 'Codex is waiting for command approval.'
+    : 'Codex is waiting for input.');
   return {
     source: 'codex-transcript',
-    reason: 'request-user-input',
-    title: 'Codex needs input',
+    reason: candidate.reason,
+    title: candidate.reason === 'approval-required' ? 'Codex needs approval' : 'Codex needs input',
     body: truncateBody(question),
     fingerprint: `codex:${hashText(candidate.callId)}`,
   };
@@ -194,15 +203,19 @@ export function classifyCodexRuntimeTranscriptText(text: string): CodexRuntimeSi
           fingerprint: `codex-runtime:${hashText(event.nativeId)}`,
         };
         break;
-      case 'needs-input':
+      case 'needs-input': {
+        const reason = event.needsInputReason ?? 'request-user-input';
         latest = {
           state: 'needs-input',
-          reason: 'request-user-input',
-          title: 'Codex needs input',
-          body: truncateBody(event.question ?? 'Codex is waiting for input.'),
+          reason,
+          title: reason === 'approval-required' ? 'Codex needs approval' : 'Codex needs input',
+          body: truncateBody(event.question ?? (reason === 'approval-required'
+            ? 'Codex is waiting for command approval.'
+            : 'Codex is waiting for input.')),
           fingerprint: `codex-runtime:${hashText(event.callId ?? event.nativeId)}`,
         };
         break;
+      }
       case 'input-resolved':
         latest = {
           state: 'running',

--- a/packages/core/src/smoke/workerAttentionSupervisorSmoke.ts
+++ b/packages/core/src/smoke/workerAttentionSupervisorSmoke.ts
@@ -284,6 +284,94 @@ async function testTranscriptCompletionAndCursorRestart(): Promise<void> {
   }
 }
 
+async function testCodexExecApprovalLifecycle(): Promise<void> {
+  const ctx = createContext('hydra-attention-approval-', 45);
+  const supervisor = createSupervisor(ctx, 'sidecar', 'sidecar-approval-owner');
+  try {
+    const approvalCall = JSON.stringify({
+      type: 'response_item',
+      sequence: 2,
+      payload: {
+        type: 'custom_tool_call',
+        status: 'completed',
+        call_id: 'call-approval',
+        name: 'exec',
+        input: [
+          'const result = await tools.exec_command({',
+          '  cmd: "printf approved > /tmp/approval.txt",',
+          '  sandbox_permissions: "require_escalated",',
+          '  justification: "Allow writing the requested file outside the worker?",',
+          '});',
+          'text(result);',
+        ].join('\n'),
+      },
+    });
+    fs.writeFileSync(ctx.transcriptFile, [
+      '{"type":"event_msg","sequence":1,"payload":{"type":"task_started","turn_id":"turn-approval"}}',
+      approvalCall,
+    ].join('\n'), 'utf-8');
+    const transcriptStat = fs.statSync(ctx.transcriptFile);
+    ctx.cursorStore.set({
+      version: 1,
+      workerId: ctx.worker.workerId,
+      lifecycleEpoch: ctx.worker.lifecycleEpoch!,
+      transcript: {
+        path: ctx.transcriptFile,
+        device: transcriptStat.dev,
+        inode: transcriptStat.ino,
+      },
+      byteOffset: transcriptStat.size,
+      pendingBytesBase64: '',
+      parserState: {
+        currentTurnId: 'turn-approval',
+      },
+      updatedAt: new Date().toISOString(),
+    });
+
+    const waiting = await supervisor.scanOnce();
+    assert.equal(
+      waiting.eventsProcessed,
+      1,
+      'parser upgrade must recover an approval skipped by the old cursor',
+    );
+    const waitingRuntime = ctx.runtimeV2Store.get(ctx.worker.workerId);
+    assert.equal(waitingRuntime?.state, 'needs-input');
+    assert.equal(waitingRuntime?.reason, 'approval-required');
+    const activeApproval = ctx.notificationStore.listOccurrences('active')
+      .filter(item => item.kind === 'needs-input');
+    assert.equal(activeApproval.length, 1);
+    assert.equal(activeApproval[0].title, `Worker #${ctx.worker.workerId} needs approval`);
+    assert.match(activeApproval[0].body, /outside the worker/);
+
+    const approvalOutput = JSON.stringify({
+      type: 'response_item',
+      sequence: 3,
+      payload: {
+        type: 'custom_tool_call_output',
+        call_id: 'call-approval',
+        output: [{ type: 'input_text', text: 'Script completed' }],
+      },
+    });
+    fs.appendFileSync(ctx.transcriptFile, `\n${approvalOutput}`, 'utf-8');
+
+    const resumed = await supervisor.scanOnce();
+    assert.equal(resumed.eventsProcessed, 1);
+    assert.equal(ctx.runtimeV2Store.get(ctx.worker.workerId)?.state, 'running');
+    assert.equal(ctx.runtimeV2Store.get(ctx.worker.workerId)?.reason, 'input-resolved');
+    assert.equal(
+      ctx.notificationStore.listOccurrences('active').filter(item => item.kind === 'needs-input').length,
+      0,
+    );
+    assert.equal(
+      ctx.notificationStore.listOccurrences('resolved').filter(item => item.kind === 'needs-input').length,
+      1,
+    );
+  } finally {
+    supervisor.dispose();
+    removeTree(ctx.root);
+  }
+}
+
 async function testCursorWriteFailureReplaysIdempotently(): Promise<void> {
   const ctx = createContext('hydra-attention-replay-', 43);
   ctx.cursorStore = new FailOnceCursorStore(path.join(ctx.hydraHome, 'codex-transcript-cursors.json'));
@@ -406,6 +494,7 @@ function removeTree(root: string): void {
 async function main(): Promise<void> {
   await testIncrementalCursorResolutionAbortAndLease();
   await testTranscriptCompletionAndCursorRestart();
+  await testCodexExecApprovalLifecycle();
   await testCursorWriteFailureReplaysIdempotently();
   await testInitialRecoveryClosesMatchingAbort();
   testStoresFailClosed();


### PR DESCRIPTION
## Summary

- recognize escalated Codex `exec` / `exec_command` custom tool calls as approval-flavored `needs-input`
- resolve the attention occurrence when the matching custom tool output arrives
- version the transcript parser cursor so upgrades recover an already-pending approval without replaying historical completions
- preserve the approval justification in Notification v2 and worker runtime state

## Validation

- `npm run compile`
- `npm run lint`
- `npm run smoke:worker-needs-input`
- `npm run smoke:worker-attention-supervisor`
- `npm run smoke:worker-runtime-state`
- `npm run smoke:desktop-control-state`
- `env -u HYDRA_CONFIG_PATH -u HYDRA_HOME npm test`
- live Desktop verification against an actual pending Codex command approval: Attention count, parent badge, worker attention state, approval title/body, and Open Terminal route all rendered correctly
