### PR TITLE
fix(desktop): build bundled CLI before packaging

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "main": "./out/main.js",
   "scripts": {
+    "build:runtime": "npm --prefix ../.. run compile",
     "build:main": "tsc -b tsconfig.json",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json",
     "build:renderer": "node scripts/build-frontend.mjs",
@@ -16,8 +17,8 @@
     "smoke:auto-update": "node out/smoke/autoUpdateSmoke.js",
     "smoke:cli": "node out/smoke/desktopCliSmoke.js",
     "smoke:release-config": "node scripts/releaseConfigurationSmoke.mjs",
-    "pack:mac": "npm run build && electron-builder --mac --dir",
-    "dist:mac": "npm run build && electron-builder --mac",
+    "pack:mac": "npm run build:runtime && npm run build && electron-builder --mac --dir",
+    "dist:mac": "npm run build:runtime && npm run build && electron-builder --mac",
     "dist:mac:release": "node scripts/dist-mac-release.mjs",
     "dist:mac:release:resume": "node scripts/dist-mac-release.mjs --resume"
   },

--- a/packages/desktop/scripts/dist-mac-release.mjs
+++ b/packages/desktop/scripts/dist-mac-release.mjs
@@ -339,6 +339,7 @@ if (resume) {
   console.log('hydra-desktop release: cleaning previous artifacts');
   await rm(distDir, { force: true, recursive: true });
   await mkdir(distDir, { recursive: true });
+  await run('npm', ['run', 'build:runtime']);
   await run('npm', ['run', 'build']);
   await run(builderPath, ['--mac', '--dir', '--arm64'], { env: releaseEnvironment() });
   await run('codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath]);

--- a/packages/desktop/scripts/releaseConfigurationSmoke.mjs
+++ b/packages/desktop/scripts/releaseConfigurationSmoke.mjs
@@ -13,6 +13,9 @@ const publishWorkflow = await readFile(path.join(repoRoot, '.github', 'workflows
 assert.equal(desktopPackage.dependencies['electron-updater']?.startsWith('^6.'), true);
 assert.equal(desktopPackage.dependencies['@hydra/cli'], '*');
 assert.equal(desktopPackage.dependencies['@hydra/core'], '*');
+assert.equal(desktopPackage.scripts['build:runtime'], 'npm --prefix ../.. run compile');
+assert.match(desktopPackage.scripts['pack:mac'], /^npm run build:runtime &&/);
+assert.match(desktopPackage.scripts['dist:mac'], /^npm run build:runtime &&/);
 assert.deepEqual(desktopPackage.build.publish, [{ provider: 'github', owner: 'sudoprivacy', repo: 'hydra' }]);
 assert.deepEqual(desktopPackage.build.extraResources, [{ from: 'build/app-update.yml', to: 'app-update.yml' }]);
 assert.match(updateConfig, /^provider: github$/m);
@@ -24,6 +27,12 @@ assert.match(releaseScript, /latest-mac\.yml/);
 assert.match(releaseScript, /zipBlockmapPath/);
 assert.match(releaseScript, /validateBundledCli/);
 assert.match(releaseScript, /node_modules', '@hydra', 'cli', 'out', 'cli', 'index\.js'/);
+const runtimeBuildIndex = releaseScript.indexOf("await run('npm', ['run', 'build:runtime']);");
+const appBuildIndex = releaseScript.indexOf("await run('npm', ['run', 'build']);");
+const packageAppIndex = releaseScript.indexOf("await run(builderPath, ['--mac', '--dir', '--arm64']");
+assert.ok(runtimeBuildIndex !== -1, 'release script must build the bundled runtime');
+assert.ok(runtimeBuildIndex < appBuildIndex, 'bundled runtime must build before the Desktop app');
+assert.ok(appBuildIndex < packageAppIndex, 'Desktop app must build before electron-builder packages it');
 assert.match(
   releaseScript,
   /\['--mac', 'dmg', '--prepackaged', appOutDir, '--publish', 'never'\]/,


### PR DESCRIPTION
## Summary

- build the full Hydra runtime before Desktop packaging
- make local macOS pack and dist commands self-contained on clean checkouts
- assert release build ordering before electron-builder packages the app

## Validation

- npm run compile
- npm run lint
- npm test
- npm run pack:mac -w @hydra/desktop
- clean detached worktree: npm ci, confirmed CLI out absent, packaged app, executed bundled CLI --version