### PR TITLE
test(nexus): make the A2A app smokes production-faithful — cross-node + cert plane

### DIFF
--- a/packages/core/src/smoke/nexusAttentionSmoke.ts
+++ b/packages/core/src/smoke/nexusAttentionSmoke.ts
@@ -72,10 +72,15 @@ async function main(): Promise<void> {
   // its own mailbox. SENDER_BUNDLE defaults to BUNDLE (single-agent degenerate run).
   const copilotBundle = process.env.BUNDLE;
   const senderBundle = process.env.SENDER_BUNDLE ?? copilotBundle;
+  // Cross-node: SENDER_ADDR points the worker (store A's mirror) at a DIFFERENT
+  // nexus node than the copilot (store B). The mailbox write on the worker's node
+  // must raft-replicate to the copilot's node, where the bridge re-materializes it
+  // — the true cross-machine A2A. Defaults to ADDR (single-node run).
+  const senderAddr = process.env.SENDER_ADDR ?? address;
 
   const storeA = isolatedStore('a');
   const storeB = isolatedStore('b');
-  const txA = new NexusMessageTransport(clientOptions(address, senderBundle));
+  const txA = new NexusMessageTransport(clientOptions(senderAddr, senderBundle));
   const txB = new NexusMessageTransport(clientOptions(address, copilotBundle));
   const collector = new NexusMessageTransport(clientOptions(address, copilotBundle));
   const mirrorA = new NotificationMailboxMirror({ store: storeA, messageTransport: txA });

--- a/packages/core/src/smoke/nexusBridgeSmoke.ts
+++ b/packages/core/src/smoke/nexusBridgeSmoke.ts
@@ -7,25 +7,58 @@
 // that lets a plain agent (no native mailbox read) receive nexus A2A messages.
 // Needs a running daemon; NOT in the CI chain. Pass a UNIQUE NAME per run.
 //
-//   SK=sk-... NAME=ts-bridge-$RANDOM node out/smoke/nexusBridgeSmoke.js
+//   Single-node, token plane:
+//     SK=sk-... NAME=ts-bridge-$RANDOM node out/smoke/nexusBridgeSmoke.js
+//   Cross-node, cert plane (the auth-on 2-node case): the WLS bridge tails on ADDR,
+//   the copilot SENDS on SENDER_ADDR (a DIFFERENT node); the mailbox write must
+//   raft-replicate to the bridge's node, where the tail wakes and injects.
+//     ADDR=127.0.0.1:12126 BUNDLE=<bridge agent dir> \
+//     SENDER_ADDR=127.0.0.1:12127 SENDER_BUNDLE=<copilot agent dir> \
+//     NAME=ts-bridge-$RANDOM node out/smoke/nexusBridgeSmoke.js
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 import { WorkerLifecycleService } from '../core/workerLifecycleService';
-import { NexusMessageTransport } from '../core/transport/nexus';
+import { NexusMessageTransport, type NexusVfsClientOptions } from '../core/transport/nexus';
 import { RecordingBackend, FakeSessionManager, createWorker } from './workerLifecycleServiceSmoke';
 
+/**
+ * Client options for one nexus connection. CERT plane when `bundle` is an agent
+ * bundle dir (ca.pem + agent.pem + agent-key.pem — the mTLS identity the daemon
+ * resolves via classify_peer_cert); otherwise the sk-/insecure token plane.
+ */
+function clientOptions(address: string, bundle: string | undefined): NexusVfsClientOptions {
+  if (bundle) {
+    return {
+      address,
+      tls: {
+        ca: readFileSync(join(bundle, 'ca.pem')),
+        cert: readFileSync(join(bundle, 'agent.pem')),
+        key: readFileSync(join(bundle, 'agent-key.pem')),
+      },
+    };
+  }
+  return { address, token: process.env.SK ?? process.env.NEXUS_SK ?? '' };
+}
+
 async function main(): Promise<void> {
-  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
-  if (!token) {
-    throw new Error('nexusBridgeSmoke: set SK (an sk- agent key)');
+  const bundle = process.env.BUNDLE;
+  if (!bundle && !(process.env.SK ?? process.env.NEXUS_SK)) {
+    throw new Error('nexusBridgeSmoke: set BUNDLE (agent cert dir) or SK (an sk- agent key)');
   }
   const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
+  // Cross-node: the copilot SENDS from a different node than the WLS bridge tails.
+  // Defaults collapse to a single-node run.
+  const senderAddr = process.env.SENDER_ADDR ?? address;
+  const senderBundle = process.env.SENDER_BUNDLE ?? bundle;
   const sessionName = process.env.NAME ?? 'ts-bridge-probe';
   const body = process.env.MSG ?? 'delivered via bridge';
 
   const worker = createWorker(1, sessionName);
   const backend = new RecordingBackend();
   const manager = new FakeSessionManager(backend, [worker]);
-  const messageTransport = new NexusMessageTransport({ address, token });
+  const messageTransport = new NexusMessageTransport(clientOptions(address, bundle));
   const service = new WorkerLifecycleService({
     backend,
     sessionManager: manager,
@@ -33,7 +66,7 @@ async function main(): Promise<void> {
     mode: 'nexus',
     eventSource: 'cli',
   });
-  const sender = new NexusMessageTransport({ address, token });
+  const sender = new NexusMessageTransport(clientOptions(senderAddr, senderBundle));
 
   try {
     await service.startWorker(sessionName); // arms the inbound mailbox->pane bridge

--- a/packages/core/src/smoke/nexusTrackingWiringSmoke.ts
+++ b/packages/core/src/smoke/nexusTrackingWiringSmoke.ts
@@ -6,15 +6,37 @@
 // wiring fires at the right lifecycle edges and reaches nexus. Needs a running nexus, so
 // it is NOT in the default `npm test` chain.
 //
-//   SK=sk-... node out/smoke/nexusTrackingWiringSmoke.js
+//   Token plane:  SK=sk-... node out/smoke/nexusTrackingWiringSmoke.js
+//   Cert plane (auth-on):  ADDR=127.0.0.1:12126 BUNDLE=<agent dir> node out/smoke/nexusTrackingWiringSmoke.js
 //
 // The tmux pane pid is faked here (no real tmux on CI/Windows); getSessionPanePids is
 // hydra's own tested tmux method, so this covers the NEW logic (wiring + nexus round
 // trip). The real-worker path is a manual E2E on a box with tmux.
 
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 import { WorkerLifecycleService } from '../core/workerLifecycleService';
-import { NexusRunTracker } from '../core/transport/nexus';
+import { NexusRunTracker, type NexusVfsClientOptions } from '../core/transport/nexus';
 import { RecordingBackend, FakeSessionManager, createWorker } from './workerLifecycleServiceSmoke';
+
+/**
+ * Client options for one nexus connection. CERT plane when `bundle` is an agent
+ * bundle dir (ca.pem + agent.pem + agent-key.pem); otherwise the sk-/insecure token plane.
+ */
+function clientOptions(address: string, bundle: string | undefined): NexusVfsClientOptions {
+  if (bundle) {
+    return {
+      address,
+      tls: {
+        ca: readFileSync(join(bundle, 'ca.pem')),
+        cert: readFileSync(join(bundle, 'agent.pem')),
+        key: readFileSync(join(bundle, 'agent-key.pem')),
+      },
+    };
+  }
+  return { address, token: process.env.SK ?? process.env.NEXUS_SK ?? '' };
+}
 
 /** Backend that reports a fixed agent-pane pid (stands in for a real tmux pane). */
 class PanePidBackend extends RecordingBackend {
@@ -27,9 +49,9 @@ class PanePidBackend extends RecordingBackend {
 }
 
 async function main(): Promise<void> {
-  const token = process.env.SK ?? process.env.NEXUS_SK ?? '';
-  if (!token) {
-    throw new Error('set SK (an sk- agent key) — the agent plane always authenticates');
+  const bundle = process.env.BUNDLE;
+  if (!bundle && !(process.env.SK ?? process.env.NEXUS_SK)) {
+    throw new Error('set BUNDLE (agent cert dir) or SK (an sk- agent key) — the agent plane always authenticates');
   }
   const address = process.env.ADDR ?? process.env.NEXUS_AGENT_ADDR ?? '127.0.0.1:2129';
   const hostPid = process.env.HOST_PID ?? '6001';
@@ -38,7 +60,7 @@ async function main(): Promise<void> {
   const worker = createWorker(1, sessionName);
   const backend = new PanePidBackend(hostPid);
   const manager = new FakeSessionManager(backend, [worker]);
-  const tracker = new NexusRunTracker({ address, token });
+  const tracker = new NexusRunTracker(clientOptions(address, bundle));
   const service = new WorkerLifecycleService({
     backend,
     sessionManager: manager,


### PR DESCRIPTION
## Why

The nexus A2A app-level smokes only spoke the **sk-/token plane** against a **single** daemon (default `127.0.0.1:2129` — the removed `--agent-bind-addr` plane). A real deployment is **auth-on** (agent mTLS on the main bind, `2126`) and A2A is **cross-machine**, so these smokes could not exercise the production path.

## What

- `nexusAttentionSmoke`: add `SENDER_ADDR` — the worker's mirror writes to a **different node** than the copilot's bridge tails, so the mailbox write must raft-replicate before the bridge re-materializes it (the true cross-machine hop).
- `nexusBridgeSmoke` / `nexusTrackingWiringSmoke`: add a `BUNDLE` **cert plane** (`ca.pem` + `agent.pem` + `agent-key.pem`) alongside the `SK` token plane; `nexusBridgeSmoke` also gains `SENDER_ADDR`/`SENDER_BUNDLE` for the cross-node copilot→worker delivery.

Both default back to the single-node token plane, so existing invocations are unchanged.

## Validation (live 2-node auth-on cluster)

Founder `12126` + enrolled joiner `12127`, cert agents:
- **worker→copilot attention** (`nexusAttentionSmoke`): mirror → mailbox → bridge re-materializes cross-node (`viaMailbox`), loop-guarded (1 frame). ✓
- **copilot→worker delivery** (`nexusBridgeSmoke`): the **real `WorkerLifecycleService`** inbound bridge tails on the founder, wakes on the joiner's write, injects into the worker's pane. ✓
- **run tracking** (`nexusTrackingWiringSmoke`): `startWorker`/`stopWorker` → `NexusRunTracker` register/unregister under cert auth. ✓

Backstops nexus-vfs cross-node stream-tail wakeup fix (nexi-lab/nexus-vfs#217): without it, the cross-node bridge tails never woke.

Smokes are not in the default `npm test` chain (each needs a live daemon); they are the manual/CI-e2e drivers.