### PR TITLE
feat(nexus): cert-agent authN for the vfs client (mTLS + agent cert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,6 +1006,55 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1199,6 +1248,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -1302,6 +1361,63 @@
       "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
       "integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
@@ -1423,7 +1539,6 @@
       "version": "20.19.43",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1871,7 +1986,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1881,7 +1995,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2492,7 +2605,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2520,7 +2632,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2533,7 +2644,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -3322,7 +3432,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -3455,7 +3564,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3971,7 +4079,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4472,7 +4579,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4736,6 +4842,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -4795,6 +4907,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5298,6 +5416,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -5471,7 +5612,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5761,7 +5901,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5792,7 +5931,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6051,7 +6189,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -6135,7 +6272,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6210,7 +6346,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -6227,7 +6362,6 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -6246,7 +6380,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6332,6 +6465,8 @@
       "version": "0.3.2026072000",
       "license": "MIT",
       "dependencies": {
+        "@grpc/grpc-js": "^1.12.0",
+        "@grpc/proto-loader": "^0.7.13",
         "iconv-lite": "^0.7.2",
         "posthog-node": "^5.33.3"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
     "smoke:nexus-tracking": "node out/smoke/nexusTrackingSmoke.js",
     "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js",
     "smoke:nexus-message": "node out/smoke/nexusMessageSmoke.js",
-    "smoke:nexus-watch": "node out/smoke/nexusWatchSmoke.js"
+    "smoke:nexus-watch": "node out/smoke/nexusWatchSmoke.js",
+    "smoke:nexus-bridge": "node out/smoke/nexusBridgeSmoke.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "compile": "tsc -b tsconfig.json",
     "smoke:nexus-tracking": "node out/smoke/nexusTrackingSmoke.js",
-    "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js"
+    "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js",
+    "smoke:nexus-message": "node out/smoke/nexusMessageSmoke.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,8 @@
     "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js",
     "smoke:nexus-message": "node out/smoke/nexusMessageSmoke.js",
     "smoke:nexus-watch": "node out/smoke/nexusWatchSmoke.js",
-    "smoke:nexus-bridge": "node out/smoke/nexusBridgeSmoke.js"
+    "smoke:nexus-bridge": "node out/smoke/nexusBridgeSmoke.js",
+    "smoke:nexus-cert-agent": "node out/smoke/nexusCertAgentSmoke.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,9 +18,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "compile": "tsc -b tsconfig.json"
+    "compile": "tsc -b tsconfig.json",
+    "smoke:nexus-tracking": "node out/smoke/nexusTrackingSmoke.js",
+    "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.12.0",
+    "@grpc/proto-loader": "^0.7.13",
     "iconv-lite": "^0.7.2",
     "posthog-node": "^5.33.3"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     "compile": "tsc -b tsconfig.json",
     "smoke:nexus-tracking": "node out/smoke/nexusTrackingSmoke.js",
     "smoke:nexus-tracking-wiring": "node out/smoke/nexusTrackingWiringSmoke.js",
-    "smoke:nexus-message": "node out/smoke/nexusMessageSmoke.js"
+    "smoke:nexus-message": "node out/smoke/nexusMessageSmoke.js",
+    "smoke:nexus-watch": "node out/smoke/nexusWatchSmoke.js"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,10 @@
       "types": "./out/index.d.ts",
       "default": "./out/index.js"
     },
+    "./transport/nexus": {
+      "types": "./out/core/transport/nexus/index.d.ts",
+      "default": "./out/core/transport/nexus/index.js"
+    },
     "./*": {
       "types": "./out/core/*.d.ts",
       "default": "./out/core/*.js"

--- a/packages/core/proto/nexus/grpc/vfs/vfs.proto
+++ b/packages/core/proto/nexus/grpc/vfs/vfs.proto
@@ -1,0 +1,601 @@
+// VFS gRPC transport for REMOTE profile and federation peers.
+//
+// Every syscall is a typed RPC. The generic `Call` RPC is retained only
+// for the non-syscall in-process control plane — service_* lifecycle
+// no-ops, trie_* / agent_* registry ops, and the `get_mount_points`
+// operational query. Every other method now errors with "unknown Call
+// method". Native bytes on the content / stream ops kill the prior
+// base64-in-JSON tax.
+//
+// Issue #1133: Unified gRPC transport.
+// Issue #1202: gRPC for REMOTE profile.
+
+syntax = "proto3";
+
+package nexus.grpc.vfs;
+
+service NexusVFSService {
+  // Generic dispatch RPC — method name + JSON-encoded params.
+  // Server routes to the same dispatch_method() as the HTTP endpoint.
+  rpc Call(CallRequest) returns (CallResponse);
+
+  // Typed RPCs for content operations — native bytes, no JSON/base64.
+  rpc Read(ReadRequest) returns (ReadResponse);
+  rpc Write(WriteRequest) returns (WriteResponse);
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
+
+  // Health check with server metadata.
+  rpc Ping(PingRequest) returns (PingResponse);
+
+  // Vectored batch read (Issue #4058). Per-request errors are reported
+  // per-item; outer Status is reserved for transport-level failures.
+  rpc BatchRead(BatchReadRequest) returns (BatchReadResponse);
+
+  // Vectored batch write — native bytes (no base64 tax) + per-item
+  // error isolation. Replaces the generic `write_batch` Call.
+  rpc BatchWrite(BatchWriteRequest) returns (BatchWriteResponse);
+
+  // Typed metadata stat — the hottest metadata op.
+  rpc Stat(StatRequest) returns (StatResponse);
+
+  // Typed directory listing — metastore + backend merge, procfs intercepts.
+  rpc Readdir(ReaddirRequest) returns (ReaddirResponse);
+
+  // Vectored stat — single redb txn on the optimized KernelConvenience
+  // override. Per-path not-found is in-band (`found = false`).
+  rpc BatchStat(BatchStatRequest) returns (BatchStatResponse);
+
+  // Typed attribute set / inode create. Exposes the subset of the
+  // 21-param inherent sys_setattr that crosses the JSON wire today —
+  // Arc<ObjectStore>, metastore, raft_backend, read_fd/write_fd, source,
+  // and remote_metastore stay off this RPC (they need in-process refs).
+  rpc Setattr(SetattrRequest) returns (SetattrResponse);
+
+  // Typed rename / server-side copy.
+  rpc Rename(RenameRequest) returns (RenameResponse);
+  rpc Copy(CopyRequest) returns (CopyResponse);
+
+  // Typed advisory-lock acquire / release.
+  rpc Lock(LockRequest) returns (LockResponse);
+  rpc Unlock(UnlockRequest) returns (UnlockResponse);
+
+  // Typed file-event watch (blocking, inotify-shaped).
+  rpc Watch(WatchRequest) returns (WatchResponse);
+
+  // Typed xattr (extended-attribute) ops — Tier 2 KernelConvenience.
+  // Direct-metastore path, no hooks / no permission gate.
+  rpc GetXattr(GetXattrRequest) returns (GetXattrResponse);
+  rpc SetXattr(SetXattrRequest) returns (SetXattrResponse);
+  rpc GetXattrBulk(GetXattrBulkRequest) returns (GetXattrBulkResponse);
+
+  // Typed mkdir — the prior generic `sys_mkdir` Call retired.
+  rpc Mkdir(MkdirRequest) returns (MkdirResponse);
+
+  // Typed IPC pipe / stream ops. Creation goes through `Setattr` with
+  // entry_type=DT_PIPE / DT_STREAM (no separate Create*Ipc RPC needed).
+  rpc ClosePipe(IpcPathRequest) returns (IpcAck);
+  rpc HasPipe(IpcPathRequest) returns (IpcHasResponse);
+  rpc CloseAllPipes(IpcEmpty) returns (IpcAck);
+
+  rpc CloseStream(IpcPathRequest) returns (IpcAck);
+  rpc HasStream(IpcPathRequest) returns (IpcHasResponse);
+  rpc StreamWriteNowait(StreamWriteRequest) returns (StreamWriteResponse);
+  rpc StreamReadAt(StreamReadAtRequest) returns (StreamReadAtResponse);
+  rpc StreamCollectAll(IpcPathRequest) returns (StreamCollectAllResponse);
+}
+
+// --- Generic dispatch messages (Phase 1, unchanged) ---
+
+message CallRequest {
+  string method = 1;      // "sys_read", "sys_write", "workspace_snapshot", ...
+  bytes payload = 2;      // JSON-encoded params dict (rpc_codec)
+  string auth_token = 3;  // Bearer token (same as HTTP Authorization header)
+}
+
+message CallResponse {
+  bytes payload = 1;      // JSON-encoded result or error dict
+  bool is_error = 2;      // If true, payload is JSON-RPC error dict
+}
+
+// --- Typed content messages (Phase 2) ---
+
+message ReadRequest {
+  string path = 1;
+  string auth_token = 2;
+  string content_id = 3;   // Opaque content identifier (hash for CAS, path for PAS) — when set, server reads content directly (no metastore lookup)
+  // Pipe-/stream-read knobs — full-fidelity sys_read on the wire.
+  // Defaults give plain file-read semantics: blocking ≤5s, from offset 0.
+  uint64 timeout_ms = 4;   // 0 → non-blocking; otherwise pipe/stream block budget
+  uint64 offset = 5;       // byte offset within content (streams + range reads)
+}
+
+message ReadResponse {
+  bytes content = 1;       // Raw file bytes — no base64
+  string content_id = 2;
+  int64 size = 3;
+  bool is_error = 4;
+  bytes error_payload = 5; // JSON error dict (same format as CallResponse)
+  uint64 gen = 6;
+  // Stream / typed-entry fields — let Python sys_read drop its Call
+  // fallback (timeout_ms/offset on the wire + these fields out).
+  int32 entry_type = 7;             // DT_* of the resolved entry
+  optional uint64 stream_next_offset = 8;  // streams: where the next read picks up
+  bool post_hook_needed = 9;        // OBSERVE chain trigger
+}
+
+message WriteRequest {
+  string path = 1;
+  bytes content = 2;       // Raw file bytes — no base64
+  string auth_token = 3;
+  // Field 4 (`content_id` — documented as "If-Match" conditional
+  // write) removed for issue #5.  The server never enforced it, so
+  // the documented optimistic-concurrency contract was a silent
+  // no-op that would mask concurrent-writer data loss in any
+  // client that trusted it.  Dropped rather than half-implemented
+  // per YAGNI: the `content_id` at rest is a hash (CAS backends)
+  // or a path (PAS backends), neither of which is the right shape
+  // for a versioning token.  If optimistic-write semantics come
+  // back later, key off `WriteResponse.gen` (monotonic version)
+  // via an explicit `expected_gen` field, not `content_id`.
+  reserved 4;
+  reserved "content_id";
+}
+
+message WriteResponse {
+  string content_id = 1;
+  int64 size = 2;
+  bool is_error = 3;
+  bytes error_payload = 4;
+  uint64 gen = 5;
+}
+
+message DeleteRequest {
+  string path = 1;
+  string auth_token = 2;
+  bool recursive = 3;      // For rmdir
+}
+
+message DeleteResponse {
+  // `success` is `optional bool` so the wire distinguishes
+  // "success=false transmitted explicitly" (idempotent no-op —
+  // target did not exist) from "field unset" (issue #8).  Under
+  // proto3's default-omit rule a bare `bool success = 1` on a
+  // not-found delete serialized as `{}`, indistinguishable from
+  // "field never populated" — a footgun for any client that
+  // relies on `success` to gate follow-up work.  With the
+  // optional marker: `Some(true)` = target existed and was
+  // deleted; `Some(false)` = target did not exist (idempotent);
+  // `None` should never occur post-fix, but a defensive client
+  // should treat it as "server does not understand the request".
+  optional bool success = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+  // Richer per-result fields — added so the typed Delete subsumes the
+  // prior `sys_unlink` Call (callers read entry_type for the audit
+  // trail, content_id / size for metrics). Zero / empty when success=false.
+  uint32 entry_type = 4;
+  string path = 5;
+  string content_id = 6;
+  uint64 size = 7;
+}
+
+// --- Typed mkdir (replaces the `sys_mkdir` Call) ---
+
+message MkdirRequest {
+  string path = 1;
+  string auth_token = 2;
+  bool parents = 3;
+  bool exist_ok = 4;
+}
+
+message MkdirResponse {
+  bool hit = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- Health check messages ---
+
+message PingRequest {
+  string auth_token = 1;
+}
+
+message PingResponse {
+  string version = 1;
+  string zone_id = 2;
+  int64 uptime_seconds = 3;
+}
+
+// --- Batch read (Issue #4058) ---
+
+message BatchReadRequest {
+  string auth_token = 1;
+  repeated BatchReadItemRequest items = 2;
+}
+
+message BatchReadItemRequest {
+  string path = 1;
+  uint64 offset = 2;
+  // proto3 `optional` so callers can distinguish "no length set"
+  // (read to EOF from offset) from `length = 0` (legitimate zero-byte
+  // EOF probe). Old clients that omitted `length` continue to read
+  // whole files; new clients can explicitly set 0 for an empty slice.
+  // (Named `length` rather than `len` so the generated Rust struct
+  // doesn't trip `clippy::len_without_is_empty`.)
+  optional uint64 length = 3;
+}
+
+message BatchReadResponse {
+  repeated BatchReadItemResponse results = 1;  // input order
+}
+
+message BatchReadItemResponse {
+  bytes content = 1;        // empty when is_error
+  bool is_error = 2;
+  bytes error_payload = 3;  // JSON RPC error dict (same as CallResponse)
+  string content_id = 4;
+  uint64 gen = 5;
+}
+
+// --- Batch write (typed — replaces the base64 `write_batch` Call) ---
+
+message BatchWriteRequest {
+  string auth_token = 1;
+  repeated BatchWriteItemRequest items = 2;
+}
+
+message BatchWriteItemRequest {
+  string path = 1;
+  bytes content = 2;        // Raw file bytes — no base64
+}
+
+message BatchWriteResponse {
+  repeated BatchWriteItemResponse results = 1;  // input order
+}
+
+message BatchWriteItemResponse {
+  string content_id = 1;
+  int64 size = 2;
+  uint64 gen = 3;
+  uint32 version = 4;
+  bool is_error = 5;
+  bytes error_payload = 6;  // JSON RPC error dict (same as CallResponse)
+}
+
+// --- Typed metadata stat (replaces the `sys_stat` Call) ---
+
+message StatRequest {
+  string path = 1;
+  string auth_token = 2;
+  string zone_id = 3;       // empty → caller's context zone
+}
+
+message StatResponse {
+  bool found = 1;           // false → path does not exist (not an error)
+  // Stat fields — valid only when found == true. Mirrors StatResult /
+  // the `stat_to_json` shape; the `lock` field is intentionally omitted
+  // (matches the generic Call path — include_lock is a separate query).
+  string path = 2;
+  int64 size = 3;
+  string content_id = 4;            // "" when unset
+  string mime_type = 5;
+  bool is_directory = 6;
+  int32 entry_type = 7;
+  uint32 mode = 8;
+  uint32 version = 9;
+  uint64 gen = 10;
+  string zone_id = 11;              // "" when unset
+  optional int64 created_at_ms = 12;
+  optional int64 modified_at_ms = 13;
+  string last_writer_address = 14;  // "" when unset
+  string link_target = 15;          // "" when unset
+  string owner_id = 16;             // "" when unset
+  bool is_error = 17;
+  bytes error_payload = 18;         // JSON error dict — auth failures only
+}
+
+// --- Typed directory listing (replaces the `sys_readdir` Call) ---
+
+message ReaddirRequest {
+  string path = 1;
+  string auth_token = 2;
+  string zone_id = 3;        // empty → caller's context zone
+  // `is_admin` is intentionally NOT a request field — the handler reads
+  // it from the auth-resolved OperationContext so a client can't spoof.
+
+  // Set to `true` by peer-side fan-out dispatch (see
+  // `try_remote_readdir` / `FederationGrpcOps::list_dir`) so the
+  // receiving node's handler runs its local metastore + backend scan
+  // only, skipping its own fan-out.  Loop-guard: prevents ping-pong
+  // in 3+ node topologies where every hop's local search comes up
+  // empty.  Kernel-level: routes to `sys_readdir_peer_dispatch`
+  // instead of `sys_readdir`.
+  bool from_peer = 4;
+}
+
+message ReaddirEntry {
+  string name = 1;           // child path (matches the inherent Vec<(String, u8)>)
+  uint32 entry_type = 2;     // DT_* code (u8 widened)
+}
+
+message ReaddirResponse {
+  repeated ReaddirEntry entries = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;   // JSON error dict — auth failures only
+}
+
+// --- Vectored stat (replaces the `stat_batch` Call) ---
+
+message BatchStatRequest {
+  string auth_token = 1;
+  string zone_id = 2;        // empty → caller's context zone
+  repeated string paths = 3;
+}
+
+// Mirrors `StatResponse`'s stat fields but without `is_error` — auth
+// failures surface as an outer tonic Status (matching BatchRead /
+// BatchWrite), and per-path not-found is in-band via `found = false`.
+message BatchStatItem {
+  bool found = 1;
+  string path = 2;
+  int64 size = 3;
+  string content_id = 4;
+  string mime_type = 5;
+  bool is_directory = 6;
+  int32 entry_type = 7;
+  uint32 mode = 8;
+  uint32 version = 9;
+  uint64 gen = 10;
+  string zone_id = 11;
+  optional int64 created_at_ms = 12;
+  optional int64 modified_at_ms = 13;
+  string last_writer_address = 14;
+  string link_target = 15;
+  string owner_id = 16;
+}
+
+message BatchStatResponse {
+  repeated BatchStatItem results = 1;  // positional — same length/order as request.paths
+}
+
+// --- Typed setattr (replaces the `sys_setattr` Call) ---
+
+message SetattrRequest {
+  string path = 1;
+  string auth_token = 2;
+  int32 entry_type = 3;             // DT_* code
+  string zone_id = 4;                // empty → ROOT_ZONE_ID
+
+  // Optional metadata fields (presence-tracked — None survives the wire).
+  optional string mime_type = 5;
+  optional string content_id = 6;
+  optional int64 modified_at_ms = 7;
+  optional int64 created_at_ms = 8;
+  optional uint64 size = 9;
+  optional uint32 version = 10;
+
+  // DT_PIPE / DT_STREAM container fields. Default-zero / empty when unused.
+  string backend_name = 11;
+  string io_profile = 12;
+  bool is_external = 13;
+  uint64 capacity = 14;
+
+  // ── DT_MOUNT backend-construction params (entry_type == 2) ──────────
+  //
+  // `backend_type` is the dispatch key (matches DRIVER_* values:
+  // "s3", "gcs", "remote", …). Empty ⇒ metadata-only / local re-mount.
+  // `backend_params` carries all app-layer constructor params as an
+  // opaque string map — each backend arm in the provider parses its
+  // own required keys (e.g. "s3_bucket", "aws_region"). This keeps the
+  // proto extensible: adding a new backend or param requires zero
+  // proto changes.
+  string backend_type = 15;
+
+  // Old flat backend fields (16-30) replaced by the opaque map.
+  reserved 16 to 30;
+
+  // Opaque app-layer backend-construction params. Keys match the
+  // provider arm's expected param names (e.g. "s3_bucket", "aws_region",
+  // "server_address"). Binary data (PEM certs) is stored as UTF-8 text.
+  map<string, string> backend_params = 31;
+}
+
+message SetattrResponse {
+  // Mirrors the Call response shape consumed by _SysSetAttrResult.
+  string path = 1;
+  bool created = 2;
+  int32 entry_type = 3;
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+// --- Typed rename (replaces the `sys_rename` Call) ---
+
+message RenameRequest {
+  string path = 1;          // old path
+  string new_path = 2;
+  string auth_token = 3;
+}
+
+message RenameResponse {
+  bool hit = 1;
+  bool success = 2;
+  bool is_directory = 3;
+  // Old metadata — surfaced for audit / post-hook context.
+  optional string old_content_id = 4;
+  optional uint64 old_size = 5;
+  optional uint32 old_version = 6;
+  optional int64 old_modified_at_ms = 7;
+  bool is_error = 8;
+  bytes error_payload = 9;
+  // post_hook_needed is omitted — always false on the gRPC architecture
+  // (no Python post-hook dispatch); _SysRenameResult defaults it.
+}
+
+// --- Typed server-side copy (replaces the `sys_copy` Call) ---
+
+message CopyRequest {
+  string src = 1;
+  string dst = 2;
+  string auth_token = 3;
+}
+
+message CopyResponse {
+  bool hit = 1;
+  string dst_path = 2;
+  optional string content_id = 3;
+  uint64 size = 4;
+  uint32 version = 5;
+  uint64 gen = 6;
+  bool is_error = 7;
+  bytes error_payload = 8;
+}
+
+// --- Typed advisory locks (replace the `sys_lock` / `sys_unlock` Calls) ---
+
+// Matches the Call wire surface: the kernel `sys_lock` hardcodes
+// Exclusive + max_holders=1 + ttl_secs=timeout_ms/1000+1 on this path,
+// so we don't expose mode / max_holders / ttl_secs on the RPC yet.
+message LockRequest {
+  string path = 1;
+  string auth_token = 2;
+  string lock_id = 3;      // empty → server generates
+  uint64 timeout_ms = 4;
+}
+
+message LockResponse {
+  bool acquired = 1;       // false → lock contention, no other error
+  string lock_id = 2;      // set when acquired
+  bool is_error = 3;
+  bytes error_payload = 4;
+}
+
+message UnlockRequest {
+  string path = 1;
+  string auth_token = 2;
+  string lock_id = 3;
+  bool force = 4;
+}
+
+message UnlockResponse {
+  bool released = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- Typed file-event watch (replaces the `sys_watch` Call) ---
+
+message WatchRequest {
+  string path = 1;
+  string auth_token = 2;
+  uint64 timeout_ms = 3;
+}
+
+message WatchResponse {
+  bool matched = 1;        // false → timed out, no event
+  string path = 2;         // event path when matched
+  string event_type = 3;   // FileEventType Debug string (e.g. "FileWrite")
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+// --- Typed xattr ops (replace get_xattr / set_xattr / get_xattr_bulk Calls) ---
+
+message GetXattrRequest {
+  string path = 1;
+  string key = 2;
+  string auth_token = 3;
+}
+
+message GetXattrResponse {
+  bool found = 1;        // false → key not set; not an error
+  string value = 2;
+  bool is_error = 3;
+  bytes error_payload = 4;
+}
+
+message SetXattrRequest {
+  string path = 1;
+  string key = 2;
+  string value = 3;
+  string auth_token = 4;
+}
+
+message SetXattrResponse {
+  bool is_error = 1;
+  bytes error_payload = 2;
+}
+
+message GetXattrBulkRequest {
+  repeated string paths = 1;
+  string key = 2;
+  string auth_token = 3;
+}
+
+message GetXattrBulkItem {
+  string path = 1;
+  bool found = 2;        // false → key not set on this path
+  string value = 3;
+}
+
+message GetXattrBulkResponse {
+  repeated GetXattrBulkItem items = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+// --- IPC pipe / stream ops (replace the IPC Call arms) ---
+
+message IpcPathRequest {
+  string path = 1;
+  string auth_token = 2;
+}
+
+message IpcAck {
+  bool is_error = 1;
+  bytes error_payload = 2;
+}
+
+message IpcHasResponse {
+  bool present = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+message IpcEmpty {
+  string auth_token = 1;
+}
+
+message StreamWriteRequest {
+  string path = 1;
+  bytes data = 2;             // native bytes — no base64 tax
+  string auth_token = 3;
+}
+
+message StreamWriteResponse {
+  uint64 offset = 1;          // offset where the data landed
+  bool is_error = 2;
+  bytes error_payload = 3;
+}
+
+message StreamReadAtRequest {
+  string path = 1;
+  uint64 offset = 2;
+  bool blocking = 3;          // true → server blocks up to timeout_ms
+  uint64 timeout_ms = 4;      // only honoured when blocking == true
+  string auth_token = 5;
+}
+
+message StreamReadAtResponse {
+  bytes data = 1;
+  uint64 next_offset = 2;
+  bool eof = 3;               // non-blocking: true → no data available
+  bool is_error = 4;
+  bytes error_payload = 5;
+}
+
+message StreamCollectAllResponse {
+  bytes data = 1;
+  bool is_error = 2;
+  bytes error_payload = 3;
+}

--- a/packages/core/src/core/transport/nexus/index.ts
+++ b/packages/core/src/core/transport/nexus/index.ts
@@ -1,0 +1,67 @@
+// The switchable transport seam (doc §5). One mode flips both planes IN SYNC — the
+// tracking plane today, the message plane joins here later — so they are never split.
+//
+//   HYDRA_TRANSPORT=legacy   (default)  tmux/NotificationStore only; nexus untouched
+//   HYDRA_TRANSPORT=nexus                nexus backends only
+//   HYDRA_TRANSPORT=dual                 both; nexus is best-effort (failures swallowed)
+//
+// Wired at the CLI composition roots (where `new TmuxBackendCore()` lives), so the
+// choice is made once per process alongside the multiplexer backend.
+
+import {
+  DualRunTracker,
+  NexusRunTracker,
+  NoopRunTracker,
+  RunTracker,
+} from './runTracker';
+import { NexusVfsClientOptions } from './vfsClient';
+
+export * from './vfsClient';
+export * from './runTracker';
+
+export type TransportMode = 'legacy' | 'nexus' | 'dual';
+
+export function resolveTransportMode(env: NodeJS.ProcessEnv = process.env): TransportMode {
+  const raw = (env.HYDRA_TRANSPORT ?? 'legacy').toLowerCase();
+  return raw === 'nexus' || raw === 'dual' ? raw : 'legacy';
+}
+
+export interface TransportOptions {
+  /** Overrides; address/token default from NEXUS_AGENT_ADDR / NEXUS_SK. */
+  clientOptions?: NexusVfsClientOptions;
+  /** Non-fatal nexus errors in Dual mode land here (default: warn to console). */
+  onError?: (op: string, error: unknown) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface TransportBackends {
+  mode: TransportMode;
+  runTracker: RunTracker;
+  // messageTransport: MessageTransport;  // joins here with the message plane
+}
+
+/** Construct the per-process transport backends, both planes switched by one mode. */
+export function createTransport(opts: TransportOptions = {}): TransportBackends {
+  const env = opts.env ?? process.env;
+  const mode = resolveTransportMode(env);
+  if (mode === 'legacy') {
+    return { mode, runTracker: new NoopRunTracker() };
+  }
+
+  const clientOptions: NexusVfsClientOptions = {
+    address: env.NEXUS_AGENT_ADDR,
+    token: env.NEXUS_SK,
+    ...opts.clientOptions,
+  };
+  const nexus = new NexusRunTracker(clientOptions);
+  if (mode === 'nexus') {
+    return { mode, runTracker: nexus };
+  }
+
+  const onError =
+    opts.onError ??
+    ((op: string, error: unknown) =>
+      // eslint-disable-next-line no-console
+      console.warn(`[hydra/nexus-tracking] non-fatal ${op} failure:`, error));
+  return { mode, runTracker: new DualRunTracker(nexus, onError) };
+}

--- a/packages/core/src/core/transport/nexus/index.ts
+++ b/packages/core/src/core/transport/nexus/index.ts
@@ -14,10 +14,16 @@ import {
   NoopRunTracker,
   RunTracker,
 } from './runTracker';
+import {
+  MessageTransport,
+  NexusMessageTransport,
+  NoopMessageTransport,
+} from './messageTransport';
 import { NexusVfsClientOptions } from './vfsClient';
 
 export * from './vfsClient';
 export * from './runTracker';
+export * from './messageTransport';
 
 export type TransportMode = 'legacy' | 'nexus' | 'dual';
 
@@ -37,7 +43,7 @@ export interface TransportOptions {
 export interface TransportBackends {
   mode: TransportMode;
   runTracker: RunTracker;
-  // messageTransport: MessageTransport;  // joins here with the message plane
+  messageTransport: MessageTransport;
 }
 
 /** Construct the per-process transport backends, both planes switched by one mode. */
@@ -45,7 +51,11 @@ export function createTransport(opts: TransportOptions = {}): TransportBackends 
   const env = opts.env ?? process.env;
   const mode = resolveTransportMode(env);
   if (mode === 'legacy') {
-    return { mode, runTracker: new NoopRunTracker() };
+    return {
+      mode,
+      runTracker: new NoopRunTracker(),
+      messageTransport: new NoopMessageTransport(),
+    };
   }
 
   const clientOptions: NexusVfsClientOptions = {
@@ -53,15 +63,22 @@ export function createTransport(opts: TransportOptions = {}): TransportBackends 
     token: env.NEXUS_SK,
     ...opts.clientOptions,
   };
-  const nexus = new NexusRunTracker(clientOptions);
+  const nexusTracker = new NexusRunTracker(clientOptions);
+  const messageTransport = new NexusMessageTransport(clientOptions);
   if (mode === 'nexus') {
-    return { mode, runTracker: nexus };
+    return { mode, runTracker: nexusTracker, messageTransport };
   }
 
+  // Dual: nexus tracking is best-effort (swallow); the tmux-legacy message send runs
+  // alongside `messageTransport.send` at the callsite (slice 2 wiring).
   const onError =
     opts.onError ??
     ((op: string, error: unknown) =>
       // eslint-disable-next-line no-console
-      console.warn(`[hydra/nexus-tracking] non-fatal ${op} failure:`, error));
-  return { mode, runTracker: new DualRunTracker(nexus, onError) };
+      console.warn(`[hydra/nexus-transport] non-fatal ${op} failure:`, error));
+  return {
+    mode,
+    runTracker: new DualRunTracker(nexusTracker, onError),
+    messageTransport,
+  };
 }

--- a/packages/core/src/core/transport/nexus/index.ts
+++ b/packages/core/src/core/transport/nexus/index.ts
@@ -15,6 +15,9 @@ import {
   RunTracker,
 } from './runTracker';
 import {
+  DualMessageTransport,
+  LegacyMessageBackend,
+  LegacyMessageTransport,
   MessageTransport,
   NexusMessageTransport,
   NoopMessageTransport,
@@ -38,6 +41,8 @@ export interface TransportOptions {
   /** Non-fatal nexus errors in Dual mode land here (default: warn to console). */
   onError?: (op: string, error: unknown) => void;
   env?: NodeJS.ProcessEnv;
+  /** The multiplexer backend — powers the legacy (tmux) message plane in legacy/dual. */
+  backend?: LegacyMessageBackend;
 }
 
 export interface TransportBackends {
@@ -50,12 +55,11 @@ export interface TransportBackends {
 export function createTransport(opts: TransportOptions = {}): TransportBackends {
   const env = opts.env ?? process.env;
   const mode = resolveTransportMode(env);
+  const legacyMessages: MessageTransport = opts.backend
+    ? new LegacyMessageTransport(opts.backend)
+    : new NoopMessageTransport();
   if (mode === 'legacy') {
-    return {
-      mode,
-      runTracker: new NoopRunTracker(),
-      messageTransport: new NoopMessageTransport(),
-    };
+    return { mode, runTracker: new NoopRunTracker(), messageTransport: legacyMessages };
   }
 
   const clientOptions: NexusVfsClientOptions = {
@@ -63,22 +67,22 @@ export function createTransport(opts: TransportOptions = {}): TransportBackends 
     token: env.NEXUS_SK,
     ...opts.clientOptions,
   };
-  const nexusTracker = new NexusRunTracker(clientOptions);
-  const messageTransport = new NexusMessageTransport(clientOptions);
-  if (mode === 'nexus') {
-    return { mode, runTracker: nexusTracker, messageTransport };
-  }
-
-  // Dual: nexus tracking is best-effort (swallow); the tmux-legacy message send runs
-  // alongside `messageTransport.send` at the callsite (slice 2 wiring).
   const onError =
     opts.onError ??
     ((op: string, error: unknown) =>
       // eslint-disable-next-line no-console
       console.warn(`[hydra/nexus-transport] non-fatal ${op} failure:`, error));
+  const nexusTracker = new NexusRunTracker(clientOptions);
+  const nexusMessages = new NexusMessageTransport(clientOptions);
+  if (mode === 'nexus') {
+    return { mode, runTracker: nexusTracker, messageTransport: nexusMessages };
+  }
+
+  // Dual: legacy tmux inject is the primary path; nexus tracking + mailbox mirror are
+  // best-effort (failures swallowed via onError) so nexus can never break delivery.
   return {
     mode,
     runTracker: new DualRunTracker(nexusTracker, onError),
-    messageTransport,
+    messageTransport: new DualMessageTransport(legacyMessages, nexusMessages, onError),
   };
 }

--- a/packages/core/src/core/transport/nexus/messageTransport.ts
+++ b/packages/core/src/core/transport/nexus/messageTransport.ts
@@ -12,10 +12,28 @@ export interface MessageEnvelope {
   body: string;
 }
 
+export interface WatchOptions {
+  /** Abort to stop tailing (the returned promise then resolves). */
+  signal?: AbortSignal;
+  /** Start from this offset (default "0" — from the beginning). */
+  fromOffset?: string;
+  /** Per-read server long-poll timeout (default 30s). */
+  timeoutMs?: number;
+}
+
 /** `target` is the recipient agent's persistent name (= `worker.sessionName` today). */
 export interface MessageTransport {
   send(target: string, envelope: MessageEnvelope): Promise<void>;
   collect(target: string): Promise<MessageEnvelope[]>;
+  /**
+   * Tail a mailbox: call `onMessage` for each new envelope until `opts.signal` aborts.
+   * The nexus plane uses sys_watch (blocking StreamReadAt); other planes are no-ops.
+   */
+  watch(
+    target: string,
+    onMessage: (envelope: MessageEnvelope) => void,
+    opts?: WatchOptions,
+  ): Promise<void>;
   close(): void;
 }
 
@@ -27,6 +45,7 @@ export class NoopMessageTransport implements MessageTransport {
   async collect(): Promise<MessageEnvelope[]> {
     return [];
   }
+  async watch(): Promise<void> {} // no mailbox on this plane
   close(): void {}
 }
 
@@ -62,6 +81,35 @@ export class NexusMessageTransport implements MessageTransport {
     return [JSON.parse(raw.toString()) as MessageEnvelope];
   }
 
+  async watch(
+    target: string,
+    onMessage: (envelope: MessageEnvelope) => void,
+    opts: WatchOptions = {},
+  ): Promise<void> {
+    const path = mailboxPath(target);
+    await this.client.mkstream(path); // idempotent — the stream must exist to tail
+    let offset = opts.fromOffset ?? '0';
+    const timeoutMs = opts.timeoutMs ?? 30000;
+    while (!opts.signal?.aborted) {
+      const { data, nextOffset, eof } = await this.client.streamReadAt(path, offset, {
+        blocking: true,
+        timeoutMs,
+      });
+      if (opts.signal?.aborted) {
+        break;
+      }
+      if (eof || !data.length) {
+        continue; // long-poll timed out with no frame — loop
+      }
+      offset = nextOffset;
+      try {
+        onMessage(JSON.parse(data.toString()) as MessageEnvelope);
+      } catch {
+        // skip a frame that is not a JSON envelope
+      }
+    }
+  }
+
   close(): void {
     this.client.close();
   }
@@ -81,6 +129,7 @@ export class LegacyMessageTransport implements MessageTransport {
   async collect(): Promise<MessageEnvelope[]> {
     return []; // tmux has no durable mailbox to read back
   }
+  async watch(): Promise<void> {} // legacy attention rides NotificationStore, not a mailbox
   close(): void {}
 }
 
@@ -111,6 +160,15 @@ export class DualMessageTransport implements MessageTransport {
       this.onError('collect', error);
       return [];
     }
+  }
+
+  async watch(
+    target: string,
+    onMessage: (envelope: MessageEnvelope) => void,
+    opts?: WatchOptions,
+  ): Promise<void> {
+    // Mailbox tailing is the nexus plane's job; legacy attention runs via its own path.
+    await this.nexus.watch(target, onMessage, opts);
   }
 
   close(): void {

--- a/packages/core/src/core/transport/nexus/messageTransport.ts
+++ b/packages/core/src/core/transport/nexus/messageTransport.ts
@@ -1,0 +1,68 @@
+// Message plane (doc §5) — the second synchronized switchable plane. Delivers + reads
+// agent-to-agent messages. Legacy backend = tmux inject + NotificationStore (stays in
+// hydra, wired at the callsite); nexus backend = chat-with-me mailbox write + collect
+// over the VFS agent plane, with the kernel stamping an unforgeable `from`.
+
+import { NexusVfsClient, NexusVfsClientOptions } from './vfsClient';
+
+/** An A2A message. `from` is a placeholder — the kernel stamp hook overwrites it. */
+export interface MessageEnvelope {
+  from?: string;
+  to?: string | null;
+  body: string;
+}
+
+/** `target` is the recipient agent's persistent name (= `worker.sessionName` today). */
+export interface MessageTransport {
+  send(target: string, envelope: MessageEnvelope): Promise<void>;
+  collect(target: string): Promise<MessageEnvelope[]>;
+  close(): void;
+}
+
+const mailboxPath = (agent: string): string => `/agents/${agent}/chat-with-me`;
+
+/** Legacy: nexus messaging off. The tmux / NotificationStore path stays in hydra. */
+export class NoopMessageTransport implements MessageTransport {
+  async send(): Promise<void> {}
+  async collect(): Promise<MessageEnvelope[]> {
+    return [];
+  }
+  close(): void {}
+}
+
+/** nexus: chat-with-me mailbox write + collect; `from` is kernel-stamped (unforgeable). */
+export class NexusMessageTransport implements MessageTransport {
+  private readonly client: NexusVfsClient;
+
+  constructor(options: NexusVfsClientOptions = {}) {
+    this.client = new NexusVfsClient(options);
+  }
+
+  async send(target: string, envelope: MessageEnvelope): Promise<void> {
+    const path = mailboxPath(target);
+    await this.client.mkstream(path);
+    // A forged `from` here is harmless — the kernel stamp hook overwrites it with the
+    // caller's authenticated agent_id (on the cert/token plane). NoAuth (serve-local)
+    // passes it through, so from-unforgeability holds only on an authenticated plane.
+    const frame = JSON.stringify({
+      from: envelope.from ?? '(unset)',
+      to: envelope.to ?? null,
+      body: envelope.body,
+    });
+    await this.client.streamWrite(path, Buffer.from(frame));
+  }
+
+  async collect(target: string): Promise<MessageEnvelope[]> {
+    const raw = await this.client.streamCollect(mailboxPath(target));
+    if (!raw.length) {
+      return [];
+    }
+    // Single-message decode: the stamp hook re-serializes each frame (dropping any
+    // delimiter), so multi-message framing is a follow-up.
+    return [JSON.parse(raw.toString()) as MessageEnvelope];
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/packages/core/src/core/transport/nexus/messageTransport.ts
+++ b/packages/core/src/core/transport/nexus/messageTransport.ts
@@ -66,3 +66,55 @@ export class NexusMessageTransport implements MessageTransport {
     this.client.close();
   }
 }
+
+/** The tmux surface the legacy plane needs — the multiplexer backend satisfies it. */
+export interface LegacyMessageBackend {
+  sendMessage(sessionName: string, message: string): Promise<void>;
+}
+
+/** Legacy: deliver via the multiplexer backend (tmux keystroke inject); no mailbox collect. */
+export class LegacyMessageTransport implements MessageTransport {
+  constructor(private readonly backend: LegacyMessageBackend) {}
+  async send(target: string, envelope: MessageEnvelope): Promise<void> {
+    await this.backend.sendMessage(target, envelope.body);
+  }
+  async collect(): Promise<MessageEnvelope[]> {
+    return []; // tmux has no durable mailbox to read back
+  }
+  close(): void {}
+}
+
+/**
+ * Dual: legacy tmux inject (primary during migration — must succeed) AND a best-effort
+ * mirror to the nexus mailbox (failures swallowed so nexus can never break delivery).
+ */
+export class DualMessageTransport implements MessageTransport {
+  constructor(
+    private readonly legacy: MessageTransport,
+    private readonly nexus: MessageTransport,
+    private readonly onError: (op: string, error: unknown) => void = () => {},
+  ) {}
+
+  async send(target: string, envelope: MessageEnvelope): Promise<void> {
+    await this.legacy.send(target, envelope);
+    try {
+      await this.nexus.send(target, envelope);
+    } catch (error) {
+      this.onError('send', error);
+    }
+  }
+
+  async collect(target: string): Promise<MessageEnvelope[]> {
+    try {
+      return await this.nexus.collect(target);
+    } catch (error) {
+      this.onError('collect', error);
+      return [];
+    }
+  }
+
+  close(): void {
+    this.legacy.close();
+    this.nexus.close();
+  }
+}

--- a/packages/core/src/core/transport/nexus/runTracker.ts
+++ b/packages/core/src/core/transport/nexus/runTracker.ts
@@ -1,0 +1,153 @@
+// Orchestration-tracking plane (doc §5) — one of the two synchronized switchable
+// planes. It reports a run's *identity and lifecycle* to a backend; process OWNERSHIP
+// (spawn / kill / git / worktree) is NOT here — that stays hydra either way (§8.1).
+//
+// Legacy backend  = tmux-session tracking only (no-op here).
+// nexus backend   = register_external / heartbeat into the kernel AgentRegistry.
+// Dual backend    = report to nexus alongside legacy, swallowing nexus failures so a
+//                   nexus outage can never take down hydra's worker lifecycle.
+
+import { NexusVfsClient, NexusVfsClientOptions } from './vfsClient';
+
+/** What nexus assigned for a reported run. */
+export interface RunHandle {
+  /** The agent pid == the OS host_pid (nexus-vfs #195), e.g. "4242" or "4242.7". */
+  pid: string;
+  /** The persistent, cluster-unique agent name. */
+  name: string;
+}
+
+export interface RegisterRunInput {
+  /** Persistent cluster-unique name, e.g. `<node_id>-hydra-w<workerId>`. */
+  name: string;
+  /** OS pid hosting the run — for hydra, the tmux pane pid. */
+  hostPid: number;
+  /** Unique id for this registration; presence selects the external (unmanaged) path. */
+  connectionId: string;
+  /** Disambiguates micro-agents sharing one OS process (coroutines/threads). */
+  localId?: number;
+  ownerId?: string;
+  zoneId?: string;
+  labels?: Record<string, string>;
+}
+
+export interface RunSummary {
+  pid: string;
+  name: string;
+  state: string;
+}
+
+/** The tracking plane a hydra run's lifecycle drives. */
+export interface RunTracker {
+  /** Report a run in. Returns null when the backend does not track (legacy) or a Dual write failed. */
+  registerRun(input: RegisterRunInput): Promise<RunHandle | null>;
+  heartbeat(pid: string): Promise<void>;
+  unregisterRun(pid: string): Promise<void>;
+  listRuns(filter?: { zoneId?: string; ownerId?: string }): Promise<RunSummary[]>;
+  close(): void;
+}
+
+/** Legacy: tmux-session tracking is implicit, so nexus tracking is a no-op. */
+export class NoopRunTracker implements RunTracker {
+  async registerRun(): Promise<RunHandle | null> {
+    return null;
+  }
+  async heartbeat(): Promise<void> {}
+  async unregisterRun(): Promise<void> {}
+  async listRuns(): Promise<RunSummary[]> {
+    return [];
+  }
+  close(): void {}
+}
+
+/** nexus: register_external / heartbeat into the kernel AgentRegistry via the Call RPC. */
+export class NexusRunTracker implements RunTracker {
+  private readonly client: NexusVfsClient;
+
+  constructor(options: NexusVfsClientOptions = {}) {
+    this.client = new NexusVfsClient(options);
+  }
+
+  async registerRun(input: RegisterRunInput): Promise<RunHandle> {
+    const desc = await this.client.call<RunHandle>('agent_register_external', {
+      name: input.name,
+      owner_id: input.ownerId ?? 'hydra',
+      zone_id: input.zoneId ?? '',
+      connection_id: input.connectionId,
+      host_pid: input.hostPid,
+      local_id: input.localId,
+      protocol: 'hydra',
+      labels: input.labels ?? {},
+    });
+    return { pid: desc.pid, name: desc.name };
+  }
+
+  async heartbeat(pid: string): Promise<void> {
+    await this.client.call('agent_heartbeat', { pid });
+  }
+
+  async unregisterRun(pid: string): Promise<void> {
+    await this.client.call('agent_unregister_external', { pid });
+  }
+
+  async listRuns(filter: { zoneId?: string; ownerId?: string } = {}): Promise<RunSummary[]> {
+    return this.client.call<RunSummary[]>('agent_list', {
+      zone_id: filter.zoneId,
+      owner_id: filter.ownerId,
+    });
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}
+
+/**
+ * Dual: report to nexus alongside legacy tracking (legacy is a no-op, so this is nexus
+ * with a safety net). nexus tracking is pure-additive — it does not own the process — so
+ * failures are swallowed via `onError`; a nexus outage must never break worker lifecycle.
+ */
+export class DualRunTracker implements RunTracker {
+  constructor(
+    private readonly nexus: RunTracker,
+    private readonly onError: (op: string, error: unknown) => void = () => {},
+  ) {}
+
+  async registerRun(input: RegisterRunInput): Promise<RunHandle | null> {
+    try {
+      return await this.nexus.registerRun(input);
+    } catch (error) {
+      this.onError('registerRun', error);
+      return null;
+    }
+  }
+
+  async heartbeat(pid: string): Promise<void> {
+    try {
+      await this.nexus.heartbeat(pid);
+    } catch (error) {
+      this.onError('heartbeat', error);
+    }
+  }
+
+  async unregisterRun(pid: string): Promise<void> {
+    try {
+      await this.nexus.unregisterRun(pid);
+    } catch (error) {
+      this.onError('unregisterRun', error);
+    }
+  }
+
+  async listRuns(filter?: { zoneId?: string; ownerId?: string }): Promise<RunSummary[]> {
+    try {
+      return await this.nexus.listRuns(filter);
+    } catch (error) {
+      this.onError('listRuns', error);
+      return [];
+    }
+  }
+
+  close(): void {
+    this.nexus.close();
+  }
+}

--- a/packages/core/src/core/transport/nexus/vfsClient.ts
+++ b/packages/core/src/core/transport/nexus/vfsClient.ts
@@ -1,0 +1,102 @@
+// Thin client over the nexus VFS gRPC "agent plane" (the loopback sk--token bind).
+//
+// This is the low-level primitive both switchable planes (doc §5) build on: the
+// tracking plane rides the generic `Call` RPC (this file); the message plane will add
+// mailbox ops (Setattr/StreamWrite/StreamCollect) on the same client later.
+//
+// The wire contract is loaded dynamically from a vendored copy of nexus-vfs's
+// `vfs.proto` (self-contained, no imports) so hydra does not depend on a sibling
+// nexus-vfs checkout at runtime.
+
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import * as path from 'node:path';
+
+// __dirname at runtime = <core>/out/core/transport/nexus  →  up 4  = <core>, then /proto.
+const DEFAULT_PROTO_ROOT = path.join(__dirname, '..', '..', '..', '..', 'proto');
+const PROTO_FILE = 'nexus/grpc/vfs/vfs.proto';
+
+// loadSync is not free; cache the resolved service constructor per proto root.
+const serviceCache = new Map<string, grpc.ServiceClientConstructor>();
+
+function loadService(protoRoot: string): grpc.ServiceClientConstructor {
+  const cached = serviceCache.get(protoRoot);
+  if (cached) {
+    return cached;
+  }
+  const def = protoLoader.loadSync(PROTO_FILE, {
+    keepCase: true, // snake_case fields: auth_token, is_error, error_payload, …
+    longs: String, // uint64 offsets as strings
+    defaults: true,
+    includeDirs: [protoRoot],
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pkg = grpc.loadPackageDefinition(def) as any;
+  const Service = pkg.nexus.grpc.vfs.NexusVFSService as grpc.ServiceClientConstructor;
+  serviceCache.set(protoRoot, Service);
+  return Service;
+}
+
+export interface NexusVfsClientOptions {
+  /** Agent-plane address, host:port (loopback token plane). Default 127.0.0.1:2129. */
+  address?: string;
+  /** sk- agent key. The agent plane always authenticates, so this is required in practice. */
+  token?: string;
+  /** Override the proto include dir (tests). */
+  protoRoot?: string;
+}
+
+interface CallResponse {
+  payload?: Buffer;
+  is_error?: boolean;
+}
+
+/** A gRPC client for the nexus VFS agent plane; carries the sk- token on every Call. */
+export class NexusVfsClient {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly client: any;
+  private readonly token: string;
+
+  constructor(options: NexusVfsClientOptions = {}) {
+    this.token = options.token ?? '';
+    const Service = loadService(options.protoRoot ?? DEFAULT_PROTO_ROOT);
+    this.client = new Service(
+      options.address ?? '127.0.0.1:2129',
+      grpc.credentials.createInsecure(),
+    );
+  }
+
+  /**
+   * One kernel Call: `method` + JSON params -> parsed JSON result.
+   * The Call rpc_codec wraps success values as `{"result": <value>}`; this unwraps it.
+   * Rejects when the daemon flags `is_error`.
+   */
+  call<T = unknown>(method: string, params: Record<string, unknown>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.client.Call(
+        { method, payload: Buffer.from(JSON.stringify(params)), auth_token: this.token },
+        (err: grpc.ServiceError | null, res: CallResponse) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          const body =
+            res.payload && res.payload.length
+              ? JSON.parse(Buffer.from(res.payload).toString())
+              : null;
+          if (res.is_error) {
+            reject(new Error(`${method}: ${JSON.stringify(body)}`));
+            return;
+          }
+          resolve(
+            body && typeof body === 'object' && 'result' in body ? body.result : body,
+          );
+        },
+      );
+    });
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/packages/core/src/core/transport/nexus/vfsClient.ts
+++ b/packages/core/src/core/transport/nexus/vfsClient.ts
@@ -152,6 +152,33 @@ export class NexusVfsClient {
     return res.data && res.data.length ? Buffer.from(res.data) : Buffer.alloc(0);
   }
 
+  /**
+   * Read frames from `offset`. With `blocking`, the server waits up to `timeoutMs` for a
+   * frame to appear (tail-follow, sys_watch under the hood); non-blocking returns
+   * `eof=true` when nothing is ready. Returns the frame bytes + the cursor for next read.
+   */
+  async streamReadAt(
+    path: string,
+    offset: string,
+    opts: { blocking?: boolean; timeoutMs?: number } = {},
+  ): Promise<{ data: Buffer; nextOffset: string; eof: boolean }> {
+    const res = await this.unary<{ data?: Buffer; next_offset?: string; eof?: boolean }>(
+      'StreamReadAt',
+      {
+        path,
+        offset,
+        blocking: opts.blocking ?? false,
+        timeout_ms: opts.timeoutMs ?? 0,
+        auth_token: this.token,
+      },
+    );
+    return {
+      data: res.data && res.data.length ? Buffer.from(res.data) : Buffer.alloc(0),
+      nextOffset: res.next_offset ?? offset,
+      eof: res.eof ?? false,
+    };
+  }
+
   close(): void {
     this.client.close();
   }

--- a/packages/core/src/core/transport/nexus/vfsClient.ts
+++ b/packages/core/src/core/transport/nexus/vfsClient.ts
@@ -1,4 +1,6 @@
-// Thin client over the nexus VFS gRPC "agent plane" (the loopback sk--token bind).
+// Thin client over the nexus VFS gRPC agent plane. Two planes by credential:
+// a CERT plane (mTLS with an agent identity cert, on the main bind — see the
+// `tls` option) and a loopback plaintext/sk--token plane (serve-local).
 //
 // This is the low-level primitive both switchable planes (doc §5) build on: the
 // tracking plane rides the generic `Call` RPC (this file); the message plane will add
@@ -15,6 +17,11 @@ import * as path from 'node:path';
 // __dirname at runtime = <core>/out/core/transport/nexus  →  up 4  = <core>, then /proto.
 const DEFAULT_PROTO_ROOT = path.join(__dirname, '..', '..', '..', '..', 'proto');
 const PROTO_FILE = 'nexus/grpc/vfs/vfs.proto';
+
+// The fixed DNS SAN every nexus NODE cert carries. On the cert plane the mTLS
+// client verifies the server against this, NOT the dialed host — so a loopback
+// or overlay-IP dial still validates. SSOT: nexus-vfs `TlsConfig::CLUSTER_SERVER_NAME`.
+const CLUSTER_SERVER_NAME = 'nexus-node';
 
 // loadSync is not free; cache the resolved service constructor per proto root.
 const serviceCache = new Map<string, grpc.ServiceClientConstructor>();
@@ -38,12 +45,28 @@ function loadService(protoRoot: string): grpc.ServiceClientConstructor {
 }
 
 export interface NexusVfsClientOptions {
-  /** Agent-plane address, host:port (loopback token plane). Default 127.0.0.1:2129. */
+  /**
+   * Agent-plane address, host:port. Cert plane (`tls` set) → the main mTLS
+   * bind, default `127.0.0.1:2126`. Loopback plaintext plane → default
+   * `127.0.0.1:2129`.
+   */
   address?: string;
-  /** sk- agent key. The agent plane always authenticates, so this is required in practice. */
+  /**
+   * `sk-` key for the loopback token/plaintext plane. Left empty on the cert
+   * plane — the client certificate IS the identity, so no token is sent.
+   */
   token?: string;
   /** Override the proto include dir (tests). */
   protoRoot?: string;
+  /**
+   * mTLS cert bundle for the CERT plane — an agent minted by
+   * `nexusd-cluster auth mint --subject-type agent`. When set, the client dials
+   * the main mTLS bind presenting its client cert; the cert authenticates, so
+   * `token` is left empty. `ca` verifies the server (whose node cert carries the
+   * fixed `nexus-node` SAN); `cert`/`key` are the agent's own. Omit for the
+   * loopback insecure/sk- plane. Mirrors the Rust `examples/mailbox_cli.rs`.
+   */
+  tls?: { ca: Buffer; cert: Buffer; key: Buffer };
 }
 
 interface CallResponse {
@@ -60,10 +83,26 @@ export class NexusVfsClient {
   constructor(options: NexusVfsClientOptions = {}) {
     this.token = options.token ?? '';
     const Service = loadService(options.protoRoot ?? DEFAULT_PROTO_ROOT);
-    this.client = new Service(
-      options.address ?? '127.0.0.1:2129',
-      grpc.credentials.createInsecure(),
-    );
+    if (options.tls) {
+      // CERT plane: mTLS with the agent's own client cert. The cert is the
+      // identity (no token). The server presents a NODE cert whose SAN is the
+      // fixed cluster server name, so verify against THAT rather than the dialed
+      // host — matching the Rust client (`examples/mailbox_cli.rs`).
+      const creds = grpc.credentials.createSsl(
+        options.tls.ca,
+        options.tls.key,
+        options.tls.cert,
+      );
+      this.client = new Service(options.address ?? '127.0.0.1:2126', creds, {
+        'grpc.ssl_target_name_override': CLUSTER_SERVER_NAME,
+      });
+    } else {
+      // Loopback plaintext plane (serve-local / auth-off): sk- token on Call.
+      this.client = new Service(
+        options.address ?? '127.0.0.1:2129',
+        grpc.credentials.createInsecure(),
+      );
+    }
   }
 
   /**

--- a/packages/core/src/core/transport/nexus/vfsClient.ts
+++ b/packages/core/src/core/transport/nexus/vfsClient.ts
@@ -96,6 +96,62 @@ export class NexusVfsClient {
     });
   }
 
+  /** One typed VFS RPC returning `{is_error, error_payload}`; rejects on `is_error`. */
+  private unary<Res>(rpc: string, req: Record<string, unknown>): Promise<Res> {
+    return new Promise<Res>((resolve, reject) => {
+      this.client[rpc](
+        req,
+        (
+          err: grpc.ServiceError | null,
+          res: Res & { is_error?: boolean; error_payload?: Buffer },
+        ) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          if (res.is_error) {
+            const msg =
+              res.error_payload && res.error_payload.length
+                ? Buffer.from(res.error_payload).toString()
+                : '(no payload)';
+            reject(new Error(`${rpc}: ${msg}`));
+            return;
+          }
+          resolve(res);
+        },
+      );
+    });
+  }
+
+  /** Create (idempotent) a wal-backed DT_STREAM mailbox at `path`. */
+  async mkstream(path: string): Promise<void> {
+    await this.unary('Setattr', {
+      path,
+      auth_token: this.token,
+      entry_type: 4, // DT_STREAM
+      io_profile: 'wal,memory',
+    });
+  }
+
+  /** Append one frame to the DT_STREAM at `path`; returns the offset it landed at. */
+  async streamWrite(path: string, data: Buffer): Promise<string> {
+    const res = await this.unary<{ offset?: string }>('StreamWriteNowait', {
+      path,
+      data,
+      auth_token: this.token,
+    });
+    return res.offset ?? '0';
+  }
+
+  /** Read the whole DT_STREAM at `path` (all frames concatenated). */
+  async streamCollect(path: string): Promise<Buffer> {
+    const res = await this.unary<{ data?: Buffer }>('StreamCollectAll', {
+      path,
+      auth_token: this.token,
+    });
+    return res.data && res.data.length ? Buffer.from(res.data) : Buffer.alloc(0);
+  }
+
   close(): void {
     this.client.close();
   }

--- a/packages/core/src/core/workerLifecycleService.ts
+++ b/packages/core/src/core/workerLifecycleService.ts
@@ -23,6 +23,7 @@ import { WorkerRuntimeCoordinator, type WorkerRuntimeIdentity } from './workerRu
 import { WorkerRuntimeStateStore } from './workerRuntimeState';
 import { WorkerRuntimeStateStoreV2, type WorkerRuntimeSnapshotV2 } from './workerRuntimeV2';
 import { getWorkerLifecycleEpoch, normalizeWorkerSessionAliases } from './workerIdentity';
+import { NoopRunTracker, type RunTracker } from './transport/nexus';
 
 export type WorkerSelector = string | number;
 
@@ -52,6 +53,8 @@ export interface WorkerLifecycleServiceOptions {
   completionJobStore?: CompletionJobStore;
   eventLog?: EventLog;
   eventSource?: HydraEventSource;
+  /** Orchestration-tracking plane (doc §5). Defaults to the legacy no-op tracker. */
+  runTracker?: RunTracker;
 }
 
 interface PreparedWorkerDispatch {
@@ -77,6 +80,9 @@ export class WorkerLifecycleService {
   private readonly runtimeCoordinator: WorkerRuntimeCoordinator;
   private readonly completionJobStore: CompletionJobStore;
   private readonly eventSource: HydraEventSource;
+  private readonly runTracker: RunTracker;
+  /** workerId -> the nexus pid we registered, so stop can unregister the same run. */
+  private readonly registeredRuns = new Map<number, string>();
 
   constructor(options: WorkerLifecycleServiceOptions) {
     this.backend = options.backend;
@@ -86,12 +92,69 @@ export class WorkerLifecycleService {
     this.runtimeV2Store = options.runtimeV2Store ?? new WorkerRuntimeStateStoreV2();
     this.completionJobStore = options.completionJobStore ?? new CompletionJobStore();
     this.eventSource = options.eventSource ?? 'session-manager';
+    this.runTracker = options.runTracker ?? new NoopRunTracker();
     this.runtimeCoordinator = options.runtimeCoordinator ?? new WorkerRuntimeCoordinator(
       workerId => this.resolveRuntimeIdentity(workerId),
       this.runtimeV2Store,
       this.runtimeStateStore,
       options.eventLog ?? new EventLog(),
     );
+  }
+
+  /** Release the tracking backend (its gRPC channel). No-op in legacy mode. */
+  close(): void {
+    this.runTracker.close();
+  }
+
+  /**
+   * Report a started run into the tracking plane (best-effort, idempotent). Tracking is
+   * observability, never a gate on lifecycle — failures are logged and swallowed. `name`
+   * is the worker's sessionName (worktree/branch-anchored); `hostPid` is the agent pane's
+   * OS pid, which the kernel makes the agent pid (nexus-vfs #195).
+   */
+  private async trackRunStarted(worker: WorkerInfo): Promise<void> {
+    if (this.registeredRuns.has(worker.workerId)) {
+      return;
+    }
+    try {
+      const panePids = await this.backend.getSessionPanePids(worker.sessionName);
+      // TODO(multi-pane): resolve the @hydra-agent-pane pid; [0] is the agent for single-pane sessions.
+      const hostPid = Number(panePids[0]);
+      if (!Number.isInteger(hostPid) || hostPid <= 0) {
+        return;
+      }
+      const handle = await this.runTracker.registerRun({
+        name: worker.sessionName,
+        hostPid,
+        connectionId: `${worker.sessionName}#${getWorkerLifecycleEpoch(worker)}`,
+        labels: { role: 'worker', workerId: String(worker.workerId) },
+      });
+      if (handle) {
+        this.registeredRuns.set(worker.workerId, handle.pid);
+      }
+    } catch (error) {
+      logger.warn('nexus-tracking.register', 'registerRun failed (non-fatal)', {
+        workerId: worker.workerId,
+        error: String(error),
+      });
+    }
+  }
+
+  /** Report a stopped run out of the tracking plane (best-effort). */
+  private async trackRunStopped(workerId: number): Promise<void> {
+    const pid = this.registeredRuns.get(workerId);
+    if (!pid) {
+      return;
+    }
+    this.registeredRuns.delete(workerId);
+    try {
+      await this.runTracker.unregisterRun(pid);
+    } catch (error) {
+      logger.warn('nexus-tracking.unregister', 'unregisterRun failed (non-fatal)', {
+        workerId,
+        error: String(error),
+      });
+    }
   }
 
   async createWorker(options: CreateWorkerOpts): Promise<CreateWorkerResult> {
@@ -117,11 +180,9 @@ export class WorkerLifecycleService {
   ): Promise<CreateWorkerResult> {
     const worker = await this.resolveWorker(selector);
     try {
-      return this.prepareReadyWorker(
-        await this.sessionManager.startWorker(worker.sessionName, agentType, agentCommand),
-        'worker-starting',
-        'start',
-      );
+      const started = await this.sessionManager.startWorker(worker.sessionName, agentType, agentCommand);
+      await this.trackRunStarted(started.workerInfo);
+      return this.prepareReadyWorker(started, 'worker-starting', 'start');
     } catch (error) {
       const currentWorker = this.resolveCurrentWorkerIdentity(worker);
       this.cancelStaleCompletionIntents(currentWorker, getWorkerLifecycleEpoch(currentWorker));
@@ -185,6 +246,7 @@ export class WorkerLifecycleService {
     const worker = await this.resolveWorker(selector);
     try {
       await this.sessionManager.stopWorker(worker.sessionName);
+      await this.trackRunStopped(worker.workerId);
       this.cancelCompletionIntent(worker, 'worker-stopped');
       this.resolveWorkerNeedsInput(worker.workerId, 'worker-stopped');
       this.runtimeCoordinator.clear(worker.workerId);

--- a/packages/core/src/core/workerLifecycleService.ts
+++ b/packages/core/src/core/workerLifecycleService.ts
@@ -28,6 +28,7 @@ import {
   NoopRunTracker,
   type MessageTransport,
   type RunTracker,
+  type TransportMode,
 } from './transport/nexus';
 
 export type WorkerSelector = string | number;
@@ -62,6 +63,8 @@ export interface WorkerLifecycleServiceOptions {
   runTracker?: RunTracker;
   /** Message plane (doc §5). Defaults to legacy tmux inject via the backend. */
   messageTransport?: MessageTransport;
+  /** Transport mode; the inbound mailbox→pane delivery bridge runs only in `nexus`. */
+  mode?: TransportMode;
 }
 
 interface PreparedWorkerDispatch {
@@ -89,8 +92,11 @@ export class WorkerLifecycleService {
   private readonly eventSource: HydraEventSource;
   private readonly runTracker: RunTracker;
   private readonly messageTransport: MessageTransport;
+  private readonly transportMode: TransportMode;
   /** workerId -> the nexus pid we registered, so stop can unregister the same run. */
   private readonly registeredRuns = new Map<number, string>();
+  /** workerId -> abort handle for its inbound mailbox->pane delivery bridge (nexus mode). */
+  private readonly inboundBridges = new Map<number, AbortController>();
 
   constructor(options: WorkerLifecycleServiceOptions) {
     this.backend = options.backend;
@@ -103,6 +109,7 @@ export class WorkerLifecycleService {
     this.runTracker = options.runTracker ?? new NoopRunTracker();
     this.messageTransport =
       options.messageTransport ?? new LegacyMessageTransport(this.backend);
+    this.transportMode = options.mode ?? 'legacy';
     this.runtimeCoordinator = options.runtimeCoordinator ?? new WorkerRuntimeCoordinator(
       workerId => this.resolveRuntimeIdentity(workerId),
       this.runtimeV2Store,
@@ -113,6 +120,10 @@ export class WorkerLifecycleService {
 
   /** Release the transport backends (their gRPC channels). No-op in legacy mode. */
   close(): void {
+    for (const controller of this.inboundBridges.values()) {
+      controller.abort();
+    }
+    this.inboundBridges.clear();
     this.runTracker.close();
     this.messageTransport.close();
   }
@@ -168,6 +179,42 @@ export class WorkerLifecycleService {
     }
   }
 
+  /**
+   * nexus mode only: tail this worker's mailbox and inject each message into its pane —
+   * the copilot->worker "mailbox->tmux-inject" delivery bridge for plain agents. Legacy
+   * and dual keep tmux as the delivery path, so this stays OFF there (no double-inject).
+   * Best-effort: a bridge failure is logged, never fatal to lifecycle.
+   */
+  private startInboundBridge(worker: WorkerInfo): void {
+    if (this.transportMode !== 'nexus' || this.inboundBridges.has(worker.workerId)) {
+      return;
+    }
+    const controller = new AbortController();
+    this.inboundBridges.set(worker.workerId, controller);
+    void this.messageTransport
+      .watch(
+        worker.sessionName,
+        (envelope) => {
+          void this.backend.sendMessage(worker.sessionName, envelope.body);
+        },
+        { signal: controller.signal },
+      )
+      .catch((error) => {
+        logger.warn('nexus-transport.bridge', 'inbound mailbox bridge failed (non-fatal)', {
+          workerId: worker.workerId,
+          error: String(error),
+        });
+      });
+  }
+
+  private stopInboundBridge(workerId: number): void {
+    const controller = this.inboundBridges.get(workerId);
+    if (controller) {
+      controller.abort();
+      this.inboundBridges.delete(workerId);
+    }
+  }
+
   async createWorker(options: CreateWorkerOpts): Promise<CreateWorkerResult> {
     await this.sessionManager.ensurePersistedWorkerIdentities();
     return this.prepareCreatedWorker(
@@ -193,6 +240,7 @@ export class WorkerLifecycleService {
     try {
       const started = await this.sessionManager.startWorker(worker.sessionName, agentType, agentCommand);
       await this.trackRunStarted(started.workerInfo);
+      this.startInboundBridge(started.workerInfo);
       return this.prepareReadyWorker(started, 'worker-starting', 'start');
     } catch (error) {
       const currentWorker = this.resolveCurrentWorkerIdentity(worker);
@@ -258,6 +306,7 @@ export class WorkerLifecycleService {
     try {
       await this.sessionManager.stopWorker(worker.sessionName);
       await this.trackRunStopped(worker.workerId);
+      this.stopInboundBridge(worker.workerId);
       this.cancelCompletionIntent(worker, 'worker-stopped');
       this.resolveWorkerNeedsInput(worker.workerId, 'worker-stopped');
       this.runtimeCoordinator.clear(worker.workerId);

--- a/packages/core/src/core/workerLifecycleService.ts
+++ b/packages/core/src/core/workerLifecycleService.ts
@@ -23,7 +23,12 @@ import { WorkerRuntimeCoordinator, type WorkerRuntimeIdentity } from './workerRu
 import { WorkerRuntimeStateStore } from './workerRuntimeState';
 import { WorkerRuntimeStateStoreV2, type WorkerRuntimeSnapshotV2 } from './workerRuntimeV2';
 import { getWorkerLifecycleEpoch, normalizeWorkerSessionAliases } from './workerIdentity';
-import { NoopRunTracker, type RunTracker } from './transport/nexus';
+import {
+  LegacyMessageTransport,
+  NoopRunTracker,
+  type MessageTransport,
+  type RunTracker,
+} from './transport/nexus';
 
 export type WorkerSelector = string | number;
 
@@ -55,6 +60,8 @@ export interface WorkerLifecycleServiceOptions {
   eventSource?: HydraEventSource;
   /** Orchestration-tracking plane (doc §5). Defaults to the legacy no-op tracker. */
   runTracker?: RunTracker;
+  /** Message plane (doc §5). Defaults to legacy tmux inject via the backend. */
+  messageTransport?: MessageTransport;
 }
 
 interface PreparedWorkerDispatch {
@@ -81,6 +88,7 @@ export class WorkerLifecycleService {
   private readonly completionJobStore: CompletionJobStore;
   private readonly eventSource: HydraEventSource;
   private readonly runTracker: RunTracker;
+  private readonly messageTransport: MessageTransport;
   /** workerId -> the nexus pid we registered, so stop can unregister the same run. */
   private readonly registeredRuns = new Map<number, string>();
 
@@ -93,6 +101,8 @@ export class WorkerLifecycleService {
     this.completionJobStore = options.completionJobStore ?? new CompletionJobStore();
     this.eventSource = options.eventSource ?? 'session-manager';
     this.runTracker = options.runTracker ?? new NoopRunTracker();
+    this.messageTransport =
+      options.messageTransport ?? new LegacyMessageTransport(this.backend);
     this.runtimeCoordinator = options.runtimeCoordinator ?? new WorkerRuntimeCoordinator(
       workerId => this.resolveRuntimeIdentity(workerId),
       this.runtimeV2Store,
@@ -101,9 +111,10 @@ export class WorkerLifecycleService {
     );
   }
 
-  /** Release the tracking backend (its gRPC channel). No-op in legacy mode. */
+  /** Release the transport backends (their gRPC channels). No-op in legacy mode. */
   close(): void {
     this.runTracker.close();
+    this.messageTransport.close();
   }
 
   /**
@@ -213,7 +224,7 @@ export class WorkerLifecycleService {
         options.reason || 'worker-send',
         options.notifyCompletion !== false,
       );
-      await this.backend.sendMessage(worker.sessionName, message);
+      await this.messageTransport.send(worker.sessionName, { body: message });
       return { worker, completionArmed: !!dispatch.completionJob };
     } catch (error) {
       if (dispatch?.completionJobCreated && dispatch.completionJob) {

--- a/packages/core/src/smoke/nexusBridgeSmoke.ts
+++ b/packages/core/src/smoke/nexusBridgeSmoke.ts
@@ -1,0 +1,66 @@
+// LIVE smoke for the copilot->worker DELIVERY BRIDGE (doc §5, increment 2 — delivery).
+//
+// Drives the REAL WorkerLifecycleService in nexus mode with a mock backend + a live
+// NexusMessageTransport: startWorker arms the inbound bridge (tail the worker's mailbox);
+// a second client sends to that mailbox; the bridge must wake and inject the body into
+// the worker's pane via backend.sendMessage. Proves the mailbox->tmux-inject last hop
+// that lets a plain agent (no native mailbox read) receive nexus A2A messages.
+// Needs a running daemon; NOT in the CI chain. Pass a UNIQUE NAME per run.
+//
+//   SK=sk-... NAME=ts-bridge-$RANDOM node out/smoke/nexusBridgeSmoke.js
+
+import { WorkerLifecycleService } from '../core/workerLifecycleService';
+import { NexusMessageTransport } from '../core/transport/nexus';
+import { RecordingBackend, FakeSessionManager, createWorker } from './workerLifecycleServiceSmoke';
+
+async function main(): Promise<void> {
+  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
+  if (!token) {
+    throw new Error('nexusBridgeSmoke: set SK (an sk- agent key)');
+  }
+  const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  const sessionName = process.env.NAME ?? 'ts-bridge-probe';
+  const body = process.env.MSG ?? 'delivered via bridge';
+
+  const worker = createWorker(1, sessionName);
+  const backend = new RecordingBackend();
+  const manager = new FakeSessionManager(backend, [worker]);
+  const messageTransport = new NexusMessageTransport({ address, token });
+  const service = new WorkerLifecycleService({
+    backend,
+    sessionManager: manager,
+    messageTransport,
+    mode: 'nexus',
+    eventSource: 'cli',
+  });
+  const sender = new NexusMessageTransport({ address, token });
+
+  try {
+    await service.startWorker(sessionName); // arms the inbound mailbox->pane bridge
+    await new Promise((r) => setTimeout(r, 500)); // let the bridge tail arm
+    await sender.send(sessionName, { from: 'copilot', to: sessionName, body });
+
+    // Poll the mock backend for the injected message (bridge is async).
+    let injected: { sessionName: string; message: string } | undefined;
+    for (let i = 0; i < 40 && !injected; i += 1) {
+      injected = backend.sent.find((s) => s.sessionName === sessionName && s.message.includes(body));
+      if (!injected) {
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    }
+    if (!injected) {
+      throw new Error('bridge did not inject the mailbox message into the pane within 10s');
+    }
+    console.log(
+      `nexusBridgeSmoke: ok — mailbox message delivered to pane via bridge: ${JSON.stringify(injected.message)}`,
+    );
+  } finally {
+    service.close();
+    sender.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusBridgeSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/nexusCertAgentSmoke.ts
+++ b/packages/core/src/smoke/nexusCertAgentSmoke.ts
@@ -1,0 +1,76 @@
+// LIVE smoke for the nexus CERT plane (agent identity cert + mTLS).
+//
+// Unlike the sk--token tracking smoke, this connects with an AGENT CERT minted
+// by `nexusd-cluster auth mint --subject-type agent` — the client cert IS the
+// identity (no token). It is NOT in the default `npm test` chain (CI has no
+// nexus daemon). Run it by hand against a TLS-on founder:
+//
+//   BUNDLE=<data>/agents/<name>  ADDR=127.0.0.1:2126  HOST_PID=4242 \
+//     node out/smoke/nexusCertAgentSmoke.js
+//
+// Verifies register -> list -> unregister live over mTLS. With REVOKED=1 (run
+// AFTER `auth revoke --agent <name>` + a CRL refresh) it also asserts the next
+// call is REJECTED — the chain is still valid, so the CRL is what rejects it.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { NexusRunTracker } from '../core/transport/nexus';
+
+async function main(): Promise<void> {
+  const bundle = process.env.BUNDLE;
+  if (!bundle) {
+    throw new Error(
+      'nexusCertAgentSmoke: set BUNDLE=<data>/agents/<name> — the cert bundle dir ' +
+        '(agent.pem / agent-key.pem / ca.pem) that `auth mint --subject-type agent` wrote',
+    );
+  }
+  const tls = {
+    ca: fs.readFileSync(path.join(bundle, 'ca.pem')),
+    cert: fs.readFileSync(path.join(bundle, 'agent.pem')),
+    key: fs.readFileSync(path.join(bundle, 'agent-key.pem')),
+  };
+  const address = process.env.ADDR ?? '127.0.0.1:2126';
+  const hostPid = Number(process.env.HOST_PID ?? 4242);
+  const name = process.env.NAME ?? path.basename(bundle);
+  const connectionId = process.env.CONN ?? `hydra-cert-smoke-${hostPid}`;
+
+  const tracker = new NexusRunTracker({ address, tls });
+  try {
+    if (process.env.REVOKED === '1') {
+      // Run AFTER `auth revoke --agent <name>` + a CRL refresh. The mTLS
+      // handshake still completes (the chain is valid), so the rejection
+      // surfaces at the application resolve — the CRL is the gate.
+      let rejected = false;
+      try {
+        await tracker.registerRun({ name, hostPid, connectionId });
+      } catch {
+        rejected = true;
+      }
+      if (!rejected) {
+        throw new Error('REVOKED=1 but the revoked cert still authenticated — CRL not enforced');
+      }
+      console.log('nexusCertAgentSmoke: ok — the revoked cert is REJECTED (CRL enforced)');
+      return;
+    }
+
+    const handle = await tracker.registerRun({ name, hostPid, connectionId });
+    console.log(
+      `nexusCertAgentSmoke: register ok over mTLS — pid=${handle.pid} name=${handle.name} (cert identity, no token)`,
+    );
+
+    const listed = await tracker.listRuns();
+    if (!listed.some((r) => r.pid === handle.pid && r.name === name)) {
+      throw new Error('run not in listRuns after register');
+    }
+    await tracker.unregisterRun(handle.pid);
+    console.log('nexusCertAgentSmoke: ok — register/list/unregister all live over the cert plane');
+  } finally {
+    tracker.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusCertAgentSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/nexusMessageSmoke.ts
+++ b/packages/core/src/smoke/nexusMessageSmoke.ts
@@ -1,0 +1,49 @@
+// LIVE smoke for the nexus message plane (doc §5, increment 2 slice 2).
+//
+// Drives NexusMessageTransport against a real nexus daemon: send an envelope to an
+// agent's chat-with-me mailbox, collect it back, and assert the kernel stamped an
+// unforgeable `from` (a forged `from` is overwritten with the caller's authenticated
+// agent_id). Needs a running daemon with the a2a stamp hook armed, so it is NOT in the
+// CI chain. Pass a UNIQUE NAME per run so the mailbox is a fresh single-message stream.
+//
+//   SK=sk-... NAME=ts-msg-$RANDOM node out/smoke/nexusMessageSmoke.js
+
+import { NexusMessageTransport } from '../core/transport/nexus';
+
+async function main(): Promise<void> {
+  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
+  if (!token) {
+    throw new Error('nexusMessageSmoke: set SK (an sk- agent key)');
+  }
+  const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  const target = process.env.NAME ?? 'ts-msg-probe'; // recipient mailbox: /agents/<target>/chat-with-me
+  const expectedFrom = process.env.AGENT ?? 'ts-probe'; // the sk- key's subject → stamped `from`
+  const body = process.env.MSG ?? 'hello via message transport';
+
+  const mt = new NexusMessageTransport({ address, token });
+  try {
+    // Forge `from` — the kernel must overwrite it with the authenticated sender.
+    await mt.send(target, { from: 'impostor', to: 'peer', body });
+    const msgs = await mt.collect(target);
+    if (msgs.length !== 1) {
+      throw new Error(`expected exactly 1 message, got ${msgs.length} (stale mailbox? pass a unique NAME)`);
+    }
+    const m = msgs[0];
+    if (m.from !== expectedFrom) {
+      throw new Error(`from ${JSON.stringify(m.from)} != ${JSON.stringify(expectedFrom)} (from-stamp)`);
+    }
+    if (m.body !== body) {
+      throw new Error(`body ${JSON.stringify(m.body)} != ${JSON.stringify(body)}`);
+    }
+    console.log(
+      `nexusMessageSmoke: ok — send/collect round-trip; from-stamp overwrote "impostor" -> "${m.from}" (unforgeable)`,
+    );
+  } finally {
+    mt.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusMessageSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/nexusTrackingSmoke.ts
+++ b/packages/core/src/smoke/nexusTrackingSmoke.ts
@@ -1,0 +1,63 @@
+// LIVE smoke for the nexus orchestration-tracking backend (doc §5, increment 2 slice 1).
+//
+// Unlike the mock-backed smokes, this one talks to a REAL nexus daemon, so it is NOT in
+// the default `npm test` chain (CI has no nexus). Run it by hand against a founder whose
+// agent plane is up:
+//
+//   SK=sk-... HOST_PID=4242 LOCAL_ID=7 node out/smoke/nexusTrackingSmoke.js
+//
+// Verifies register -> list -> heartbeat -> unregister, and that the assigned pid IS the
+// OS host_pid (nexus-vfs #195): host_pid=4242, local_id=7  ->  pid="4242.7".
+
+import { NexusRunTracker } from '../core/transport/nexus';
+
+async function main(): Promise<void> {
+  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
+  if (!token) {
+    throw new Error('nexusTrackingSmoke: set SK (an sk- agent key) — the agent plane always authenticates');
+  }
+  const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  const hostPid = Number(process.env.HOST_PID ?? 4242);
+  const localId = process.env.LOCAL_ID ? Number(process.env.LOCAL_ID) : undefined;
+  const name = process.env.NAME ?? 'pocnode-hydra-w1';
+  const connectionId = process.env.CONN ?? `hydra-smoke-${hostPid}`;
+  const expectedPid = localId != null ? `${hostPid}.${localId}` : String(hostPid);
+
+  const tracker = new NexusRunTracker({ address, token });
+  try {
+    const handle = await tracker.registerRun({ name, hostPid, connectionId, localId });
+    if (!handle) {
+      throw new Error('registerRun returned null');
+    }
+    if (handle.pid !== expectedPid) {
+      throw new Error(`pid ${handle.pid} != expected ${expectedPid} (host_pid encoding, #195)`);
+    }
+    if (handle.name !== name) {
+      throw new Error(`name ${handle.name} != ${name}`);
+    }
+
+    const listed = await tracker.listRuns();
+    if (!listed.some((r) => r.pid === handle.pid && r.name === name)) {
+      throw new Error('run not in listRuns after register');
+    }
+
+    await tracker.heartbeat(handle.pid);
+
+    await tracker.unregisterRun(handle.pid);
+    const after = await tracker.listRuns();
+    if (after.some((r) => r.pid === handle.pid)) {
+      throw new Error('run still present after unregister');
+    }
+
+    console.log(
+      `nexusTrackingSmoke: ok — pid == host_pid (${handle.pid}); register/list/heartbeat/unregister all live`,
+    );
+  } finally {
+    tracker.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusTrackingSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/nexusTrackingWiringSmoke.ts
+++ b/packages/core/src/smoke/nexusTrackingWiringSmoke.ts
@@ -1,0 +1,77 @@
+// LIVE smoke for the tracking-plane WIRING (doc §5, increment 2 slice 1).
+//
+// Where nexusTrackingSmoke exercises the RunTracker in isolation, this drives the REAL
+// WorkerLifecycleService.startWorker / stopWorker (with the mock backend + session
+// manager from workerLifecycleServiceSmoke) through a live NexusRunTracker, proving the
+// wiring fires at the right lifecycle edges and reaches nexus. Needs a running nexus, so
+// it is NOT in the default `npm test` chain.
+//
+//   SK=sk-... node out/smoke/nexusTrackingWiringSmoke.js
+//
+// The tmux pane pid is faked here (no real tmux on CI/Windows); getSessionPanePids is
+// hydra's own tested tmux method, so this covers the NEW logic (wiring + nexus round
+// trip). The real-worker path is a manual E2E on a box with tmux.
+
+import { WorkerLifecycleService } from '../core/workerLifecycleService';
+import { NexusRunTracker } from '../core/transport/nexus';
+import { RecordingBackend, FakeSessionManager, createWorker } from './workerLifecycleServiceSmoke';
+
+/** Backend that reports a fixed agent-pane pid (stands in for a real tmux pane). */
+class PanePidBackend extends RecordingBackend {
+  constructor(private readonly panePid: string) {
+    super();
+  }
+  override async getSessionPanePids(): Promise<string[]> {
+    return [this.panePid];
+  }
+}
+
+async function main(): Promise<void> {
+  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
+  if (!token) {
+    throw new Error('set SK (an sk- agent key) — the agent plane always authenticates');
+  }
+  const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  const hostPid = process.env.HOST_PID ?? '6001';
+  const sessionName = process.env.NAME ?? 'hydra_poc_wiretest';
+
+  const worker = createWorker(1, sessionName);
+  const backend = new PanePidBackend(hostPid);
+  const manager = new FakeSessionManager(backend, [worker]);
+  const tracker = new NexusRunTracker({ address, token });
+  const service = new WorkerLifecycleService({
+    backend,
+    sessionManager: manager,
+    runTracker: tracker,
+    eventSource: 'cli',
+  });
+
+  try {
+    await service.startWorker(sessionName);
+    const listedAfterStart = await tracker.listRuns();
+    const found = listedAfterStart.find((r) => r.name === sessionName);
+    if (!found) {
+      throw new Error('worker not registered in nexus after startWorker (see nexus-tracking.register warning)');
+    }
+    if (found.pid !== hostPid) {
+      throw new Error(`registered pid ${found.pid} != agent-pane host_pid ${hostPid}`);
+    }
+    console.log(`startWorker -> nexus register: name=${found.name} pid=${found.pid}`);
+
+    await service.stopWorker(sessionName);
+    const listedAfterStop = await tracker.listRuns();
+    if (listedAfterStop.some((r) => r.name === sessionName)) {
+      throw new Error('worker still registered in nexus after stopWorker');
+    }
+    console.log('stopWorker -> nexus unregister: gone');
+
+    console.log('nexusTrackingWiringSmoke: ok — startWorker/stopWorker drive nexus register/unregister');
+  } finally {
+    service.close(); // closes the injected tracker's channel
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusTrackingWiringSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/nexusWatchSmoke.ts
+++ b/packages/core/src/smoke/nexusWatchSmoke.ts
@@ -1,0 +1,76 @@
+// LIVE smoke for the message-plane RECEIVE side (doc §5, increment 2 — receive).
+//
+// Arms a tailing watcher on a mailbox (NexusMessageTransport.watch → blocking
+// StreamReadAt / sys_watch), sends an envelope to that mailbox from a second client, and
+// asserts the watcher wakes and receives it (with the kernel-stamped `from`). This is the
+// primitive the copilot→worker delivery bridge + worker→copilot attention build on.
+// Needs a running daemon; NOT in the CI chain. Pass a UNIQUE NAME per run.
+//
+//   SK=sk-... NAME=ts-watch-$RANDOM node out/smoke/nexusWatchSmoke.js
+
+import { MessageEnvelope, NexusMessageTransport } from '../core/transport/nexus';
+
+async function main(): Promise<void> {
+  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
+  if (!token) {
+    throw new Error('nexusWatchSmoke: set SK (an sk- agent key)');
+  }
+  const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  const target = process.env.NAME ?? 'ts-watch-probe';
+  const expectedFrom = process.env.AGENT ?? 'ts-probe';
+  const body = process.env.MSG ?? 'hello via watch';
+
+  const watcher = new NexusMessageTransport({ address, token });
+  const sender = new NexusMessageTransport({ address, token });
+  const controller = new AbortController();
+  const received: MessageEnvelope[] = [];
+  let resolveFirst: () => void = () => {};
+  const first = new Promise<void>((resolve) => {
+    resolveFirst = resolve;
+  });
+
+  // Arm the tail (from offset 0), running in the background.
+  const watching = watcher.watch(
+    target,
+    (env) => {
+      received.push(env);
+      resolveFirst();
+    },
+    { signal: controller.signal, timeoutMs: 5000 },
+  );
+
+  try {
+    // Let the watcher arm, then send from the other client.
+    await new Promise((r) => setTimeout(r, 500));
+    await sender.send(target, { from: 'impostor', to: 'peer', body });
+
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('watcher did not receive within 10s')), 10_000),
+    );
+    await Promise.race([first, timeout]);
+
+    const m = received[0];
+    if (!m) {
+      throw new Error('no message received');
+    }
+    if (m.from !== expectedFrom) {
+      throw new Error(`from ${JSON.stringify(m.from)} != ${JSON.stringify(expectedFrom)}`);
+    }
+    if (m.body !== body) {
+      throw new Error(`body ${JSON.stringify(m.body)} != ${JSON.stringify(body)}`);
+    }
+    console.log(
+      `nexusWatchSmoke: ok — sys_watch tail woke + received {from:"${m.from}", body:${JSON.stringify(m.body)}}`,
+    );
+  } finally {
+    controller.abort();
+    await watching.catch(() => {});
+    watcher.close();
+    sender.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('nexusWatchSmoke: FAIL', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/core/src/smoke/workerLifecycleServiceSmoke.ts
+++ b/packages/core/src/smoke/workerLifecycleServiceSmoke.ts
@@ -48,7 +48,7 @@ type OperationError =
   | 'rename'
   | 'restore';
 
-class RecordingBackend implements MultiplexerBackendCore {
+export class RecordingBackend implements MultiplexerBackendCore {
   readonly type = 'tmux' as const;
   readonly displayName = 'recording-backend';
   readonly installHint = 'not needed';
@@ -96,7 +96,7 @@ class FailingCompletionJobStore extends CompletionJobStore {
   }
 }
 
-class FakeSessionManager extends SessionManager {
+export class FakeSessionManager extends SessionManager {
   readonly workers = new Map<string, WorkerInfo>();
   readonly archived = new Map<string, ArchivedSessionInfo>();
   readonly stopCalls: string[] = [];
@@ -319,7 +319,7 @@ function restoreEnv(previous: Record<string, string | undefined>): void {
   }
 }
 
-function createWorker(workerId: number, sessionName: string, overrides: Partial<WorkerInfo> = {}): WorkerInfo {
+export function createWorker(workerId: number, sessionName: string, overrides: Partial<WorkerInfo> = {}): WorkerInfo {
   const now = new Date().toISOString();
   return {
     source: 'repo',
@@ -724,7 +724,9 @@ async function main(): Promise<void> {
   console.log('workerLifecycleServiceSmoke: ok');
 }
 
-main().catch(error => {
-  console.error(error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -82,6 +82,7 @@ import {
 import { DiffService } from '@hydra/core/diff';
 import { getCopilotOnboardingPrompt } from '@hydra/core/copilotOnboarding';
 import { WorkerLifecycleService } from '@hydra/core/workerLifecycleService';
+import { createTransport } from '@hydra/core/transport/nexus';
 import { SessionTerminalService } from '@hydra/core/sessionTerminalService';
 
 import { collectCodeWorkerGitStatus } from './gitStatus';
@@ -226,6 +227,9 @@ export class HydraAppService implements HydraAppServiceApi {
     });
     this.diffService = options.diffService ?? new DiffService();
     this.notificationEventSource = options.notificationEventSource ?? 'session-manager';
+    // Orchestration-tracking plane (a2a-mapping doc §5), switched by HYDRA_TRANSPORT.
+    // Defaults to legacy (no-op), so this is inert unless nexus/dual is selected; the
+    // gRPC channel (nexus/dual only) dies with the sidecar's process.exit on shutdown.
     this.workerLifecycle = new WorkerLifecycleService({
       backend: this.backend,
       sessionManager: this.sessionManager,
@@ -234,6 +238,7 @@ export class HydraAppService implements HydraAppServiceApi {
       runtimeV2Store: this.runtimeV2Store,
       eventLog: this.eventLog,
       eventSource: this.notificationEventSource,
+      runTracker: createTransport().runTracker,
     });
     this.sessionTerminal = new SessionTerminalService(this.backend, this.sessionManager);
   }

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -242,6 +242,7 @@ export class HydraAppService implements HydraAppServiceApi {
       eventSource: this.notificationEventSource,
       runTracker: transport.runTracker,
       messageTransport: transport.messageTransport,
+      mode: transport.mode,
     });
     this.sessionTerminal = new SessionTerminalService(this.backend, this.sessionManager);
   }

--- a/packages/sidecar/src/appService.ts
+++ b/packages/sidecar/src/appService.ts
@@ -227,9 +227,11 @@ export class HydraAppService implements HydraAppServiceApi {
     });
     this.diffService = options.diffService ?? new DiffService();
     this.notificationEventSource = options.notificationEventSource ?? 'session-manager';
-    // Orchestration-tracking plane (a2a-mapping doc §5), switched by HYDRA_TRANSPORT.
-    // Defaults to legacy (no-op), so this is inert unless nexus/dual is selected; the
-    // gRPC channel (nexus/dual only) dies with the sidecar's process.exit on shutdown.
+    // Two synchronized switchable planes (a2a-mapping doc §5), by HYDRA_TRANSPORT.
+    // Defaults to legacy (tmux + no-op tracking) so this is inert unless nexus/dual is
+    // selected; nexus/dual gRPC channels die with the sidecar's process.exit on shutdown.
+    // `backend` powers the legacy (tmux) message plane.
+    const transport = createTransport({ backend: this.backend });
     this.workerLifecycle = new WorkerLifecycleService({
       backend: this.backend,
       sessionManager: this.sessionManager,
@@ -238,7 +240,8 @@ export class HydraAppService implements HydraAppServiceApi {
       runtimeV2Store: this.runtimeV2Store,
       eventLog: this.eventLog,
       eventSource: this.notificationEventSource,
-      runTracker: createTransport().runTracker,
+      runTracker: transport.runTracker,
+      messageTransport: transport.messageTransport,
     });
     this.sessionTerminal = new SessionTerminalService(this.backend, this.sessionManager);
   }

--- a/spikes/a2a-mailbox/.gitignore
+++ b/spikes/a2a-mailbox/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/spikes/a2a-mailbox/README.md
+++ b/spikes/a2a-mailbox/README.md
@@ -1,0 +1,103 @@
+# a2a-mailbox — PoC increment 1
+
+A minimal **TypeScript/Node client for the nexus A2A substrate**. It proves hydra
+(TS) can participate in agent-to-agent messaging end to end, over the loopback
+**agent plane** (the `sk-`-token VFS bind), with no Rust/hydra glue — just the VFS
+gRPC contract loaded dynamically from `nexus-vfs/proto`.
+
+It is the TS twin of the Rust `mailbox_cli` example and the core capability the
+future switchable messaging backend wraps (see the hydra A2A mapping doc §5:
+`MultiplexerBackendCore.sendMessage` → `send()`, worker→copilot attention →
+`send()` + a watch on the copilot's mailbox).
+
+This is the client half of the "two synchronized switchable planes" (doc §5):
+
+- `mailbox.mjs` — the **message plane** (increment 1).
+- `tracking.mjs` — the **orchestration-tracking plane** (increment 2, slice 1).
+
+## What `mailbox.mjs` demonstrates (message plane)
+
+- **mkstream / send / collect** on a federated `/agents/{name}/chat-with-me`
+  DT_STREAM via `Setattr` / `StreamWriteNowait` / `StreamCollectAll`.
+- **Unforgeable `from`**: the client sends `{from:"impostor", to, body}`; the kernel
+  stamp hook (`nexus-vfs/rust/a2a`) rewrites `from` to the caller's authenticated
+  `agent_id`. `collect` returns `{"from":"ts-probe",...}` — the forged value is gone.
+
+## What `tracking.mjs` demonstrates (orchestration-tracking plane)
+
+- **register / list / heartbeat / unregister** a run into the kernel `AgentRegistry`,
+  all over the generic `Call(method, JSON) → CallResponse` RPC — the nexus tracking
+  backend hydra swaps in beside tmux-session tracking (register-don't-spawn; process
+  ownership stays hydra).
+- **pid IS the OS host_pid** (nexus-vfs #195): register with `host_pid=4242, local_id=7`
+  and the descriptor's `pid` comes back `"4242.7"` — no separate `host_pid` field. For
+  hydra this is the tmux pane pid, so `/proc/{pid}` / `ps` / `kill` line up.
+  **Requires a nexus binary built at #195 (`b24e10b76`) or later** — a pre-#195 daemon
+  returns the connection_id as the pid and a stale `external_info.host_pid`.
+
+## Run it (live, against a local nexus)
+
+1. **Mint an agent key** into a fresh data dir (nexus-vfs repo):
+
+   ```bash
+   MSYS_NO_PATHCONV=1 NEXUS_API_KEY_SECRET=poc-secret \
+     ./target/debug/nexusd-cluster.exe auth mint \
+     --subject-id ts-probe --subject-type agent --zone sharedzone:rw \
+     --data-dir 'C:\Users\songym\nexus-poc\data'
+   # prints: sk-...  (copy it)
+   ```
+
+2. **Boot a single-node founder** with the loopback agent plane (same secret):
+
+   ```bash
+   MSYS_NO_PATHCONV=1 \
+     NEXUS_DATA_DIR='C:\Users\songym\nexus-poc\data' \
+     NEXUS_IDENTITY_DIR='C:\Users\songym\nexus-poc\id' \
+     NEXUS_API_KEY_SECRET=poc-secret NEXUS_INSECURE_NO_AUTH=true NEXUS_NO_TLS=true \
+     NEXUS_ADVERTISE_ADDR=127.0.0.1:2126 \
+     NEXUS_CLUSTER_INIT=sharedzone NEXUS_CLUSTER_INIT_MOUNTS=/agents=sharedzone \
+     ./target/debug/nexusd-cluster.exe --agent-bind-addr 127.0.0.1:2129
+   ```
+
+   (`--agent-bind-addr` *requires* `NEXUS_API_KEY_SECRET` — the token plane stamps
+   `from`, so it is never unauthenticated even under `--insecure-no-auth`.)
+
+3. **Run the clients** (this repo):
+
+   ```bash
+   npm install
+
+   # message plane
+   MSYS_NO_PATHCONV=1 SK=sk-... node mailbox.mjs
+   # mkstream ok: /agents/ts-a2a/chat-with-me
+   # ROUND-TRIP OK — from-stamp overwrote "impostor" -> "ts-probe" (unforgeable)
+
+   # orchestration-tracking plane
+   SK=sk-... HOST_PID=4242 LOCAL_ID=7 NAME=pocnode-hydra-w1 node tracking.mjs
+   # registered: { pid: '4242.7', name: 'pocnode-hydra-w1', state: 'REGISTERED', ... }
+   # TRACKING ROUND-TRIP OK — pid == host_pid (4242.7); register/list/heartbeat/unregister all live
+   ```
+
+   `MSYS_NO_PATHCONV=1` is mandatory on Git-Bash for `mailbox.mjs`: without it the
+   leading `/agents` env value is rewritten to a Windows path and the mailbox lands off
+   the mount. (`tracking.mjs` takes no path arg, so it is unaffected.)
+
+Env knobs: `ADDR` (default `127.0.0.1:2129`), `SK`, `PROTO_ROOT` (nexus-vfs `proto/`
+dir) — shared; `MBOX`, `MSG`, `AGENT` (mailbox); `HOST_PID`, `LOCAL_ID`, `NAME`, `CONN`
+(tracking).
+
+## Next (increment 2, slice 2 — wire into hydra)
+
+Both plane clients are validated live; the remaining work integrates them behind
+hydra's backend seam (doc §5):
+
+- Vendor these clients + `vfs.proto` into a hydra package; add the grpc deps to it.
+- A `RunTracker` (tracking) + `MessageTransport` (message) seam with `Legacy | nexus |
+  Dual` impls, chosen by **one synchronized switch** at the CLI composition roots
+  (where `new TmuxBackendCore()` is), never split.
+- Wire tracking into the worker/copilot lifecycle (Dual is trivially safe — nexus
+  tracking is pure-additive reporting); route `sendMessage` + worker→copilot attention
+  through the message transport.
+- Multi-message frame delimiting (the stamp hook re-serializes each envelope, so this
+  spike decodes single-message streams only); worker→copilot delivery via `sys_watch`,
+  itself switchable (mailbox→tmux-inject bridge ↔ agent-reads-mailbox-via-mount).

--- a/spikes/a2a-mailbox/mailbox.mjs
+++ b/spikes/a2a-mailbox/mailbox.mjs
@@ -1,0 +1,138 @@
+// PoC increment 1 — TypeScript/Node nexus A2A mailbox client.
+//
+// Proves hydra (TS) can talk to the nexus A2A substrate end to end: it dials the
+// loopback agent plane (the sk--token VFS plane, default 127.0.0.1:2129) and does
+// mkstream / send / collect on a chat-with-me DT_STREAM — the TS equivalent of the
+// Rust `mailbox_cli` example. Dynamic proto load (@grpc/proto-loader), no codegen.
+//
+// This is the core capability the future `transport-a2a` messaging backend wraps
+// (doc §5): sendMessage -> send(), worker->copilot attention -> send()+watch on
+// the copilot's mailbox. Kept a spike until the switchable abstraction lands.
+//
+//   node mailbox.mjs                       # round-trip self-test (mkstream/send/collect)
+//   SK=sk-... MBOX=/agents/x/chat-with-me MSG="hi" node mailbox.mjs
+
+import grpc from "@grpc/grpc-js";
+import protoLoader from "@grpc/proto-loader";
+
+const DT_STREAM = 4;
+
+/** Minimal nexus A2A mailbox client over the VFS gRPC agent plane. */
+export class NexusMailbox {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.address]   agent-plane address (host:port)
+   * @param {string} [opts.token]     sk- agent key; "" when the plane is auth-off
+   * @param {string} [opts.protoRoot] nexus-vfs `proto/` dir (include root)
+   */
+  constructor({ address = "127.0.0.1:2129", token = "", protoRoot } = {}) {
+    this.token = token;
+    const root =
+      protoRoot ?? "C:/Users/songym/cursor-projects/nexus-vfs/proto";
+    const def = protoLoader.loadSync("nexus/grpc/vfs/vfs.proto", {
+      keepCase: true, // snake_case fields: auth_token, entry_type, io_profile, is_error…
+      longs: String, // uint64 offset as string
+      defaults: true,
+      includeDirs: [root],
+    });
+    const pkg = grpc.loadPackageDefinition(def);
+    const Svc = pkg.nexus.grpc.vfs.NexusVFSService;
+    this.client = new Svc(address, grpc.credentials.createInsecure());
+  }
+
+  #call(method, req) {
+    return new Promise((resolve, reject) => {
+      this.client[method](req, (err, res) => (err ? reject(err) : resolve(res)));
+    });
+  }
+
+  static #errText(payload) {
+    return payload && payload.length ? Buffer.from(payload).toString() : "";
+  }
+
+  static #check(res, op) {
+    if (res.is_error) throw new Error(`${op}: ${NexusMailbox.#errText(res.error_payload)}`);
+    return res;
+  }
+
+  /** Create (idempotent) a wal-backed DT_STREAM mailbox at `path`. */
+  async mkstream(path) {
+    const res = await this.#call("Setattr", {
+      path,
+      auth_token: this.token,
+      entry_type: DT_STREAM,
+      io_profile: "wal,memory",
+    });
+    return NexusMailbox.#check(res, "mkstream");
+  }
+
+  /**
+   * Append one A2A envelope. The message is a JSON envelope `{from, to, body}`;
+   * the kernel stamp hook (rust/a2a) parses it on every chat-with-me write and
+   * overwrites `from` with the caller's authenticated agent_id — so a sender
+   * cannot forge authorship. `from` here is only a placeholder.
+   */
+  async send(path, { to = null, body, from = "(claimed-by-sender)" }) {
+    const frame = JSON.stringify({ from, to, body });
+    const res = await this.#call("StreamWriteNowait", {
+      path,
+      data: Buffer.from(frame),
+      auth_token: this.token,
+    });
+    return NexusMailbox.#check(res, "send").offset;
+  }
+
+  /**
+   * Read the whole stream (all frames, concatenated). The stamp hook re-serializes
+   * each envelope, so single-message streams decode with one `JSON.parse`; frame
+   * delimiting for multi-message reads is an increment-2 concern (the messaging seam).
+   */
+  async collect(path) {
+    const res = await this.#call("StreamCollectAll", {
+      path,
+      auth_token: this.token,
+    });
+    return Buffer.from(NexusMailbox.#check(res, "collect").data ?? Buffer.alloc(0)).toString();
+  }
+
+  close() {
+    this.client.close();
+  }
+}
+
+async function main() {
+  const mbox = new NexusMailbox({
+    address: process.env.ADDR ?? "127.0.0.1:2129",
+    token: process.env.SK ?? "",
+    protoRoot: process.env.PROTO_ROOT,
+  });
+  const path = process.env.MBOX ?? "/agents/ts-a2a/chat-with-me";
+  const body = process.env.MSG ?? "hello from ts";
+  const agent = process.env.AGENT ?? "ts-probe"; // the sk- key's subject → stamped `from`
+  try {
+    await mbox.mkstream(path);
+    console.log("mkstream ok:", path);
+    // Forge `from` — the kernel must overwrite it with the authenticated agent_id.
+    const offset = await mbox.send(path, { to: "peer", body, from: "impostor" });
+    console.log("sent offset:", offset);
+    const raw = await mbox.collect(path);
+    console.log("collect:", raw);
+    const env = JSON.parse(raw); // fresh stream → exactly one stamped envelope
+    const ok = env.from === agent && env.body === body;
+    if (!ok) {
+      console.error(
+        `FAIL: expected {from:${agent}, body:${JSON.stringify(body)}}, got ${JSON.stringify(env)}`,
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(`ROUND-TRIP OK — from-stamp overwrote "impostor" -> "${env.from}" (unforgeable)`);
+    }
+  } finally {
+    mbox.close();
+  }
+}
+
+main().catch((e) => {
+  console.error("ERROR:", e.message ?? e);
+  process.exitCode = 1;
+});

--- a/spikes/a2a-mailbox/package-lock.json
+++ b/spikes/a2a-mailbox/package-lock.json
@@ -1,0 +1,359 @@
+{
+  "name": "a2a-mailbox-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "a2a-mailbox-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.0",
+        "@grpc/proto-loader": "^0.7.13"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/spikes/a2a-mailbox/package.json
+++ b/spikes/a2a-mailbox/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "a2a-mailbox-spike",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "PoC increment 1: TS nexus A2A mailbox client over the loopback agent plane.",
+  "dependencies": {
+    "@grpc/grpc-js": "^1.12.0",
+    "@grpc/proto-loader": "^0.7.13"
+  }
+}

--- a/spikes/a2a-mailbox/tracking.mjs
+++ b/spikes/a2a-mailbox/tracking.mjs
@@ -1,0 +1,151 @@
+// PoC increment 2, slice 1 — TS nexus orchestration-tracking client.
+//
+// The second of the "two synchronized switchable planes" (doc §5): a run's
+// identity / lifecycle. Legacy backend = tmux-session tracking; nexus backend =
+// register_external / heartbeat into the kernel AgentRegistry (+ /proc/{pid}).
+// Process OWNERSHIP (spawn/kill/git/worktree) stays hydra either way — this only
+// *reports the run in* (register-don't-spawn); the tmux/OS process is untouched.
+//
+// All ops ride the generic Call RPC (method + JSON params) on NexusVFSService, over
+// the same loopback agent plane as the mailbox client.
+//
+//   SK=sk-... node tracking.mjs   # register -> list -> heartbeat -> unregister round-trip
+
+import grpc from "@grpc/grpc-js";
+import protoLoader from "@grpc/proto-loader";
+
+/** Reports hydra runs (worker/copilot) into the nexus kernel AgentRegistry. */
+export class NexusTracking {
+  constructor({ address = "127.0.0.1:2129", token = "", protoRoot } = {}) {
+    this.token = token;
+    const root = protoRoot ?? "C:/Users/songym/cursor-projects/nexus-vfs/proto";
+    const def = protoLoader.loadSync("nexus/grpc/vfs/vfs.proto", {
+      keepCase: true,
+      longs: String,
+      defaults: true,
+      includeDirs: [root],
+    });
+    const pkg = grpc.loadPackageDefinition(def);
+    this.client = new pkg.nexus.grpc.vfs.NexusVFSService(
+      address,
+      grpc.credentials.createInsecure(),
+    );
+  }
+
+  /** One kernel Call: method + JSON params -> parsed JSON result (throws on is_error). */
+  #call(method, params) {
+    return new Promise((resolve, reject) => {
+      this.client.Call(
+        { method, payload: Buffer.from(JSON.stringify(params)), auth_token: this.token },
+        (err, res) => {
+          if (err) return reject(err);
+          if (process.env.DEBUG)
+            console.error(
+              `[call] ${method} is_error=${res.is_error} payload=${res.payload && res.payload.length ? Buffer.from(res.payload).toString() : "<empty>"}`,
+            );
+          const body =
+            res.payload && res.payload.length
+              ? JSON.parse(Buffer.from(res.payload).toString())
+              : null;
+          if (res.is_error) return reject(new Error(`${method}: ${JSON.stringify(body)}`));
+          // Call rpc_codec wraps success values as {"result": <value>}.
+          resolve(body && typeof body === "object" && "result" in body ? body.result : body);
+        },
+      );
+    });
+  }
+
+  /**
+   * Report a run in as an UNMANAGED external agent. `hostPid` is the OS pid of the
+   * process hosting the agent (for hydra: the tmux pane pid); the kernel encodes the
+   * agent pid = `${hostPid}[.${localId}]` (nexus-vfs #195 — the pid IS the OS pid).
+   * Returns the AgentDescriptor (`pid`, `name`, `state`, `last_heartbeat_ms`, …).
+   */
+  registerRun({
+    name,
+    hostPid,
+    connectionId,
+    ownerId = "hydra",
+    zoneId = "sharedzone",
+    localId,
+    protocol = "hydra",
+    labels = {},
+  }) {
+    return this.#call("agent_register_external", {
+      name,
+      owner_id: ownerId,
+      zone_id: zoneId,
+      connection_id: connectionId,
+      host_pid: hostPid,
+      local_id: localId,
+      protocol,
+      labels,
+    });
+  }
+
+  heartbeat(pid) {
+    return this.#call("agent_heartbeat", { pid });
+  }
+
+  list(filter = {}) {
+    return this.#call("agent_list", {
+      zone_id: filter.zoneId,
+      owner_id: filter.ownerId,
+      kind: filter.kind,
+      state: filter.state,
+    });
+  }
+
+  unregister(pid) {
+    return this.#call("agent_unregister_external", { pid });
+  }
+
+  close() {
+    this.client.close();
+  }
+}
+
+async function main() {
+  const t = new NexusTracking({
+    address: process.env.ADDR ?? "127.0.0.1:2129",
+    token: process.env.SK ?? "",
+    protoRoot: process.env.PROTO_ROOT,
+  });
+  const name = process.env.NAME ?? "pocnode-hydra-w1";
+  const hostPid = Number(process.env.HOST_PID ?? 4242);
+  const connectionId = process.env.CONN ?? "hydra-conn-1";
+  const localId = process.env.LOCAL_ID ? Number(process.env.LOCAL_ID) : undefined;
+  const expectedPid = localId != null ? `${hostPid}.${localId}` : String(hostPid);
+  try {
+    const desc = await t.registerRun({ name, hostPid, connectionId, localId });
+    console.log("registered:", { pid: desc.pid, name: desc.name, state: desc.state, kind: desc.kind });
+    if (desc.pid !== expectedPid)
+      throw new Error(`pid ${desc.pid} != expected ${expectedPid} (host_pid encoding, #195)`);
+    if (desc.name !== name) throw new Error(`name ${desc.name} != ${name}`);
+
+    const before = await t.list();
+    if (!before.some((a) => a.pid === desc.pid && a.name === name))
+      throw new Error("run not in agent_list after register");
+    console.log(`list: ${before.length} agent(s), ours present`);
+
+    const hb = await t.heartbeat(desc.pid);
+    console.log("heartbeat: last_heartbeat_ms =", hb.last_heartbeat_ms);
+    if (hb.last_heartbeat_ms == null) throw new Error("heartbeat did not stamp last_heartbeat_ms");
+
+    await t.unregister(desc.pid);
+    const after = await t.list();
+    if (after.some((a) => a.pid === desc.pid)) throw new Error("run still present after unregister");
+    console.log("unregister ok — run gone from agent_list");
+
+    console.log(
+      `TRACKING ROUND-TRIP OK — pid == host_pid (${desc.pid}); register/list/heartbeat/unregister all live`,
+    );
+  } finally {
+    t.close();
+  }
+}
+
+main().catch((e) => {
+  console.error("ERROR:", e.message ?? e);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Connection-layer half of the A2A auth migration — **disjoint from the message-plane mailbox methods** (I touch only the constructor creds/token; `NexusRunTracker` passes the new `tls` option straight through).

**Why:** nexus-vfs #194 retired the `--agent-bind-addr` sk- loopback plane; agents are now cert-only over the main mTLS bind (SAN-typed). This moves `NexusVfsClient` to the CERT plane.

**What:** a `tls: {ca, cert, key}` option (the bundle `auth mint --subject-type agent` writes) → `createSsl` + `ssl_target_name_override = nexus-node`, dialing `:2126`; `token` left empty (cert IS the identity). Insecure/sk- path unchanged.

**Live-verified** against a real nexusd-cluster (auth-on + TLS): register/list/unregister over mTLS with a minted agent cert, then `auth revoke --agent` + a CRL refresh → the same cert is REJECTED (`npm run smoke:nexus-cert-agent`, cert plane).

**Draft:** merge/rollout waits for the release chain to ship the cert-agent binary to prod (don't let prod hydra's new client hit an old daemon). @peer review the diff per our boundary agreement.