### PR TITLE
chore: release v0.3.2026082900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.3.2026082900] - 2026-08-29
+
+### Added
+- Desktop: the Worker drawer now shows the branch's pull-request status (number and state) with an Open PR action
+- Nexus A2A transport: run worker↔copilot messaging and attention over the nexus message plane, including cross-machine delivery
+- Track orchestration runs over the nexus tracking plane
+- Certificate-based agent authentication (mTLS agent identity) for the nexus VFS client and the shipped app
+
+### Fixed
+- Make nexus stream creation idempotent and collect frames per-frame so multi-message and fan-out delivery stay reliable
+
+### Changed
+- Internal refactors extracting the run-tracking and mailbox-tail registries; removed the superseded terminal-bridge and a2a-mailbox spikes
+
 ## [0.3.2026072000] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-monorepo",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -6450,7 +6450,7 @@
     },
     "packages/cli": {
       "name": "@hydra/cli",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6462,7 +6462,7 @@
     },
     "packages/core": {
       "name": "@hydra/core",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
@@ -6473,7 +6473,7 @@
     },
     "packages/desktop": {
       "name": "@hydra/desktop",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/cli": "*",
@@ -6502,7 +6502,7 @@
     },
     "packages/extension": {
       "name": "hydra-code",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6522,7 +6522,7 @@
     },
     "packages/protocol": {
       "name": "@hydra/protocol",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*"
@@ -6530,7 +6530,7 @@
     },
     "packages/sidecar": {
       "name": "@hydra/sidecar",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/core": "*",
@@ -6542,7 +6542,7 @@
     },
     "packages/transport-loopback": {
       "name": "@hydra/transport-loopback",
-      "version": "0.3.2026072000",
+      "version": "0.3.2026082900",
       "license": "MIT",
       "dependencies": {
         "@hydra/protocol": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-monorepo",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra monorepo — @hydra/core engine, @hydra/cli, and the hydra-code VS Code extension",
   "license": "MIT",
   "private": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/cli",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra CLI — the `hydra` command (depends on @hydra/core)",
   "license": "MIT",
   "private": true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/core",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra headless engine — worker lifecycle, tmux/git, sessions, telemetry (vscode-free)",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/desktop",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra desktop — Electron shell (M1). Main forks the plain-Node sidecar, mints a per-launch bearer token, and hands { url, token } to a React renderer that talks to the sidecar over LoopbackHttpWsTransport.",
   "license": "MIT",
   "private": true,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "hydra-code",
   "displayName": "Hydra Code",
   "description": "Monitor and orchestrate parallel AI coding agents — see every worker's status, git diff, and terminal output from one sidebar",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/protocol",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra control-plane seam — HydraControlClient over a swappable HydraTransport (engine-free, transport-agnostic)",
   "license": "MIT",
   "private": true,

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/sidecar",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra sidecar — the server side of the seam. HydraAppService imports @hydra/core in-process (loopback HTTP/WS server lands in M1).",
   "license": "MIT",
   "private": true,

--- a/packages/transport-loopback/package.json
+++ b/packages/transport-loopback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydra/transport-loopback",
-  "version": "0.3.2026072000",
+  "version": "0.3.2026082900",
   "description": "Hydra loopback transport — LoopbackHttpWsTransport (renderer → sidecar over 127.0.0.1 HTTP/WS) + the shared loopback wire vocabulary. Engine-free: depends only on @hydra/protocol types and global fetch/WebSocket.",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Release **v0.3.2026082900**.

Merging this bumps the version on `main`, which `auto-tag-release.yml` detects → pushes the `v0.3.2026082900` tag → triggers the publish workflow (VSIX + signed/notarized macOS Desktop DMG + GitHub Release).

See CHANGELOG.md for the full entry. Highlights:
- Desktop: Worker drawer now shows branch PR status + Open PR action
- Nexus A2A transport: worker↔copilot messaging/attention + run tracking over nexus, cert-based agent authN

🤖 Generated with [Claude Code](https://claude.com/claude-code)